### PR TITLE
Additional tests

### DIFF
--- a/schema/test-suite.rnc
+++ b/schema/test-suite.rnc
@@ -34,8 +34,11 @@ passingTest =
       & attribute src { text }?
       & attribute step { text }?
       & attribute expected { "pass" }
-      & (input* & option* & pipeline? & schematron?)
+      & (testtitle? & description? & input* & option* & pipeline? & schematron?)
     }
+
+testtitle =
+    element t:title {text}
 
 failingTest =
     element t:test {
@@ -47,7 +50,7 @@ failingTest =
       & attribute step { text }?
       & attribute expected { "fail" }
       & attribute code { text }
-      & (input* & option* & pipeline?)
+      & (testtitle? & description? & input* & option* & pipeline?)
     }
 
 pipeline =
@@ -80,4 +83,9 @@ any =
     element * {
         attribute * { text }*
       & (text | any)*
+    }
+
+description =
+    element t:description{
+        any*
     }

--- a/test-suite/documents/ab-doc.xml
+++ b/test-suite/documents/ab-doc.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doc />

--- a/test-suite/pipelines/choose-001.xpl
+++ b/test-suite/pipelines/choose-001.xpl
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:option name="match"/>
   <p:output port="result"/>
 

--- a/test-suite/pipelines/choose-004.xpl
+++ b/test-suite/pipelines/choose-004.xpl
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:option name="match"/>
   <p:output port="result"/>
 

--- a/test-suite/pipelines/doc-prop-001.xpl
+++ b/test-suite/pipelines/doc-prop-001.xpl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:identity name="id">

--- a/test-suite/pipelines/doc-prop-002.xpl
+++ b/test-suite/pipelines/doc-prop-002.xpl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:identity name="id">

--- a/test-suite/pipelines/doc-prop-003.xpl
+++ b/test-suite/pipelines/doc-prop-003.xpl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:identity name="id">

--- a/test-suite/pipelines/doc-prop-004.xpl
+++ b/test-suite/pipelines/doc-prop-004.xpl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:identity name="id">

--- a/test-suite/pipelines/doc-prop-005.xpl
+++ b/test-suite/pipelines/doc-prop-005.xpl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:variable name="a" select="3 + 4"/>

--- a/test-suite/pipelines/inline-avt.xpl
+++ b/test-suite/pipelines/inline-avt.xpl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:identity name="one">

--- a/test-suite/pipelines/opt-drp.xpl
+++ b/test-suite/pipelines/opt-drp.xpl
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:identity>

--- a/test-suite/pipelines/p-count-001.xpl
+++ b/test-suite/pipelines/p-count-001.xpl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:option name="limit" select="0"/>
   <p:output port="result"/>
 

--- a/test-suite/pipelines/parameters-001.xpl
+++ b/test-suite/pipelines/parameters-001.xpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:parameters parameters="{ map {{ 'a': 1, 'b': 2 }} }"/>

--- a/test-suite/pipelines/parameters-002.xpl
+++ b/test-suite/pipelines/parameters-002.xpl
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:parameters>

--- a/test-suite/pipelines/parameters-003.xpl
+++ b/test-suite/pipelines/parameters-003.xpl
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:identity name="fred">

--- a/test-suite/pipelines/simple.xpl
+++ b/test-suite/pipelines/simple.xpl
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                version="1.0">
+                version="3.0">
   <p:input port="source"/>
   <p:output port="result"/>
 

--- a/test-suite/pipelines/try-catch-001.xpl
+++ b/test-suite/pipelines/try-catch-001.xpl
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
                 xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
+                <!-- we should replace cx with something better -->
   <p:option name="error"/>
   <p:output port="result"/>
 

--- a/test-suite/pipelines/try-catch-002.xpl
+++ b/test-suite/pipelines/try-catch-002.xpl
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
                 xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
+                <!-- we should replace cx with something better -->
   <p:option name="error"/>
   <p:output port="result">
     <p:pipe step="try" port="finally"/>

--- a/test-suite/pipelines/try-catch-003.xpl
+++ b/test-suite/pipelines/try-catch-003.xpl
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
                 xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
+                <!-- we should replace cx with something better -->
   <p:option name="error"/>
   <p:output port="result"/>
 

--- a/test-suite/pipelines/with-input-select-001.xpl
+++ b/test-suite/pipelines/with-input-select-001.xpl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
                 xmlns:c="http://www.w3.org/ns/xproc-step"
-                version="1.0">
+                version="3.0">
   <p:output port="result" sequence="true"/>
   <p:option name="blank" select="''"/>
   <p:option name="class" select="concat($blank, 'b')"/>

--- a/test-suite/schematron/ab-doc-result.sch
+++ b/test-suite/schematron/ab-doc-result.sch
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron"
+          xmlns:p="http://www.w3.org/ns/xproc"
+          xmlns:rng="http://relaxng.org/ns/structure/1.0">
+   <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+
+   <s:pattern>
+     <s:rule context="/*">
+       <s:assert test="self::doc">The pipeline root is not doc.</s:assert>
+       <s:assert test="count(self::doc//*) = 0">No children of doc expected.</s:assert>
+       <s:assert test="count(self::doc//@*) = 0">No attributes of doc expected.</s:assert>
+     </s:rule>
+   </s:pattern>
+</s:schema>

--- a/test-suite/schematron/ab-wrapped-result.sch
+++ b/test-suite/schematron/ab-wrapped-result.sch
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron"
+          xmlns:p="http://www.w3.org/ns/xproc"
+          xmlns:rng="http://relaxng.org/ns/structure/1.0">
+   <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+
+   <s:pattern>
+     <s:rule context="/*">
+       <s:assert test="self::wrapped">The pipeline root is not wrapped.</s:assert>
+       <s:assert test="name(self::wrapped/child::*[1])='doc'">The first child is not 'doc'.</s:assert>
+       <s:assert test="name(self::wrapped/child::*[2])='doc2'">The second child is not 'doc2'.</s:assert>
+       <s:assert test="count(self::wrapped//*)=2">'wrapped' does not have exactly two child elements.</s:assert>
+     </s:rule>
+   </s:pattern>
+</s:schema>

--- a/test-suite/tests/ab-connection-001.xml
+++ b/test-suite/tests/ab-connection-001.xml
@@ -1,0 +1,18 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <title>Connections 001</title>
+  <description>
+    <p>Tests that an implicit primary output port is auto connected to the output of the last step of the subpipeline.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input port="source">
+          <doc xmlns=""/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+  <schematron src="../schematron/ab-doc-result.sch"/>
+</test>

--- a/test-suite/tests/ab-connection-002.xml
+++ b/test-suite/tests/ab-connection-002.xml
@@ -1,0 +1,18 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <title>Connection 002</title>
+  <description>
+    <p>Tests that an explicit primary output port is auto connected to the output of the last step of the subpipeline.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result" primary="true"/>
+      
+      <p:identity>
+        <p:with-input port="source">
+          <doc xmlns=""/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+  <schematron src="../schematron/ab-doc-result.sch"/>
+</test>

--- a/test-suite/tests/ab-connection-003.xml
+++ b/test-suite/tests/ab-connection-003.xml
@@ -1,0 +1,17 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0005">
+  <title>Connection 003</title>
+  <description>
+    <p>Tests that an explicit non primary output port is NOT connected to the output of the last step of the subpipeline.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result" primary="false"/>
+      
+      <p:identity>
+        <p:with-input port="source">
+          <doc />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+</test>

--- a/test-suite/tests/ab-connection-004.xml
+++ b/test-suite/tests/ab-connection-004.xml
@@ -1,0 +1,20 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <title>Connection 004</title>
+  <description>
+    <p>Tests explicit connection between output port and step in subpipeline.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result">
+        <p:pipe step="producer" port="result" />
+      </p:output>
+      
+      <p:identity name="producer">
+        <p:with-input port="source">
+          <doc xmlns=""/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+  <schematron src="../schematron/ab-doc-result.sch"/>
+</test>

--- a/test-suite/tests/ab-connection-005.xml
+++ b/test-suite/tests/ab-connection-005.xml
@@ -1,0 +1,20 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <title>Connection 005</title>
+  <description>
+    <p>Tests explicit connection between an explicit primary output port and step in subpipeline.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result" primary="true">
+        <p:pipe step="producer" port="result" />
+      </p:output>
+      
+      <p:identity name="producer">
+        <p:with-input port="source">
+          <doc xmlns=""/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+  <schematron src="../schematron/ab-doc-result.sch"/>
+</test>

--- a/test-suite/tests/ab-connection-006.xml
+++ b/test-suite/tests/ab-connection-006.xml
@@ -1,0 +1,20 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <title>Connection 006</title>
+  <description>
+    <p>Tests explicit connection between an explicit non primary output port and step in subpipeline.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result" primary="false">
+        <p:pipe step="producer" port="result" />
+      </p:output>
+      
+      <p:identity name="producer">
+        <p:with-input port="source">
+          <doc xmlns=""/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+  <schematron src="../schematron/ab-doc-result.sch"/>
+</test>

--- a/test-suite/tests/ab-connection-007.xml
+++ b/test-suite/tests/ab-connection-007.xml
@@ -1,0 +1,22 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0005">
+  <title>Connection 007</title>
+  <description>
+    <p>Tests that the primary output port of the last step of a subpipeline is not connected to the pipelines primary output port, if the later has an explicit connection.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result" primary="true">
+        <p:pipe step="one" port="result" />
+      </p:output>
+      
+      <p:identity name="one">
+        <p:with-input port="source">
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity name="two"/>
+    </p:declare-step>
+  </pipeline>
+  
+</test>

--- a/test-suite/tests/ab-option-001.xml
+++ b/test-suite/tests/ab-option-001.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0038">
+    <t:title>Option declaration 001</t:title>
+    <t:description>
+        <p>Tests option is declared with a name.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-option-002.xml
+++ b/test-suite/tests/ab-option-002.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0028">
+    <t:title>Option declaration 002</t:title>
+    <t:description>
+        <p>Tests option is not declared with a name in XProc's namespace.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="p:option"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-option-003.xml
+++ b/test-suite/tests/ab-option-003.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0087">
+    <t:title>Option declaration 003</t:title>
+    <t:description>
+        <p>Tests option is not declared with a name that has an undeclared namespace prefix.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="x:option"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-option-004.xml
+++ b/test-suite/tests/ab-option-004.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+    <t:title>Option declaration 004</t:title>
+    <t:description>
+        <p>Tests option is declared with an incorrect sequence type in @as</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" as="something"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option" select="''" />
+</t:test>

--- a/test-suite/tests/ab-option-005.xml
+++ b/test-suite/tests/ab-option-005.xml
@@ -2,7 +2,7 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
     <t:title>Option declaration 005</t:title>
     <t:description>
-        <p>Tests option is declared with a correct boolean value in in @required</p>
+        <p>Tests option is declared with a correct boolean value in @required</p>
     </t:description>
     
     <t:pipeline>

--- a/test-suite/tests/ab-option-005.xml
+++ b/test-suite/tests/ab-option-005.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+    <t:title>Option declaration 005</t:title>
+    <t:description>
+        <p>Tests option is declared with a correct boolean value in in @required</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="no"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-option-006.xml
+++ b/test-suite/tests/ab-option-006.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0017">
+    <t:title>Option declaration 006</t:title>
+    <t:description>
+        <p>Tests option is not required and has a default value</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="true" select="10"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-option-007.xml
+++ b/test-suite/tests/ab-option-007.xml
@@ -2,7 +2,7 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0004">
     <t:title>Option declaration 007</t:title>
     <t:description>
-        <p>Checks no option with the name same are declared.</p>
+        <p>Checks no options with the name same are declared.</p>
     </t:description>
     
     <t:pipeline>

--- a/test-suite/tests/ab-option-007.xml
+++ b/test-suite/tests/ab-option-007.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0004">
+    <t:title>Option declaration 007</t:title>
+    <t:description>
+        <p>Checks no option with the name same are declared.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" />
+            <p:option name="option" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-option-008.xml
+++ b/test-suite/tests/ab-option-008.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 008</t:title>
+    <t:description>
+        <p>Checks required option is used correctly.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="true"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option" select="'test-value'"/>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='test-value'">The root element does not have a text child 'test-value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-option-009.xml
+++ b/test-suite/tests/ab-option-009.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0018">
+    <t:title>Option declaration 009</t:title>
+    <t:description>
+        <p>Checks error is raised, if required option is not bound.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="true"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+
+</t:test>

--- a/test-suite/tests/ab-option-010.xml
+++ b/test-suite/tests/ab-option-010.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0036">
+    <t:title>Option declaration 010</t:title>
+    <t:description>
+        <p>Checks error is raised, if value of required option does not match sequence type.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="true" as="xs:integer"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option" select="'X'" />
+</t:test>

--- a/test-suite/tests/ab-option-011.xml
+++ b/test-suite/tests/ab-option-011.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 011</t:title>
+    <t:description>
+        <p>Checks value of option is casted to expected type.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="true" as="xs:float"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option" select="1" />
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='1'">The root element does not have a text child '1'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-option-012.xml
+++ b/test-suite/tests/ab-option-012.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 012</t:title>
+    <t:description>
+        <p>Checks not required option with no default value is treated right.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option" select="'Some value'" />
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='Some value'">The root element does not have a text child 'Some value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-option-013.xml
+++ b/test-suite/tests/ab-option-013.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0050">
+    <t:title>Option declaration 013</t:title>
+    <t:description>
+        <p>Checks error for required option with no default value and no value supplied.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+ </t:test>

--- a/test-suite/tests/ab-option-014.xml
+++ b/test-suite/tests/ab-option-014.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0030">
+    <t:title>Option declaration 014</t:title>
+    <t:description>
+        <p>Checks error for required option with no default value and no value supplied.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" />
+            <p:variable name="var" select="$option" />
+            
+            <p:identity>
+                <p:with-input>
+                    <failure />
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+ </t:test>

--- a/test-suite/tests/ab-option-015.xml
+++ b/test-suite/tests/ab-option-015.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0030">
+    <t:title>Option declaration 015</t:title>
+    <t:description>
+        <p>Checks error for required option with no default value and no value supplied.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" />
+           
+            
+            <p:add-attribute match="/failure" attribute-name="name" attribute-value="{$option}"> 
+                <p:with-input>
+                    <failure />
+                </p:with-input>
+            </p:add-attribute>
+        </p:declare-step>
+    </t:pipeline>
+    
+ </t:test>

--- a/test-suite/tests/ab-option-016.xml
+++ b/test-suite/tests/ab-option-016.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 016</t:title>
+    <t:description>
+        <p>Checks not required option with default value is treated right.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" select="default value"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option" select="'Some value'" />
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='Some value'">The root element does not have a text child 'Some value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-option-017.xml
+++ b/test-suite/tests/ab-option-017.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 017</t:title>
+    <t:description>
+        <p>Checks not required option with default value is treated right.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" select="'default value'"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='default value'">The root element does not have a text child 'default value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-option-018.xml
+++ b/test-suite/tests/ab-option-018.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0036">
+    <t:title>Option declaration 018</t:title>
+    <t:description>
+        <p>Checks not required option with default value is type checked.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" select="'default value'" as="xs:boolean"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+</t:test>

--- a/test-suite/tests/ab-option-019.xml
+++ b/test-suite/tests/ab-option-019.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0036">
+    <t:title>Option declaration 019</t:title>
+    <t:description>
+        <p>Checks not required option with default value is type checked.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" select="'default value'" as="xs:boolean"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option" select="'5'" />
+</t:test>

--- a/test-suite/tests/ab-option-020.xml
+++ b/test-suite/tests/ab-option-020.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 020</t:title>
+    <t:description>
+        <p>Checks not required option with default value is type casted.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" select="'false'" as="xs:boolean"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='false'">The root element does not have a text child 'Some value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-option-021.xml
+++ b/test-suite/tests/ab-option-021.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 021</t:title>
+    <t:description>
+        <p>Checks not required option with default value is type casted.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" select="'false'" as="xs:boolean"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option" select="'true'"/>
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='true'">The root element does not have a text child 'Some value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-option-022.xml
+++ b/test-suite/tests/ab-option-022.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 022</t:title>
+    <t:description>
+        <p>Checks not required option depends on required option.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option1" required="true" />
+            <p:option name="option" required="false" select="$option1" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option1" select="'text'"/>
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='text'">The root element does not have a text child 'Some value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-option-023.xml
+++ b/test-suite/tests/ab-option-023.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0030">
+    <t:title>Option declaration 023</t:title>
+    <t:description>
+        <p>Checks self reference of options is not allowed.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" select="$option" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-option-024.xml
+++ b/test-suite/tests/ab-option-024.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 024</t:title>
+    <t:description>
+        <p>Checks no error from xpath exception is raised when value is supplied.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" required="false" select="5+false()" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$option}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:option name="option" select="'text'" />
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='text'">The root element does not have a text child 'Some value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+    
+</t:test>

--- a/test-suite/tests/ab-option-025.xml
+++ b/test-suite/tests/ab-option-025.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Option declaration 025</t:title>
+    <t:description>
+        <p>Checks XD0049 (invalid sequence type) is not raised if option is not used.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:option name="option" as="something" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=0">The root element should have no children.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+    
+</t:test>

--- a/test-suite/tests/ab-output-declaration-001.xml
+++ b/test-suite/tests/ab-output-declaration-001.xml
@@ -1,0 +1,17 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+  <title>Output port declaration 001</title>
+  <description>
+    <p>Tests for error XS0077 to be raised, when @primary on p:output is not 'true' or 'false'.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result" primary="no"/>
+      
+      <p:identity>
+        <p:with-input port="source">
+          <doc />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+</test>

--- a/test-suite/tests/ab-output-declaration-002.xml
+++ b/test-suite/tests/ab-output-declaration-002.xml
@@ -1,0 +1,17 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+  <title>Output port declaration 002</title>
+  <description>
+    <p>Tests for error XS0077 to be raised, when @sequence on p:output is not 'true' or 'false'.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result" sequence="no"/>
+      
+      <p:identity>
+        <p:with-input port="source">
+          <doc />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+</test>

--- a/test-suite/tests/ab-output-declaration-003.xml
+++ b/test-suite/tests/ab-output-declaration-003.xml
@@ -1,0 +1,18 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0014">
+  <title>Output port declaration 003</title>
+  <description>
+    <p>Tests for error XS0014 to be raised, if two output ports are declared to be primary.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result" primary="true"/>
+      <p:output port="secondary" primary="true"/>
+      
+      <p:identity>
+        <p:with-input port="source">
+          <doc />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+</test>

--- a/test-suite/tests/ab-output-declaration-004.xml
+++ b/test-suite/tests/ab-output-declaration-004.xml
@@ -1,0 +1,18 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0011">
+  <title>Output port declaration 004</title>
+  <description>
+    <p>Tests for error XS0011 to be raised, if two output ports are declared with the same name.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input port="source">
+          <doc />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+</test>

--- a/test-suite/tests/ab-variable-001.xml
+++ b/test-suite/tests/ab-variable-001.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0038">
+    <t:title>Variable declaration 001</t:title>
+    <t:description>
+        <p>Tests variable is declared with a name.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable select="4" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-002.xml
+++ b/test-suite/tests/ab-variable-002.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0038">
+    <t:title>Variable declaration 002</t:title>
+    <t:description>
+        <p>Tests variable is declared with an @select.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-003.xml
+++ b/test-suite/tests/ab-variable-003.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0008">
+    <t:title>Variable declaration 003</t:title>
+    <t:description>
+        <p>Tests only allowed attributes on p:variable</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" bogus="c"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-004.xml
+++ b/test-suite/tests/ab-variable-004.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0028">
+    <t:title>Variable declaration 004</t:title>
+    <t:description>
+        <p>Tests a variable does not have a name in XProc's namespace.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="p:var" select="4" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-005.xml
+++ b/test-suite/tests/ab-variable-005.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0087">
+    <t:title>Variable declaration 005</t:title>
+    <t:description>
+        <p>Tests a variable does not have a name with an undeclared prefix.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="dummy:var" select="4" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-006.xml
+++ b/test-suite/tests/ab-variable-006.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+    <t:title>Variable declaration 006</t:title>
+    <t:description>
+        <p>Tests a variable does not have an incorrect sequence type.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" as="dummy"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-007.xml
+++ b/test-suite/tests/ab-variable-007.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0085">
+    <t:title>Variable declaration 007</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @pipe and @href.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" pipe="step@port" href="some-uri"/>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-008.xml
+++ b/test-suite/tests/ab-variable-008.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+    <t:title>Variable declaration 008</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @href and an implicit inline as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" href="some-uri">
+                <doc />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-009.xml
+++ b/test-suite/tests/ab-variable-009.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+    <t:title>Variable declaration 009</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @href and an explicit inline as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" href="some-uri">
+                <p:inline>
+                    <doc />
+                </p:inline>
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-010.xml
+++ b/test-suite/tests/ab-variable-010.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+    <t:title>Variable declaration 010</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @href and a p:document as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" href="some-uri">
+               <p:document href="some-uri"/>
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-011.xml
+++ b/test-suite/tests/ab-variable-011.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+    <t:title>Variable declaration 011</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @href and a p:empty as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" href="some-uri">
+               <p:empty />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-012.xml
+++ b/test-suite/tests/ab-variable-012.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+    <t:title>Variable declaration 012</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @href and a p:pipe as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" href="some-uri">
+               <p:pipe step="step" port="port" />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-013.xml
+++ b/test-suite/tests/ab-variable-013.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+    <t:title>Variable declaration 013</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @pipe and an implicit inline as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" pipe="step@port">
+                <doc />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-014.xml
+++ b/test-suite/tests/ab-variable-014.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+    <t:title>Variable declaration 014</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @pipe and an inline as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" pipe="step@port">
+                <p:inline>
+                    <doc />
+                </p:inline>
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-015.xml
+++ b/test-suite/tests/ab-variable-015.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+    <t:title>Variable declaration 015</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @pipe and a p:document as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" pipe="step@port">
+                <p:document href="some-uri"/>
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-016.xml
+++ b/test-suite/tests/ab-variable-016.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+    <t:title>Variable declaration 016</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @pipe and p:empty as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" pipe="step@port">
+                <p:empty />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-017.xml
+++ b/test-suite/tests/ab-variable-017.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+    <t:title>Variable declaration 017</t:title>
+    <t:description>
+        <p>Tests a variable declaration does not have @pipe and p:pipe as child.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="4" pipe="step@port">
+                <p:pipe step="step" port="port" />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-018.xml
+++ b/test-suite/tests/ab-variable-018.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0036">
+    <t:title>Variable declaration 018</t:title>
+    <t:description>
+        <p>Tests a variable declaration raises an error if select result does not match required type.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="'X'" as="xs:float" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-019.xml
+++ b/test-suite/tests/ab-variable-019.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 019</t:title>
+    <t:description>
+        <p>Tests a variable declaration properly casted/promoted.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="xs:int(1)" as="xs:decimal" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var instance of xs:decimal}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='true'">The root element does not have a text child 'true'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-020.xml
+++ b/test-suite/tests/ab-variable-020.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 020</t:title>
+    <t:description>
+        <p>Tests a variable declaration with select result matches sequence-type.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="xs:decimal(1)" as="xs:decimal" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var instance of xs:decimal}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='true'">The root element does not have a text child 'true'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-021.xml
+++ b/test-suite/tests/ab-variable-021.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0008">
+    <t:title>Variable declaration 021</t:title>
+    <t:description>
+        <p>Check XD008 is raised if more than one document appears as connection of p:variable and @connection is missing.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="5">
+                <doc />
+                <doc />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc />
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+</t:test>

--- a/test-suite/tests/ab-variable-022.xml
+++ b/test-suite/tests/ab-variable-022.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0008">
+    <t:title>Variable declaration 022</t:title>
+    <t:description>
+        <p>Check XD008 is raised if more than one document appears as connection of p:variable and @connection is false.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="5" collection="false">
+                <doc />
+                <doc />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc />
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+</t:test>

--- a/test-suite/tests/ab-variable-023.xml
+++ b/test-suite/tests/ab-variable-023.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 023</t:title>
+    <t:description>
+        <p>Check XD008 is not raised if more than one document appears as connection of p:variable and @connection is true.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="5" collection="true">
+                <doc />
+                <doc />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc />
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+   
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=0">The root element should have no children.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-024.xml
+++ b/test-suite/tests/ab-variable-024.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+    <t:title>Variable declaration 024</t:title>
+    <t:description>
+        <p>Checks XS0077 is raised @connection on p:variable is not a boolean value.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="5" collection="foo">
+                <doc />
+                <doc />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc />
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+   
+  </t:test>

--- a/test-suite/tests/ab-variable-025.xml
+++ b/test-suite/tests/ab-variable-025.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 025</t:title>
+    <t:description>
+        <p>Test a p:variable selecting from an implicit inline document.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="/doc/text()">
+                <doc>value</doc>
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-026.xml
+++ b/test-suite/tests/ab-variable-026.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 026</t:title>
+    <t:description>
+        <p>Test a p:variable selecting from an explit inline document.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:variable name="var" select="/doc/text()">
+                <p:inline>
+                    <doc>value</doc>
+                </p:inline>
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-027.xml
+++ b/test-suite/tests/ab-variable-027.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 027</t:title>
+    <t:description>
+        <p>Test a p:variable selecting from default readble port.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-028.xml
+++ b/test-suite/tests/ab-variable-028.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 028</t:title>
+    <t:description>
+        <p>Test a p:variable selecting p:pipe.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity name="first">
+                <p:with-input>
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()">
+                <p:pipe step="first" port="result" />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-029.xml
+++ b/test-suite/tests/ab-variable-029.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 029</t:title>
+    <t:description>
+        <p>Test a p:variable selecting @pipe in full form.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity name="first">
+                <p:with-input>
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()" pipe="first@result" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-029.xml
+++ b/test-suite/tests/ab-variable-029.xml
@@ -15,7 +15,7 @@
                 </p:with-input>
             </p:identity>
             
-            <p:variable name="var" select="/doc/text()" pipe="first@result" />
+            <p:variable name="var" select="/doc/text()" pipe="result@first" />
             
             <p:identity>
                 <p:with-input>

--- a/test-suite/tests/ab-variable-030.xml
+++ b/test-suite/tests/ab-variable-030.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 030</t:title>
+    <t:description>
+        <p>Test a p:variable selecting @pipe with only port.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity name="first">
+                <p:with-input>
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()" pipe="@result" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-030.xml
+++ b/test-suite/tests/ab-variable-030.xml
@@ -15,7 +15,7 @@
                 </p:with-input>
             </p:identity>
             
-            <p:variable name="var" select="/doc/text()" pipe="@result" />
+            <p:variable name="var" select="/doc/text()" pipe="result" />
             
             <p:identity>
                 <p:with-input>

--- a/test-suite/tests/ab-variable-031.xml
+++ b/test-suite/tests/ab-variable-031.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 031</t:title>
+    <t:description>
+        <p>Test a p:variable selecting @pipe with only step.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity name="first">
+                <p:with-input>
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()" pipe="first" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-031.xml
+++ b/test-suite/tests/ab-variable-031.xml
@@ -15,7 +15,7 @@
                 </p:with-input>
             </p:identity>
             
-            <p:variable name="var" select="/doc/text()" pipe="first" />
+            <p:variable name="var" select="/doc/text()" pipe="@first" />
             
             <p:identity>
                 <p:with-input>

--- a/test-suite/tests/ab-variable-032.xml
+++ b/test-suite/tests/ab-variable-032.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 032</t:title>
+    <t:description>
+        <p>Test a p:variable selecting p:pipe with only step.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity name="first">
+                <p:with-input>
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()">
+                <p:pipe step="first" />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-033.xml
+++ b/test-suite/tests/ab-variable-033.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 033</t:title>
+    <t:description>
+        <p>Test a p:variable selecting p:pipe with only port.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity name="first">
+                <p:with-input>
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()">
+                <p:pipe port="result" />
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-034.xml
+++ b/test-suite/tests/ab-variable-034.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 034</t:title>
+    <t:description>
+        <p>Test a p:variable selecting p:pipe with neither port nor step.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity name="first">
+                <p:with-input>
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()">
+                <p:pipe/>
+            </p:variable>
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-035.xml
+++ b/test-suite/tests/ab-variable-035.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 035</t:title>
+    <t:description>
+        <p>Test a p:variable selecting @pipe with neither port nor step.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity name="first">
+                <p:with-input>
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()" pipe="" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-036.xml
+++ b/test-suite/tests/ab-variable-036.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 036</t:title>
+    <t:description>
+        <p>Test a p:variable selecting implicit from container's primary input port.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:input port="source">
+                <doc>value</doc>
+            </p:input>
+            <p:output port="result" />
+                        
+            <p:variable name="var" select="/doc/text()" />
+            
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-037.xml
+++ b/test-suite/tests/ab-variable-037.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>Variable declaration 037</t:title>
+    <t:description>
+        <p>Tests a p:variable does not change default readable port.</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step name="pipeline" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            
+            <p:identity>
+                <p:with-input port="source">
+                    <doc>value</doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:variable name="var" select="/doc/text()" />
+            
+            <p:identity/>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The pipeline root is not doc.</s:assert>
+                    <s:assert test="count(doc/node())=1">The root element does not have exactly one child.</s:assert>
+                    <s:assert test="count(doc/text())=1">The root element does not have exactly one text child.</s:assert>
+                    <s:assert test="doc/text()='value'">The root element does not have a text child 'value'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>        
+    </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-with-input-001.xml
+++ b/test-suite/tests/ab-with-input-001.xml
@@ -1,0 +1,18 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <title>with-input-001</title>
+  <description>
+    <p>Tests p:with-input with missing @port on atomic step is connection for primary input port.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+          
+      <p:identity>
+        <p:with-input>
+          <doc xmlns=""/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+  <schematron src="../schematron/ab-doc-result.sch"/>
+</test>

--- a/test-suite/tests/ab-with-input-002.xml
+++ b/test-suite/tests/ab-with-input-002.xml
@@ -1,0 +1,15 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0065">
+  <title>with-input-002</title>
+  <description>
+    <p>Tests p:with-input with missing @port on atomic step: XS0065 is raised because there is no primary input port.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:load>
+        <p:with-input />
+      </p:load>
+    </p:declare-step>
+  </pipeline>
+</test>

--- a/test-suite/tests/ab-with-input-003.xml
+++ b/test-suite/tests/ab-with-input-003.xml
@@ -1,0 +1,17 @@
+<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0010">
+  <title>with-input-003</title>
+  <description>
+    <p>Tests p:with-input with undeclared port: XS0010 to be raised.</p>
+  </description>
+  <pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input port="undeclared">
+          <doc />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </pipeline>
+</test>

--- a/test-suite/tests/ab-with-input-004.xml
+++ b/test-suite/tests/ab-with-input-004.xml
@@ -1,0 +1,22 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-004</t:title>
+  <t:description>
+    <p>Tests p:with-input with select.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input select="root/doc">
+          <p:inline>
+            <root>
+              <doc />
+            </root>
+          </p:inline>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-005.xml
+++ b/test-suite/tests/ab-with-input-005.xml
@@ -1,0 +1,16 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-005</t:title>
+  <t:description>
+    <p>Tests p:with-input with @href.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input href="../documents/ab-doc.xml"/>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-006.xml
+++ b/test-suite/tests/ab-with-input-006.xml
@@ -1,0 +1,15 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0085">
+  <t:title>with-input-006</t:title>
+  <t:description>
+    <p>Tests p:with-input with @href and @pipe: XS0081 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input href="../documents/ab-doc.xml" pipe="step@port"/>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-007.xml
+++ b/test-suite/tests/ab-with-input-007.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+  <t:title>with-input-007</t:title>
+  <t:description>
+    <p>Tests p:with-input with @href and p:inline: XS0081 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input href="../documents/ab-doc.xml">
+          <p:inline><doc /></p:inline>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-008.xml
+++ b/test-suite/tests/ab-with-input-008.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+  <t:title>with-input-008</t:title>
+  <t:description>
+    <p>Tests p:with-input with @href and p:empty: XS0081 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input href="../documents/ab-doc.xml">
+          <p:empty/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-009.xml
+++ b/test-suite/tests/ab-with-input-009.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+  <t:title>with-input-009</t:title>
+  <t:description>
+    <p>Tests p:with-input with @href and p:document: XS0081 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input href="../documents/ab-doc.xml">
+          <p:document href="../documents/ab-doc.xml"/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-010.xml
+++ b/test-suite/tests/ab-with-input-010.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+  <t:title>with-input-010</t:title>
+  <t:description>
+    <p>Tests p:with-input with @href and p:pipe: XS0081 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input href="../documents/ab-doc.xml">
+          <p:pipe step="source" port="result" />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-011.xml
+++ b/test-suite/tests/ab-with-input-011.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+  <t:title>with-input-011</t:title>
+  <t:description>
+    <p>Tests p:with-input with @href and implicit inline content: XS0081 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input href="../documents/ab-doc.xml">
+          <doc />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-012.xml
+++ b/test-suite/tests/ab-with-input-012.xml
@@ -1,0 +1,19 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-012</t:title>
+  <t:description>
+    <p>Tests p:with-input with @href. Checks p:documentation and p:pipeinfo are allowed as children of p:with-input.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input href="../documents/ab-doc.xml">
+          <p:documentation>This is a documentation.</p:documentation>
+          <p:pipeinfo>This is pipeinfo.</p:pipeinfo>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-013.xml
+++ b/test-suite/tests/ab-with-input-013.xml
@@ -1,0 +1,22 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-013</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe (step and port)</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input  pipe="one@result"/>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-013.xml
+++ b/test-suite/tests/ab-with-input-013.xml
@@ -14,7 +14,7 @@
       </p:identity>
       
       <p:identity>
-        <p:with-input  pipe="one@result"/>
+        <p:with-input  pipe="result@one"/>
       </p:identity>
     </p:declare-step>
   </t:pipeline>

--- a/test-suite/tests/ab-with-input-014.xml
+++ b/test-suite/tests/ab-with-input-014.xml
@@ -14,7 +14,7 @@
       </p:identity>
       
       <p:identity>
-        <p:with-input  pipe="one"/>
+        <p:with-input  pipe="@one"/>
       </p:identity>
     </p:declare-step>
   </t:pipeline>

--- a/test-suite/tests/ab-with-input-014.xml
+++ b/test-suite/tests/ab-with-input-014.xml
@@ -1,0 +1,22 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-014</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe (just step)</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input  pipe="one"/>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-015.xml
+++ b/test-suite/tests/ab-with-input-015.xml
@@ -1,0 +1,22 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-015</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe (just port)</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input pipe="@result"/>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-015.xml
+++ b/test-suite/tests/ab-with-input-015.xml
@@ -14,7 +14,7 @@
       </p:identity>
       
       <p:identity>
-        <p:with-input pipe="@result"/>
+        <p:with-input pipe="result"/>
       </p:identity>
     </p:declare-step>
   </t:pipeline>

--- a/test-suite/tests/ab-with-input-016.xml
+++ b/test-suite/tests/ab-with-input-016.xml
@@ -1,0 +1,22 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-016</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe (neither step nor port)</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input pipe=""/>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-017.xml
+++ b/test-suite/tests/ab-with-input-017.xml
@@ -1,0 +1,23 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+  <t:title>with-input-017</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe and p:empty: XS0082 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input pipe="one@result">
+          <p:empty/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-018.xml
+++ b/test-suite/tests/ab-with-input-018.xml
@@ -1,0 +1,23 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+  <t:title>with-input-018</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe and p:document: XS0082 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input pipe="one@result">
+          <p:document href="some-uri"/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-019.xml
+++ b/test-suite/tests/ab-with-input-019.xml
@@ -1,0 +1,23 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+  <t:title>with-input-019</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe and p:pipe: XS0082 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input pipe="one@result">
+          <p:pipe step="one" port="result"/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-020.xml
+++ b/test-suite/tests/ab-with-input-020.xml
@@ -1,0 +1,25 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+  <t:title>with-input-020</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe and p:inline: XS0082 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input pipe="one@result">
+          <p:inline>>
+              <doc />
+          </p:inline>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-021.xml
+++ b/test-suite/tests/ab-with-input-021.xml
@@ -1,0 +1,23 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+  <t:title>with-input-021</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe and implicit inline content: XS0082 to be raised</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input pipe="one@result">
+          <doc />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-022.xml
+++ b/test-suite/tests/ab-with-input-022.xml
@@ -1,0 +1,25 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-022</t:title>
+  <t:description>
+    <p>Tests p:with-input with @pipe. Checks p:documentation and p:pipeinfo are allowed as children of p:with-input.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input pipe="one@result">
+          <p:documentation>This is a documentation.</p:documentation>
+          <p:pipeinfo>This is pipeinfo.</p:pipeinfo>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-022.xml
+++ b/test-suite/tests/ab-with-input-022.xml
@@ -14,7 +14,7 @@
       </p:identity>
       
       <p:identity>
-        <p:with-input pipe="one@result">
+        <p:with-input pipe="result@one">
           <p:documentation>This is a documentation.</p:documentation>
           <p:pipeinfo>This is pipeinfo.</p:pipeinfo>
         </p:with-input>

--- a/test-suite/tests/ab-with-input-023.xml
+++ b/test-suite/tests/ab-with-input-023.xml
@@ -1,0 +1,24 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-023</t:title>
+  <t:description>
+    <p>Tests p:with-input with p:pipe (step and port).</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input>
+         <p:pipe port="result" step="one" />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-024.xml
+++ b/test-suite/tests/ab-with-input-024.xml
@@ -1,0 +1,24 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-024</t:title>
+  <t:description>
+    <p>Tests p:with-input with p:pipe (just step).</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input>
+         <p:pipe step="one" />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-025.xml
+++ b/test-suite/tests/ab-with-input-025.xml
@@ -1,0 +1,24 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-025</t:title>
+  <t:description>
+    <p>Tests p:with-input with p:pipe (just port).</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input>
+         <p:pipe port="result" />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-026.xml
+++ b/test-suite/tests/ab-with-input-026.xml
@@ -1,0 +1,24 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-026</t:title>
+  <t:description>
+    <p>Tests p:with-input with p:pipe neither @step nor @port.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input>
+         <p:pipe />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-doc-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-028.xml
+++ b/test-suite/tests/ab-with-input-028.xml
@@ -1,0 +1,23 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0022">
+  <t:title>with-input-028</t:title>
+  <t:description>
+    <p>Tests p:with-input with p:pipe with an unknown port.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input>
+         <p:pipe step="one" port="i-do-not-exist"/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-029.xml
+++ b/test-suite/tests/ab-with-input-029.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0067">
+  <t:title>with-input-029</t:title>
+  <t:description>
+    <p>Tests p:with-input with p:pipe (no port and no step) and no default readable port</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+        <p:identity>
+        <p:with-input>
+         <p:pipe />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-030.xml
+++ b/test-suite/tests/ab-with-input-030.xml
@@ -1,0 +1,23 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0022">
+  <t:title>with-input-030</t:title>
+  <t:description>
+    <p>Tests p:with-input with p:pipe (no @step) with an unknown port.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input>
+         <p:pipe port="i-do-not-exist"/>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-031.xml
+++ b/test-suite/tests/ab-with-input-031.xml
@@ -1,0 +1,15 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0067">
+  <t:title>with-input-031</t:title>
+  <t:description>
+    <p>Tests p:with-input with empty @pipe and no default readable port</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+       <p:identity>
+          <p:with-input pipe="" />
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-032.xml
+++ b/test-suite/tests/ab-with-input-032.xml
@@ -1,0 +1,21 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+  <t:title>with-input-032</t:title>
+  <t:description>
+    <p>Tests p:with-input with defective @pipe: step@</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc/>
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+        <p:with-input pipe="one@"/>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-033.xml
+++ b/test-suite/tests/ab-with-input-033.xml
@@ -20,7 +20,7 @@
       </p:identity>
       
       <p:wrap-sequence wrapper="wrapped">
-        <p:with-input pipe="one@result two@result" /> 
+        <p:with-input pipe="result@one result@two" /> 
       </p:wrap-sequence>
     </p:declare-step>
 

--- a/test-suite/tests/ab-with-input-033.xml
+++ b/test-suite/tests/ab-with-input-033.xml
@@ -1,0 +1,29 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-033</t:title>
+  <t:description>
+    <p>Tests p:with-input with space separated explicit targets on @pipe </p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc xmlns=""/>
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity name="two">
+         <p:with-input>
+           <doc2 xmlns=""/>
+         </p:with-input>
+      </p:identity>
+      
+      <p:wrap-sequence wrapper="wrapped">
+        <p:with-input pipe="one@result two@result" /> 
+      </p:wrap-sequence>
+    </p:declare-step>
+
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-wrapped-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-034.xml
+++ b/test-suite/tests/ab-with-input-034.xml
@@ -20,7 +20,7 @@
       </p:identity>
       
       <p:wrap-sequence wrapper="wrapped">
-        <p:with-input pipe="one two" /> 
+        <p:with-input pipe="@one @two" /> 
       </p:wrap-sequence>
     </p:declare-step>
 

--- a/test-suite/tests/ab-with-input-034.xml
+++ b/test-suite/tests/ab-with-input-034.xml
@@ -1,0 +1,29 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-034</t:title>
+  <t:description>
+    <p>Tests p:with-input with space separated targets (just step names) on @pipe </p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="one">
+        <p:with-input>
+          <doc/>
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity name="two">
+         <p:with-input>
+           <doc2/>
+         </p:with-input>
+      </p:identity>
+      
+      <p:wrap-sequence wrapper="wrapped">
+        <p:with-input pipe="one two" /> 
+      </p:wrap-sequence>
+    </p:declare-step>
+
+  </t:pipeline>
+  <t:schematron src="../schematron/ab-wrapped-result.sch"/>
+</t:test>

--- a/test-suite/tests/ab-with-input-035.xml
+++ b/test-suite/tests/ab-with-input-035.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-035</t:title>
+  <t:description>
+    <p>Tests p:with-input: Checks only one p:empty is allowed as connection.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+          <p:with-input>
+            <p:empty />
+            <p:empty />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-036.xml
+++ b/test-suite/tests/ab-with-input-036.xml
@@ -1,0 +1,22 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-036</t:title>
+  <t:description>
+    <p>Tests p:with-input: Checks p:empty and p:inline are not allowed as connection.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+          <p:with-input>
+            <p:empty />
+            <p:inline>
+              <doc />
+            </p:inline>
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-037.xml
+++ b/test-suite/tests/ab-with-input-037.xml
@@ -1,0 +1,26 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-037</t:title>
+  <t:description>
+    <p>Tests p:with-input: Checks p:empty and p:pipe are not allowed as connection.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity name="identity">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:identity>
+      
+      <p:identity>
+          <p:with-input>
+            <p:empty />
+            <p:pipe step="identity" port="result" />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-038.xml
+++ b/test-suite/tests/ab-with-input-038.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-038</t:title>
+  <t:description>
+    <p>Tests p:with-input: Checks p:empty and p:document are not allowed as connection.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input>
+            <p:empty />
+            <p:document href="some-uri" />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-039.xml
+++ b/test-suite/tests/ab-with-input-039.xml
@@ -1,0 +1,22 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-039</t:title>
+  <t:description>
+    <p>Tests p:with-input: Checks p:namespaces is not allowed.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input>
+              <p:inline>
+                <doc />
+              </p:inline>
+              <p:namespaces xmlns:dummy="http://www.dummy.com" />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-040.xml
+++ b/test-suite/tests/ab-with-input-040.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-040</t:title>
+  <t:description>
+    <p>Tests p:with-input: p:documentation and implicit inline not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input> 
+            <p:documentation>Some documentation.</p:documentation>
+            <doc />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-041.xml
+++ b/test-suite/tests/ab-with-input-041.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-041</t:title>
+  <t:description>
+    <p>Tests p:with-input: p:pipeinfo and implicit inline not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input> 
+            <p:pipeinfo>Some documentation.</p:pipeinfo>
+            <doc />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-042.xml
+++ b/test-suite/tests/ab-with-input-042.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-042</t:title>
+  <t:description>
+    <p>Tests p:with-input: p:inline and implicit inline not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input> 
+            <p:inline><some-doc /></p:inline>
+            <doc />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-043.xml
+++ b/test-suite/tests/ab-with-input-043.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-043</t:title>
+  <t:description>
+    <p>Tests p:with-input: p:document and implicit inline not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input> 
+            <p:document href="some-uri"/>
+            <doc />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-044.xml
+++ b/test-suite/tests/ab-with-input-044.xml
@@ -1,0 +1,24 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-044</t:title>
+  <t:description>
+    <p>Tests p:with-input: p:pipe and implicit inline not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input><doc/></p:with-input>
+      </p:identity>
+      
+      <p:identity>
+          <p:with-input>
+            <p:pipe/>
+            <doc />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-045.xml
+++ b/test-suite/tests/ab-with-input-045.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-045</t:title>
+  <t:description>
+    <p>Tests p:with-input: implicit inline and p:documentation not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input>
+            <doc />
+            <p:documentation>Some documentation.</p:documentation>
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-046.xml
+++ b/test-suite/tests/ab-with-input-046.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-046</t:title>
+  <t:description>
+    <p>Tests p:with-input: implicit inline and p:pipeinfo not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input> 
+            <doc />
+            <p:pipeinfo>Some documentation.</p:pipeinfo>
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-047.xml
+++ b/test-suite/tests/ab-with-input-047.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-047</t:title>
+  <t:description>
+    <p>Tests p:with-input: implicit inline and p:inline not allowed </p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input> 
+            <doc />
+            <p:inline><some-doc /></p:inline>
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-048.xml
+++ b/test-suite/tests/ab-with-input-048.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-048</t:title>
+  <t:description>
+    <p>Tests p:with-input: implicit inline and p:document not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+           
+      <p:identity>
+          <p:with-input> 
+            <doc />
+            <p:document href="some-uri"/>
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-049.xml
+++ b/test-suite/tests/ab-with-input-049.xml
@@ -1,0 +1,24 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-049</t:title>
+  <t:description>
+    <p>Tests p:with-input: implicit inline and p:pipe not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input><doc/></p:with-input>
+      </p:identity>
+      
+      <p:identity>
+          <p:with-input>
+            <doc />
+            <p:pipe/>
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-050.xml
+++ b/test-suite/tests/ab-with-input-050.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-050</t:title>
+  <t:description>
+    <p>Tests p:with-input: implicit inline and p:empty not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+          <p:with-input>
+            <doc />
+            <p:empty />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-051.xml
+++ b/test-suite/tests/ab-with-input-051.xml
@@ -1,0 +1,20 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+  <t:title>with-input-051</t:title>
+  <t:description>
+    <p>Tests p:with-input: p:empty and implicit inline not allowed</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+          <p:with-input>
+            <p:empty/>
+            <doc />
+          </p:with-input>
+      </p:identity>
+      
+    </p:declare-step>
+
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-052.xml
+++ b/test-suite/tests/ab-with-input-052.xml
@@ -1,0 +1,22 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+  <t:title>with-input-052</t:title>
+  <t:description>
+    <p>Tests p:with-input: implicit inline with two documents </p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+          <p:with-input>
+            <doc />
+            <doc2/>
+          </p:with-input>
+      </p:identity>
+      
+      <p:wrap-sequence wrapper="wrapped" />
+    </p:declare-step>
+  </t:pipeline>
+  
+  <t:schematron src="../schematron/ab-wrapped-result.sch" />
+</t:test>

--- a/test-suite/tests/ab-with-input-053.xml
+++ b/test-suite/tests/ab-with-input-053.xml
@@ -1,0 +1,24 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0079">
+  <t:title>with-input-053</t:title>
+  <t:description>
+    <p>Tests p:with-input: No comments or processing instructions allowed as siblings with implicit inlines</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+          <p:with-input>
+            <!-- comment -->
+            <?process instruction?>
+            <doc />
+            <!-- comment -->
+            <?process instruction?>
+            <doc />
+            <!-- comment -->
+            <?process instruction?>
+          </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-054.xml
+++ b/test-suite/tests/ab-with-input-054.xml
@@ -1,0 +1,19 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0079">
+  <t:title>with-input-054</t:title>
+  <t:description>
+    <p>Tests p:with-input: No non empty text nodes allowed as siblings with implicit inlines</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+          <p:with-input>
+            text
+            <doc />
+            more-text
+          </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-055.xml
+++ b/test-suite/tests/ab-with-input-055.xml
@@ -1,0 +1,13 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0032">
+  <t:title>with-input-055</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests primary input port is connected.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity />
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-056.xml
+++ b/test-suite/tests/ab-with-input-056.xml
@@ -1,0 +1,15 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0032">
+  <t:title>with-input-056</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests primary input port is connected.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input />
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-057.xml
+++ b/test-suite/tests/ab-with-input-057.xml
@@ -1,0 +1,18 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0032">
+  <t:title>with-input-057</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests primary input port is connected. (p:documentation and p:pipeinfo are no connections)</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input>
+          <p:documentation />
+          <p:pipeinfo />
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-058.xml
+++ b/test-suite/tests/ab-with-input-058.xml
@@ -1,0 +1,18 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0003">
+  <t:title>with-input-058</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests non-primary input port is connected.</p>
+  </t:description>
+  <t:pipeline>
+   
+   <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:insert match="/doc" position="first-child">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+      </p:insert>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-059.xml
+++ b/test-suite/tests/ab-with-input-059.xml
@@ -1,0 +1,19 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0003">
+  <t:title>with-input-059</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests non-primary input port is connected.</p>
+  </t:description>
+  <t:pipeline>
+   
+   <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:insert match="/doc" position="first-child">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+        <p:with-input port="insertion"></p:with-input>
+      </p:insert>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-060.xml
+++ b/test-suite/tests/ab-with-input-060.xml
@@ -1,0 +1,22 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0003">
+  <t:title>with-input-060</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests non-primary input port is connected.</p>
+  </t:description>
+  <t:pipeline>
+   
+   <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+      <p:insert match="/doc" position="first-child">
+        <p:with-input>
+          <doc />
+        </p:with-input>
+        <p:with-input port="insertion">
+          <p:documentation/>
+          <p:pipeinfo/>
+        </p:with-input>
+      </p:insert>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-061.xml
+++ b/test-suite/tests/ab-with-input-061.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0086">
+  <t:title>with-input-061</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests port is not bound twice.</p>
+  </t:description>
+  <t:pipeline>
+   
+   <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+     <p:identity>
+       <p:with-input><doc/></p:with-input>
+       <p:with-input><doc/></p:with-input>
+     </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-062.xml
+++ b/test-suite/tests/ab-with-input-062.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0086">
+  <t:title>with-input-062</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests port is not bound twice.</p>
+  </t:description>
+  <t:pipeline>
+   
+   <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+     <p:identity>
+       <p:with-input port="source"><doc/></p:with-input>
+       <p:with-input port="source"><doc/></p:with-input>
+     </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-063.xml
+++ b/test-suite/tests/ab-with-input-063.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0086">
+  <t:title>with-input-063</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests port is not bound twice.</p>
+  </t:description>
+  <t:pipeline>
+   
+   <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+     <p:identity>
+       <p:with-input><doc/></p:with-input>
+       <p:with-input port="source"><doc/></p:with-input>
+     </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-064.xml
+++ b/test-suite/tests/ab-with-input-064.xml
@@ -1,0 +1,17 @@
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0086">
+  <t:title>with-input-064</t:title>
+  <t:description>
+    <p>Tests p:with-input: Tests port is not bound twice.</p>
+  </t:description>
+  <t:pipeline>
+   
+   <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      
+     <p:identity>
+       <p:with-input port="source"><doc/></p:with-input>
+       <p:with-input><doc/></p:with-input>
+     </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-with-input-select-001.xml
+++ b/test-suite/tests/ab-with-input-select-001.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>with-input-select-001</t:title>
+    <t:description>
+        <p>Test select on p:with-input select="."</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input select=".">
+                    <doc>
+                        <!-- A comment -->
+                        <element1 att="att"/>
+                        <?target pi?>
+                        A text node
+                        <element2/>
+                    </doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="count(*) = 1">Document does not have exactly one child element.</s:assert>
+                    <s:assert test="count(doc)=1">Root element is not named 'doc'.</s:assert>
+                </s:rule>
+                <s:rule context="/doc">
+                    <s:assert test="count(*) = 2">Root element does not have 2 child elements.</s:assert>
+                    <s:assert test="*[1]/name()='element1'">First child element is not called 'element1'.</s:assert>
+                    <s:assert test="*[2]/name()='element2'">Second child element is not called 'element2'.</s:assert>
+                    <s:assert test="count(comment())=1">Root element does not have one comment as child.</s:assert>
+                    <s:assert test="count(processing-instruction(target))=1"></s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>    
+    </t:schematron>
+</t:test>
+

--- a/test-suite/tests/ab-with-input-select-002.xml
+++ b/test-suite/tests/ab-with-input-select-002.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>with-input-select-002</t:title>
+    <t:description>
+        <p>Test select on p:with-input select="comment()"</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                        xmlns:c="http://www.w3.org/ns/xproc-step"
+            version="3.0">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input select="*/comment()">
+                    <doc>
+                        <!-- A comment -->
+                        <element1 att="att"/>
+                        <?target pi?>
+                        A text node
+                        <element2/>
+                    </doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:wrap-sequence wrapper="c:result" />
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
+            
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="count(*) = 1">Document does not have exactly one child element.</s:assert>
+                    <s:assert test="*[1]/name()='c:result'">Root element is not named 'c:result'.</s:assert>
+                </s:rule>
+                <s:rule context="/c:result">
+                    <s:assert test="count(node())=1">c:result does not have exactly one child node.</s:assert>
+                    <s:assert test="count(comment()) = 1">c:result does not have exactly one comment as child.</s:assert>
+                    <s:assert test="comment()= ' A comment '">Text of comment is not ' A comment '.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>    
+    </t:schematron>
+</t:test>
+
+

--- a/test-suite/tests/ab-with-input-select-003.xml
+++ b/test-suite/tests/ab-with-input-select-003.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>with-input-select-003</t:title>
+    <t:description>
+        <p>Test select on p:with-input select="processing-instruction()"</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+            xmlns:c="http://www.w3.org/ns/xproc-step"
+            version="3.0">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input select="*/processing-instruction()">
+                    <doc>
+                        <!-- A comment -->
+                        <element1 att="att"/>
+                        <?pi target?>
+                        A text node
+                        <element2/>
+                    </doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:wrap-sequence wrapper="c:result" />
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
+            
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="count(*) = 1">Document does not have exactly one child element.</s:assert>
+                    <s:assert test="*[1]/name()='c:result'">Root element is not named 'c:result'.</s:assert>
+                </s:rule>
+                <s:rule context="/c:result">
+                    <s:assert test="count(node())=1">c:result does not have exactly one child node.</s:assert>
+                    <s:assert test="count(processing-instruction()) = 1">c:result does not have exactly one pi as child.</s:assert>
+                    <s:assert test="name(processing-instruction())='pi'">Target of processing instruction is not 'pi'.</s:assert>
+                    <s:assert test="string(processing-instruction())='target'">Content of processing instruction is not 'target'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>    
+    </t:schematron>
+</t:test>
+
+
+

--- a/test-suite/tests/ab-with-input-select-004.xml
+++ b/test-suite/tests/ab-with-input-select-004.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>with-input-select-004</t:title>
+    <t:description>
+        <p>Test select on p:with-input select="text()"</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+            xmlns:c="http://www.w3.org/ns/xproc-step"
+            version="3.0">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input select="*/text()">
+                    <doc>
+                        <!-- A comment -->
+                        <element1 att="att"/>
+                        <?pi target?>
+                        A text node
+                        <element2/>
+                    </doc>
+                </p:with-input>
+            </p:identity>
+            
+            <p:wrap-sequence wrapper="c:result" />
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
+            
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="count(*) = 1">Document does not have exactly one child element.</s:assert>
+                    <s:assert test="*[1]/name()='c:result'">Root element is not named 'c:result'.</s:assert>
+                </s:rule>
+                <s:rule context="/c:result">
+                    <s:assert test="count(node())=count(text())">c:result does not have only text node children.</s:assert>
+                    <s:assert test="normalize-space(string-join(text(),''))='A text node'">The normalized text is not 'A next node'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>    
+    </t:schematron>
+</t:test>
+
+
+

--- a/test-suite/tests/ab-with-input-select-005.xml
+++ b/test-suite/tests/ab-with-input-select-005.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>with-input-select-005</t:title>
+    <t:description>
+        <p>Tests that an all text selection on p:with-input results in content-type "text/plain"</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+            version="3.0">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input select="*/text()[1]">
+                    <doc>
+                        <!-- A comment -->
+                        <element1 att="att"/>
+                        <?pi target?>
+                        A text node
+                        <element2/>
+                    </doc>
+                </p:with-input>
+            </p:identity>
+            
+           <p:identity>
+               <p:with-input select="p:document-properties-document(.)"/>
+           </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+            
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="count(*) = 1">Document does not have exactly one child element.</s:assert>
+                    <s:assert test="*[1]/name()='p:document-properties'">Root element is not named 'p:document-properties'.</s:assert>
+                </s:rule>
+                <s:rule context="/p:document-properties">
+                    <s:assert test="content-type='text/plain'">Content type is not text/plain.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>    
+    </t:schematron>
+</t:test>
+
+
+

--- a/test-suite/tests/ab-with-input-select-006.xml
+++ b/test-suite/tests/ab-with-input-select-006.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>with-input-select-006</t:title>
+    <t:description>
+        <p>Tests that content-type is changed to application/xml when selecting from XLST document.</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            version="3.0">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input select="/xsl:stylesheet/xsl:template[1]" >
+                    <p:inline document-properties="map{xs:QName('content-type'):'application/xslt+xml'}">
+                        <xsl:stylesheet version="2.0">
+                            <xsl:template match="/">
+                                <xsl:text>result</xsl:text>
+                            </xsl:template>
+                        </xsl:stylesheet>
+                    </p:inline>
+                </p:with-input>
+            </p:identity>
+            
+           <p:identity>
+               <p:with-input select="p:document-properties-document(.)"/>
+           </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+            
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="count(*) = 1">Document does not have exactly one child element.</s:assert>
+                    <s:assert test="*[1]/name()='p:document-properties'">Root element is not named 'p:document-properties'.</s:assert>
+                </s:rule>
+                <s:rule context="/p:document-properties">
+                    <s:assert test="content-type ='application/xml'">Content type is not 'application/xml'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>    
+    </t:schematron>
+</t:test>
+
+
+

--- a/test-suite/tests/default-p-input.xml
+++ b/test-suite/tests/default-p-input.xml
@@ -1,9 +1,8 @@
 <test xmlns='http://xproc.org/ns/testsuite/3.0' expected="pass">
   <pipeline>
     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                    xmlns:ex="http://xmlcalabash.com/ext/foo"
                     name="main"
-                    version="1.0">
+                    version="3.0">
       <p:output port="result"/>
 
       <p:identity name="two">

--- a/test-suite/tests/p-inline-001.xml
+++ b/test-suite/tests/p-inline-001.xml
@@ -18,7 +18,7 @@
   </p:identity>
 
   <p:wrap-sequence wrapper="c:result">
-    <p:with-input port="source" pipe="properties inline"/>
+    <p:with-input port="source" pipe="@properties @inline"/>
   </p:wrap-sequence>
 
 </p:declare-step>

--- a/test-suite/tests/p-inline-002.xml
+++ b/test-suite/tests/p-inline-002.xml
@@ -7,7 +7,7 @@
 
   <p:identity name="inline">
     <p:with-input port="source">
-      <p:inline document-properties="map { 'content-type': 'text/plain' }"
+      <p:inline document-properties="map { xs:QName('content-type'): 'text/plain' }"
                 >Hello, world.</p:inline>
     </p:with-input>
   </p:identity>

--- a/test-suite/tests/p-inline-002.xml
+++ b/test-suite/tests/p-inline-002.xml
@@ -17,7 +17,7 @@
   </p:identity>
 
   <p:wrap-sequence wrapper="c:result">
-    <p:with-input port="source" pipe="properties inline"/>
+    <p:with-input port="source" pipe="@properties @inline"/>
   </p:wrap-sequence>
 
 </p:declare-step>

--- a/test-suite/tests/p-inline-003.xml
+++ b/test-suite/tests/p-inline-003.xml
@@ -7,7 +7,7 @@
 
   <p:identity name="inline">
     <p:with-input port="source">
-      <p:inline encoding="base64" document-properties="map { 'content-type': 'image/png' }">
+      <p:inline encoding="base64" document-properties="map { xs:QName('content-type'): 'image/png' }">
 iVBORw0KGgoAAAANSUhEUgAAAIAAAAAdCAYAAABixmRWAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
 AAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAA
 CXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4QoICxwdF+yMrAAADXpJREFUaN7tW2lsFOUb/83u

--- a/test-suite/tests/p-inline-003.xml
+++ b/test-suite/tests/p-inline-003.xml
@@ -84,11 +84,11 @@ YII=
   </p:identity>
 
   <p:cast-content-type name="cast" content-type="application/xml">
-    <p:with-input port="source" pipe="inline"/>
+    <p:with-input port="source" pipe="@inline"/>
   </p:cast-content-type>
 
   <p:wrap-sequence wrapper="c:result">
-    <p:with-input port="source" pipe="properties cast"/>
+    <p:with-input port="source" pipe="@properties @cast"/>
   </p:wrap-sequence>
 </p:declare-step>
   </pipeline>

--- a/test-suite/tests/p-inline-004.xml
+++ b/test-suite/tests/p-inline-004.xml
@@ -9,7 +9,7 @@
 
   <p:identity name="inline">
     <p:with-input port="source">
-      <p:inline encoding="unknown" document-properties="map { 'content-type': 'image/png' }">
+      <p:inline encoding="unknown" document-properties="map { xs:QName('content-type'): 'image/png' }">
 iVBORw0KGgoAAAANSUhEUgAAAIAAAAAdCAYAAABixmRWAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
       </p:inline>
     </p:with-input>

--- a/test-suite/tests/p-inline-006.xml
+++ b/test-suite/tests/p-inline-006.xml
@@ -9,7 +9,7 @@
 
   <p:identity name="inline">
     <p:with-input port="source">
-      <p:inline encoding="base64" document-properties="map { 'content-type': 'image/png' }">
+      <p:inline encoding="base64" document-properties="map { xs:QName('content-type'): 'image/png' }">
 iVBORw0KGgoAAAANSUhEUgAAAIAAAAAdCAYAAABixmRWAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
 <no-markup-please/>
       </p:inline>

--- a/test-suite/tests/pipe-attr-001.xml
+++ b/test-suite/tests/pipe-attr-001.xml
@@ -1,11 +1,8 @@
 <test xmlns='http://xproc.org/ns/testsuite/3.0' expected="pass">
   <pipeline>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:identity name="one">

--- a/test-suite/tests/pipe-attr-001.xml
+++ b/test-suite/tests/pipe-attr-001.xml
@@ -24,7 +24,7 @@
   </p:identity>
 
   <p:identity name="combined">
-    <p:with-input port="source" pipe="three two one"/>
+    <p:with-input port="source" pipe="@three @two @one"/>
   </p:identity>
 
   <p:wrap-sequence wrapper="docs"/>

--- a/test-suite/tests/pipe-attr-002.xml
+++ b/test-suite/tests/pipe-attr-002.xml
@@ -3,11 +3,8 @@
       expected="fail" code="err:XS0082">
   <pipeline>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                xmlns:ex="http://xmlcalabash.com/ext/foo"
-                xmlns:exf="http://exproc.org/standard/functions"
-                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
-                version="1.0">
+                version="3.0">
   <p:output port="result"/>
 
   <p:identity name="one">


### PR DESCRIPTION
- Additional tests
- Added optional elements to test suite syntax
- Changed text to revered order (port@pipe) as decided in Prague