### PR TITLE
Fix namespace declarations

### DIFF
--- a/test-suite/tests/ab-connection-003.xml
+++ b/test-suite/tests/ab-connection-003.xml
@@ -1,4 +1,6 @@
-<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0005">
+<test xmlns='http://xproc.org/ns/testsuite/3.0'
+      xmlns:err="http://www.w3.org/ns/xproc-error"
+      expected="fail" code="err:XS0005">
   <title>Connection 003</title>
   <description>
     <p>Tests that an explicit non primary output port is NOT connected to the output of the last step of the subpipeline.</p>

--- a/test-suite/tests/ab-connection-007.xml
+++ b/test-suite/tests/ab-connection-007.xml
@@ -1,4 +1,6 @@
-<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0005">
+<test xmlns='http://xproc.org/ns/testsuite/3.0'
+      xmlns:err="http://www.w3.org/ns/xproc-error"
+      expected="fail" code="err:XS0005">
   <title>Connection 007</title>
   <description>
     <p>Tests that the primary output port of the last step of a subpipeline is not connected to the pipelines primary output port, if the later has an explicit connection.</p>

--- a/test-suite/tests/ab-contenttypes-001.xml
+++ b/test-suite/tests/ab-contenttypes-001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0077">
     <t:title>Contenttypes 001</t:title>
     <t:description>
         <p>Tests XS0077 is raised for defective content-types on p:input</p>

--- a/test-suite/tests/ab-contenttypes-002.xml
+++ b/test-suite/tests/ab-contenttypes-002.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0077">
     <t:title>Contenttypes 002</t:title>
     <t:description>
         <p>Tests XS0077 is raised for defective content-types on p:output</p>

--- a/test-suite/tests/ab-contenttypes-003.xml
+++ b/test-suite/tests/ab-contenttypes-003.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0038">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0038">
     <t:title>Contenttypes 003</t:title>
     <t:description>
         <p>Tests XD0038 is raised when document does not match (default) content-types on p:input</p>

--- a/test-suite/tests/ab-contenttypes-004.xml
+++ b/test-suite/tests/ab-contenttypes-004.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0038">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0038">
     <t:title>Contenttypes 004</t:title>
     <t:description>
         <p>Tests XD0038 is raised when document does not match explicit content-types on p:input</p>

--- a/test-suite/tests/ab-contenttypes-005.xml
+++ b/test-suite/tests/ab-contenttypes-005.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0038">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0038">
     <t:title>Contenttypes 005</t:title>
     <t:description>
         <p>Tests XD0038 is raised when document does not match explicit content-types on p:input</p>

--- a/test-suite/tests/ab-contenttypes-006.xml
+++ b/test-suite/tests/ab-contenttypes-006.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0042">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0042">
     <t:title>Contenttypes 006</t:title>
     <t:description>
         <p>Tests XD0042 is raised when document does not match implicit content-types on p:output</p>

--- a/test-suite/tests/ab-contenttypes-007.xml
+++ b/test-suite/tests/ab-contenttypes-007.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0042">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0042">
     <t:title>Contenttypes 007</t:title>
     <t:description>
         <p>Tests XD0042 is raised when document does not match explicit content-types on p:output</p>

--- a/test-suite/tests/ab-contenttypes-008.xml
+++ b/test-suite/tests/ab-contenttypes-008.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0042">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0042">
     <t:title>Contenttypes 008</t:title>
     <t:description>
         <p>Tests XD0042 is raised when document does not match explicit content-types on p:output</p>

--- a/test-suite/tests/ab-contenttypes-009.xml
+++ b/test-suite/tests/ab-contenttypes-009.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0038">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0038">
     <t:title>Contenttypes 009</t:title>
     <t:description>
         <p>Tests XD0038 is raised when an externally supplied document does not match explicit content-types on p:input</p>

--- a/test-suite/tests/ab-err-d0006-001.xml
+++ b/test-suite/tests/ab-err-d0006-001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0006">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0006">
     <t:title>Error test XD006 001</t:title>
     <t:description>
         <p>Tests that XD006 is raised when a non sequence port receives p:empty</p>

--- a/test-suite/tests/ab-err-d0006-002.xml
+++ b/test-suite/tests/ab-err-d0006-002.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0006">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0006">
     <t:title>Error test XD006 002</t:title>
     <t:description>
         <p>Tests that XD006 is raised when more than one document arrives on a non-sequence port</p>

--- a/test-suite/tests/ab-err-d0006-003.xml
+++ b/test-suite/tests/ab-err-d0006-003.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0006">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0006">
     <t:title>Error test XD006 003</t:title>
     <t:description>
         <p>Tests that XD006 is raised when more than one document arrives on a non-sequence port</p>

--- a/test-suite/tests/ab-err-d0006-004.xml
+++ b/test-suite/tests/ab-err-d0006-004.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0006">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0006">
     <t:title>Error test XD006 004</t:title>
     <t:description>
         <p>Tests that XD006 is raised when more than one document arrives on a non-sequence port</p>

--- a/test-suite/tests/ab-err-d0049-001.xml
+++ b/test-suite/tests/ab-err-d0049-001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0049">
     <t:title>Error test XD0049 001</t:title>
     <t:description>
         <p>Tests that XD0049 is raised when sequence type in @as on p:variable is not valid: Wrong quantifier</p>

--- a/test-suite/tests/ab-err-d0049-002.xml
+++ b/test-suite/tests/ab-err-d0049-002.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0049">
     <t:title>Error test XD0049 002</t:title>
     <t:description>
         <p>Tests that XD0049 is raised when sequence type in @as on p:option is not valid: Wrong quantifier</p>

--- a/test-suite/tests/ab-err-d0049-003.xml
+++ b/test-suite/tests/ab-err-d0049-003.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0049">
     <t:title>Error test XD0049 003</t:title>
     <t:description>
         <p>Tests that XD0049 is raised when sequence type in @as on p:with-option is not valid: Wrong quantifier</p>

--- a/test-suite/tests/ab-err-d0049-004.xml
+++ b/test-suite/tests/ab-err-d0049-004.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0049">
     <t:title>Error test XD0049 004</t:title>
     <t:description>
         <p>Tests that XD0049 is raised when sequence type in @as on p:variable is not valid: Unknown type</p>

--- a/test-suite/tests/ab-err-d0049-005.xml
+++ b/test-suite/tests/ab-err-d0049-005.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0049">
     <t:title>Error test XD0049 005</t:title>
     <t:description>
         <p>Tests that XD0049 is raised when sequence type in @as on p:option is not valid: Unknown type</p>

--- a/test-suite/tests/ab-err-d0049-006.xml
+++ b/test-suite/tests/ab-err-d0049-006.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0049">
     <t:title>Error test XD0049 006</t:title>
     <t:description>
         <p>Tests that XD0049 is raised when sequence type in @as on p:with-option is not valid: Unknown type</p>

--- a/test-suite/tests/ab-err-s0037-001.xml
+++ b/test-suite/tests/ab-err-s0037-001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0037">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0037">
     <t:title>Error test XS0037 001</t:title>
     <t:description>
         <p>Tests that XS0037 is raised, when subpipeline contains non whitespace text nodes.</p>

--- a/test-suite/tests/ab-err-s0037-002.xml
+++ b/test-suite/tests/ab-err-s0037-002.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0037">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0037">
     <t:title>Error test XS0037 002</t:title>
     <t:description>
         <p>Tests that XS0037 is raised, when atomic step call contains non whitespace text nodes.</p>

--- a/test-suite/tests/ab-err-s0044-001.xml
+++ b/test-suite/tests/ab-err-s0044-001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
     <t:title>Error test XS0044 001</t:title>
     <t:description>
         <p>Tests that XS0044 is raised, when p:input contains non whitespace text nodes.</p>

--- a/test-suite/tests/ab-err-s0044-002.xml
+++ b/test-suite/tests/ab-err-s0044-002.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
     <t:title>Error test XS0044 002</t:title>
     <t:description>
         <p>Tests that XS0044 is raised, when p:with-input contains non whitespace text nodes.</p>

--- a/test-suite/tests/ab-err-s0044-003.xml
+++ b/test-suite/tests/ab-err-s0044-003.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
     <t:title>Error test XS0044 003</t:title>
     <t:description>
         <p>Tests that XS0044 is raised, when p:output contains non whitespace text nodes.</p>

--- a/test-suite/tests/ab-inline-001.xml
+++ b/test-suite/tests/ab-inline-001.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
-      xmlns:err="http://www.w3.org/ns/xproc-error"
-      expected="fail" code="err:XS0069">
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0069">
   <t:title>ab-inline-001</t:title>
   <t:description>
     <p>Tests that XS0069 is raised when encoding contains unsupported method.</p>

--- a/test-suite/tests/ab-inline-002.xml
+++ b/test-suite/tests/ab-inline-002.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
-      xmlns:err="http://www.w3.org/ns/xproc-error"
-      expected="fail" code="err:XD0055">
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0055">
   <t:title>ab-inline-002</t:title>
   <t:description>
     <p>Tests that XD0055 is raised when content-type contains charset and encoding is not present.</p>

--- a/test-suite/tests/ab-inline-012.xml
+++ b/test-suite/tests/ab-inline-012.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0057">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0057">
   <t:title>ab-inline-012</t:title>
   <t:description>
     <p>Tests an error is raised for a defective inline json construction</p>

--- a/test-suite/tests/ab-input-001.xml
+++ b/test-suite/tests/ab-input-001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0038">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0038">
     <t:title>Input 001</t:title>
     <t:description>
          <p>Tests that XS0038 is raised when p:input has no attribute "port".</p>

--- a/test-suite/tests/ab-input-002.xml
+++ b/test-suite/tests/ab-input-002.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0077">
     <t:title>Input 002</t:title>
     <t:description>
          <p>Tests that XS0077 is raised when p:input's @port is not an NCName.</p>

--- a/test-suite/tests/ab-input-003.xml
+++ b/test-suite/tests/ab-input-003.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0008">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0008">
     <t:title>Input 003</t:title>
     <t:description>
          <p>Tests that XS00008 is raised when p:input has an unknown attribute.</p>

--- a/test-suite/tests/ab-input-004.xml
+++ b/test-suite/tests/ab-input-004.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0077">
     <t:title>Input 004</t:title>
     <t:description>
         <p>Tests that XS0077 is raised when @primary on p:input is no boolean.</p>

--- a/test-suite/tests/ab-input-005.xml
+++ b/test-suite/tests/ab-input-005.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0077">
     <t:title>Input 005</t:title>
     <t:description>
         <p>Tests that XS0077 is raised when @sequence on p:input is no boolean.</p>

--- a/test-suite/tests/ab-input-006.xml
+++ b/test-suite/tests/ab-input-006.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0011">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0011">
     <t:title>Input 006</t:title>
     <t:description>
         <p>Tests that XS0011 is raised two input port with the same name are declared.</p>

--- a/test-suite/tests/ab-input-007.xml
+++ b/test-suite/tests/ab-input-007.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0011">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0011">
     <t:title>Input 007</t:title>
     <t:description>
         <p>Tests that XS0011 is raised when an input port and an output port are declared with the same name.</p>

--- a/test-suite/tests/ab-input-008.xml
+++ b/test-suite/tests/ab-input-008.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0014">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0014">
     <t:title>Input 008</t:title>
     <t:description>
         <p>Tests that XS0014 is raised when two input ports are declared as primary.</p>

--- a/test-suite/tests/ab-input-009.xml
+++ b/test-suite/tests/ab-input-009.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0008">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0008">
     <t:title>Input 009</t:title>
     <t:description>
         <p>Tests that XS0008 is raised when @pipe is used on p:input.</p>

--- a/test-suite/tests/ab-input-010.xml
+++ b/test-suite/tests/ab-input-010.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
     <t:title>Input 010</t:title>
     <t:description>
         <p>Tests that XS0044 is raised when p:pipe is a child on p:input.</p>

--- a/test-suite/tests/ab-input-011.xml
+++ b/test-suite/tests/ab-input-011.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
     <t:title>Input 011</t:title>
     <t:description>
         <p>Tests that XS0081 is raised when p:input has @href and p:empty as a child.</p>

--- a/test-suite/tests/ab-input-012.xml
+++ b/test-suite/tests/ab-input-012.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
     <t:title>Input 012</t:title>
     <t:description>
         <p>Tests that XS0081 is raised when p:input has @href and p:inline as a child.</p>

--- a/test-suite/tests/ab-input-013.xml
+++ b/test-suite/tests/ab-input-013.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
     <t:title>Input 013</t:title>
     <t:description>
         <p>Tests that XS0081 is raised when p:input has @href and p:document as a child.</p>

--- a/test-suite/tests/ab-input-014.xml
+++ b/test-suite/tests/ab-input-014.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
     <t:title>Input 014</t:title>
     <t:description>
         <p>Tests that XS0081 is raised when p:input has @href and implicit only content as a child.</p>

--- a/test-suite/tests/ab-input-026.xml
+++ b/test-suite/tests/ab-input-026.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD006">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD006">
     <t:title>Input 026</t:title>
     <t:description>
         <p>Tests XD006 is raised, when a non-sequence port is not externally bound.</p>

--- a/test-suite/tests/ab-input-027.xml
+++ b/test-suite/tests/ab-input-027.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD006">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD006">
     <t:title>Input 027</t:title>
     <t:description>
         <p>Tests XD006 is raised, when a non-sequence port is not externally bound.</p>

--- a/test-suite/tests/ab-input-028.xml
+++ b/test-suite/tests/ab-input-028.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0016">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0016">
     <t:title>Input 028</t:title>
     <t:description>
         <p>Tests XD0016 is raised, when @select return something, that is not a node.</p>

--- a/test-suite/tests/ab-input-029.xml
+++ b/test-suite/tests/ab-input-029.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0016">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0016">
     <t:title>Input 029</t:title>
     <t:description>
         <p>Tests XD0016 is raised, when @select returns an attribute.</p>

--- a/test-suite/tests/ab-option-001.xml
+++ b/test-suite/tests/ab-option-001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0038">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0038">
     <t:title>Option declaration 001</t:title>
     <t:description>
         <p>Tests option is declared with a name.</p>

--- a/test-suite/tests/ab-option-002.xml
+++ b/test-suite/tests/ab-option-002.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0028">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0028">
     <t:title>Option declaration 002</t:title>
     <t:description>
         <p>Tests option is not declared with a name in XProc's namespace.</p>

--- a/test-suite/tests/ab-option-003.xml
+++ b/test-suite/tests/ab-option-003.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0087">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0087">
     <t:title>Option declaration 003</t:title>
     <t:description>
         <p>Tests option is not declared with a name that has an undeclared namespace prefix.</p>

--- a/test-suite/tests/ab-option-004.xml
+++ b/test-suite/tests/ab-option-004.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0049">
     <t:title>Option declaration 004</t:title>
     <t:description>
         <p>Tests option is declared with an incorrect sequence type in @as</p>

--- a/test-suite/tests/ab-option-005.xml
+++ b/test-suite/tests/ab-option-005.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0077">
     <t:title>Option declaration 005</t:title>
     <t:description>
         <p>Tests option is declared with a correct boolean value in @required</p>

--- a/test-suite/tests/ab-option-006.xml
+++ b/test-suite/tests/ab-option-006.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0017">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0017">
     <t:title>Option declaration 006</t:title>
     <t:description>
         <p>Tests option is required and has a default value</p>

--- a/test-suite/tests/ab-option-007.xml
+++ b/test-suite/tests/ab-option-007.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0004">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0004">
     <t:title>Option declaration 007</t:title>
     <t:description>
         <p>Checks no options with the name same are declared.</p>

--- a/test-suite/tests/ab-option-009.xml
+++ b/test-suite/tests/ab-option-009.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0018">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0018">
     <t:title>Option declaration 009</t:title>
     <t:description>
         <p>Checks error is raised, if required option is not bound.</p>

--- a/test-suite/tests/ab-option-010.xml
+++ b/test-suite/tests/ab-option-010.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0036">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0036">
     <t:title>Option declaration 010</t:title>
     <t:description>
         <p>Checks error is raised, if value of required option does not match sequence type.</p>

--- a/test-suite/tests/ab-option-018.xml
+++ b/test-suite/tests/ab-option-018.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0036">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0036">
     <t:title>Option declaration 018</t:title>
     <t:description>
         <p>Checks not required option with default value is type checked.</p>

--- a/test-suite/tests/ab-option-019.xml
+++ b/test-suite/tests/ab-option-019.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0036">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0036">
     <t:title>Option declaration 019</t:title>
     <t:description>
         <p>Checks not required option with default value is type checked.</p>

--- a/test-suite/tests/ab-option-023.xml
+++ b/test-suite/tests/ab-option-023.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0030">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0030">
     <t:title>Option declaration 023</t:title>
     <t:description>
         <p>Checks self reference of options is not allowed.</p>

--- a/test-suite/tests/ab-option-025.xml
+++ b/test-suite/tests/ab-option-025.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0049">
     <t:title>Option declaration 025</t:title>
     <t:description>
         <p>Checks XD0049 (invalid sequence type) is raised when default value is used.</p>

--- a/test-suite/tests/ab-option-029.xml
+++ b/test-suite/tests/ab-option-029.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0036">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0036">
     <t:title>Option declaration 029</t:title>
     <t:description>
         <p>Checks non required option with no default value and no value supplied (= ()) is type checked.</p>

--- a/test-suite/tests/ab-output-declaration-001.xml
+++ b/test-suite/tests/ab-output-declaration-001.xml
@@ -1,4 +1,6 @@
-<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<test xmlns='http://xproc.org/ns/testsuite/3.0'
+      xmlns:err="http://www.w3.org/ns/xproc-error"
+      expected="fail" code="err:XS0077">
   <title>Output port declaration 001</title>
   <description>
     <p>Tests for error XS0077 to be raised, when @primary on p:output is not 'true' or 'false'.</p>

--- a/test-suite/tests/ab-output-declaration-002.xml
+++ b/test-suite/tests/ab-output-declaration-002.xml
@@ -1,4 +1,6 @@
-<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<test xmlns='http://xproc.org/ns/testsuite/3.0'
+      xmlns:err="http://www.w3.org/ns/xproc-error"
+      expected="fail" code="err:XS0077">
   <title>Output port declaration 002</title>
   <description>
     <p>Tests for error XS0077 to be raised, when @sequence on p:output is not 'true' or 'false'.</p>

--- a/test-suite/tests/ab-output-declaration-003.xml
+++ b/test-suite/tests/ab-output-declaration-003.xml
@@ -1,4 +1,6 @@
-<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0014">
+<test xmlns='http://xproc.org/ns/testsuite/3.0'
+      xmlns:err="http://www.w3.org/ns/xproc-error"
+      expected="fail" code="err:XS0014">
   <title>Output port declaration 003</title>
   <description>
     <p>Tests for error XS0014 to be raised, if two output ports are declared to be primary.</p>

--- a/test-suite/tests/ab-output-declaration-004.xml
+++ b/test-suite/tests/ab-output-declaration-004.xml
@@ -1,4 +1,6 @@
-<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0011">
+<test xmlns='http://xproc.org/ns/testsuite/3.0'
+      xmlns:err="http://www.w3.org/ns/xproc-error"
+      expected="fail" code="err:XS0011">
   <title>Output port declaration 004</title>
   <description>
     <p>Tests for error XS0011 to be raised, if two output ports are declared with the same name.</p>

--- a/test-suite/tests/ab-p-document008.xml
+++ b/test-suite/tests/ab-p-document008.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0011">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0011">
     <t:title>p:document 008</t:title>
     <t:description>
         <p>Tests p:document with @href to a non existing resource: XD0011 expected.</p>

--- a/test-suite/tests/ab-p-document009.xml
+++ b/test-suite/tests/ab-p-document009.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0011">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0011">
     <t:title>p:document 009</t:title>
     <t:description>
         <p>Tests p:with-input with @href to a non existing resource: XD0011 expected.</p>

--- a/test-suite/tests/ab-p-document010.xml
+++ b/test-suite/tests/ab-p-document010.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0011">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0011">
     <t:title>p:document 010</t:title>
     <t:description>
         <p>Tests p:document with @href to a not well-formed document: XD0011 expected.</p>

--- a/test-suite/tests/ab-p-document011.xml
+++ b/test-suite/tests/ab-p-document011.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0011">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0011">
     <t:title>p:document 011</t:title>
     <t:description>
         <p>Tests p:with-input with @href to a not well-formed document: XD0011 expected.</p>

--- a/test-suite/tests/ab-p-document015.xml
+++ b/test-suite/tests/ab-p-document015.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0023">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0023">
     <t:title>p:document 015</t:title>
     <t:description>
         <p>Tests invalid p:document with dtd-validate='true'.</p>

--- a/test-suite/tests/ab-p-document019.xml
+++ b/test-suite/tests/ab-p-document019.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0060"
-    xmlns:mox="http://www.xml-project-com/morganaxproc">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0060">
     <t:title>p:document 019</t:title>
     <t:description>
         <p>Tests p:document with a simple text document in an unsupported encoding.</p>

--- a/test-suite/tests/ab-p-document023.xml
+++ b/test-suite/tests/ab-p-document023.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0058">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0058">
     <t:title>p:document 023</t:title>
     <t:description>
         <p>Tests p:document with a JSON-document: Error MOX003 expected because 'duplicates'='reject'</p>

--- a/test-suite/tests/ab-p-document025.xml
+++ b/test-suite/tests/ab-p-document025.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0059">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0059">
     <t:title>p:document 025</t:title>
     <t:description>
         <p>Tests p:document with a JSON-document: Error MOX004 expected because 'duplicates' has illegal value.</p>

--- a/test-suite/tests/ab-p-document026.xml
+++ b/test-suite/tests/ab-p-document026.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0057">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0057">
     <t:title>p:document 026</t:title>
     <t:description>
         <p>Tests p:document with a JSON-document: Error MOX002 expected for defective document and liberal=false.</p>

--- a/test-suite/tests/ab-variable-001.xml
+++ b/test-suite/tests/ab-variable-001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0038">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0038">
     <t:title>Variable declaration 001</t:title>
     <t:description>
         <p>Tests variable is declared with a name.</p>

--- a/test-suite/tests/ab-variable-002.xml
+++ b/test-suite/tests/ab-variable-002.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0038">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0038">
     <t:title>Variable declaration 002</t:title>
     <t:description>
         <p>Tests variable is declared with an @select.</p>

--- a/test-suite/tests/ab-variable-003.xml
+++ b/test-suite/tests/ab-variable-003.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0008">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0008">
     <t:title>Variable declaration 003</t:title>
     <t:description>
         <p>Tests only allowed attributes on p:variable</p>

--- a/test-suite/tests/ab-variable-004.xml
+++ b/test-suite/tests/ab-variable-004.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0028">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0028">
     <t:title>Variable declaration 004</t:title>
     <t:description>
         <p>Tests a variable does not have a name in XProc's namespace.</p>

--- a/test-suite/tests/ab-variable-005.xml
+++ b/test-suite/tests/ab-variable-005.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0087">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0087">
     <t:title>Variable declaration 005</t:title>
     <t:description>
         <p>Tests a variable does not have a name with an undeclared prefix.</p>

--- a/test-suite/tests/ab-variable-006.xml
+++ b/test-suite/tests/ab-variable-006.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0049">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0049">
     <t:title>Variable declaration 006</t:title>
     <t:description>
         <p>Tests XD0049 is raised if a variable has an incorrect sequence type.</p>

--- a/test-suite/tests/ab-variable-007.xml
+++ b/test-suite/tests/ab-variable-007.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0085">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0085">
     <t:title>Variable declaration 007</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @pipe and @href.</p>

--- a/test-suite/tests/ab-variable-008.xml
+++ b/test-suite/tests/ab-variable-008.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
     <t:title>Variable declaration 008</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @href and an implicit inline as child.</p>

--- a/test-suite/tests/ab-variable-009.xml
+++ b/test-suite/tests/ab-variable-009.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
     <t:title>Variable declaration 009</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @href and an explicit inline as child.</p>

--- a/test-suite/tests/ab-variable-010.xml
+++ b/test-suite/tests/ab-variable-010.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
     <t:title>Variable declaration 010</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @href and a p:document as child.</p>

--- a/test-suite/tests/ab-variable-011.xml
+++ b/test-suite/tests/ab-variable-011.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
     <t:title>Variable declaration 011</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @href and a p:empty as child.</p>

--- a/test-suite/tests/ab-variable-012.xml
+++ b/test-suite/tests/ab-variable-012.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
     <t:title>Variable declaration 012</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @href and a p:pipe as child.</p>

--- a/test-suite/tests/ab-variable-013.xml
+++ b/test-suite/tests/ab-variable-013.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
     <t:title>Variable declaration 013</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @pipe and an implicit inline as child.</p>

--- a/test-suite/tests/ab-variable-014.xml
+++ b/test-suite/tests/ab-variable-014.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
     <t:title>Variable declaration 014</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @pipe and an inline as child.</p>

--- a/test-suite/tests/ab-variable-015.xml
+++ b/test-suite/tests/ab-variable-015.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
     <t:title>Variable declaration 015</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @pipe and a p:document as child.</p>

--- a/test-suite/tests/ab-variable-016.xml
+++ b/test-suite/tests/ab-variable-016.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
     <t:title>Variable declaration 016</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @pipe and p:empty as child.</p>

--- a/test-suite/tests/ab-variable-017.xml
+++ b/test-suite/tests/ab-variable-017.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
     <t:title>Variable declaration 017</t:title>
     <t:description>
         <p>Tests a variable declaration does not have @pipe and p:pipe as child.</p>

--- a/test-suite/tests/ab-variable-018.xml
+++ b/test-suite/tests/ab-variable-018.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0036">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0036">
     <t:title>Variable declaration 018</t:title>
     <t:description>
         <p>Tests a variable declaration raises an error (XD0036) if select result does not match required type.</p>

--- a/test-suite/tests/ab-variable-021.xml
+++ b/test-suite/tests/ab-variable-021.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0008">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0008">
     <t:title>Variable declaration 021</t:title>
     <t:description>
         <p>Checks XD0008 is raised if more than one document appears as connection of p:variable and @connection is missing.</p>

--- a/test-suite/tests/ab-variable-022.xml
+++ b/test-suite/tests/ab-variable-022.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0008">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0008">
     <t:title>Variable declaration 022</t:title>
     <t:description>
         <p>Checks XD0008 is raised if more than one document appears as connection of p:variable and @connection is false.</p>

--- a/test-suite/tests/ab-variable-024.xml
+++ b/test-suite/tests/ab-variable-024.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0077">
     <t:title>Variable declaration 024</t:title>
     <t:description>
         <p>Checks XS0077 is raised @connection on p:variable is not a boolean value.</p>

--- a/test-suite/tests/ab-with-input-002.xml
+++ b/test-suite/tests/ab-with-input-002.xml
@@ -1,4 +1,6 @@
-<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0065">
+<test xmlns='http://xproc.org/ns/testsuite/3.0'
+      xmlns:err="http://www.w3.org/ns/xproc-error"
+      expected="fail" code="err:XS0065">
   <title>with-input-002</title>
   <description>
     <p>Tests p:with-input with missing @port on atomic step: XS0065 is raised because there is no primary input port.</p>

--- a/test-suite/tests/ab-with-input-003.xml
+++ b/test-suite/tests/ab-with-input-003.xml
@@ -1,4 +1,6 @@
-<test xmlns='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0010">
+<test xmlns='http://xproc.org/ns/testsuite/3.0'
+      xmlns:err="http://www.w3.org/ns/xproc-error"
+      expected="fail" code="err:XS0010">
   <title>with-input-003</title>
   <description>
     <p>Tests p:with-input with undeclared port: XS0010 to be raised.</p>

--- a/test-suite/tests/ab-with-input-006.xml
+++ b/test-suite/tests/ab-with-input-006.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0085">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0085">
   <t:title>with-input-006</t:title>
   <t:description>
     <p>Tests p:with-input with @href and @pipe: XS0081 to be raised</p>

--- a/test-suite/tests/ab-with-input-007.xml
+++ b/test-suite/tests/ab-with-input-007.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
   <t:title>with-input-007</t:title>
   <t:description>
     <p>Tests p:with-input with @href and p:inline: XS0081 to be raised</p>

--- a/test-suite/tests/ab-with-input-008.xml
+++ b/test-suite/tests/ab-with-input-008.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
   <t:title>with-input-008</t:title>
   <t:description>
     <p>Tests p:with-input with @href and p:empty: XS0081 to be raised</p>

--- a/test-suite/tests/ab-with-input-009.xml
+++ b/test-suite/tests/ab-with-input-009.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
   <t:title>with-input-009</t:title>
   <t:description>
     <p>Tests p:with-input with @href and p:document: XS0081 to be raised</p>

--- a/test-suite/tests/ab-with-input-010.xml
+++ b/test-suite/tests/ab-with-input-010.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
   <t:title>with-input-010</t:title>
   <t:description>
     <p>Tests p:with-input with @href and p:pipe: XS0081 to be raised</p>

--- a/test-suite/tests/ab-with-input-011.xml
+++ b/test-suite/tests/ab-with-input-011.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0081">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0081">
   <t:title>with-input-011</t:title>
   <t:description>
     <p>Tests p:with-input with @href and implicit inline content: XS0081 to be raised</p>

--- a/test-suite/tests/ab-with-input-017.xml
+++ b/test-suite/tests/ab-with-input-017.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
   <t:title>with-input-017</t:title>
   <t:description>
     <p>Tests p:with-input with @pipe and p:empty: XS0082 to be raised</p>

--- a/test-suite/tests/ab-with-input-018.xml
+++ b/test-suite/tests/ab-with-input-018.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
   <t:title>with-input-018</t:title>
   <t:description>
     <p>Tests p:with-input with @pipe and p:document: XS0082 to be raised</p>

--- a/test-suite/tests/ab-with-input-019.xml
+++ b/test-suite/tests/ab-with-input-019.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
   <t:title>with-input-019</t:title>
   <t:description>
     <p>Tests p:with-input with @pipe and p:pipe: XS0082 to be raised</p>

--- a/test-suite/tests/ab-with-input-020.xml
+++ b/test-suite/tests/ab-with-input-020.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
   <t:title>with-input-020</t:title>
   <t:description>
     <p>Tests p:with-input with @pipe and p:inline: XS0082 to be raised</p>

--- a/test-suite/tests/ab-with-input-021.xml
+++ b/test-suite/tests/ab-with-input-021.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0082">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0082">
   <t:title>with-input-021</t:title>
   <t:description>
     <p>Tests p:with-input with @pipe and implicit inline content: XS0082 to be raised</p>

--- a/test-suite/tests/ab-with-input-028.xml
+++ b/test-suite/tests/ab-with-input-028.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0022">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0022">
   <t:title>with-input-028</t:title>
   <t:description>
     <p>Tests p:with-input with p:pipe with an unknown port.</p>

--- a/test-suite/tests/ab-with-input-029.xml
+++ b/test-suite/tests/ab-with-input-029.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0067">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0067">
   <t:title>with-input-029</t:title>
   <t:description>
     <p>Tests p:with-input with p:pipe (no port and no step) and no default readable port</p>

--- a/test-suite/tests/ab-with-input-030.xml
+++ b/test-suite/tests/ab-with-input-030.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0022">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0022">
   <t:title>with-input-030</t:title>
   <t:description>
     <p>Tests p:with-input with p:pipe (no @step) with an unknown port.</p>

--- a/test-suite/tests/ab-with-input-031.xml
+++ b/test-suite/tests/ab-with-input-031.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0067">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0067">
   <t:title>with-input-031</t:title>
   <t:description>
     <p>Tests p:with-input with empty @pipe and no default readable port</p>

--- a/test-suite/tests/ab-with-input-032.xml
+++ b/test-suite/tests/ab-with-input-032.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0077">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0077">
   <t:title>with-input-032</t:title>
   <t:description>
     <p>Tests p:with-input with defective @pipe: step@</p>

--- a/test-suite/tests/ab-with-input-035.xml
+++ b/test-suite/tests/ab-with-input-035.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-035</t:title>
   <t:description>
     <p>Tests p:with-input: Checks only one p:empty is allowed as connection.</p>

--- a/test-suite/tests/ab-with-input-036.xml
+++ b/test-suite/tests/ab-with-input-036.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-036</t:title>
   <t:description>
     <p>Tests p:with-input: Checks p:empty and p:inline are not allowed as connection.</p>

--- a/test-suite/tests/ab-with-input-037.xml
+++ b/test-suite/tests/ab-with-input-037.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-037</t:title>
   <t:description>
     <p>Tests p:with-input: Checks p:empty and p:pipe are not allowed as connection.</p>

--- a/test-suite/tests/ab-with-input-038.xml
+++ b/test-suite/tests/ab-with-input-038.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-038</t:title>
   <t:description>
     <p>Tests p:with-input: Checks p:empty and p:document are not allowed as connection.</p>

--- a/test-suite/tests/ab-with-input-039.xml
+++ b/test-suite/tests/ab-with-input-039.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-039</t:title>
   <t:description>
     <p>Tests p:with-input: Checks p:namespaces is not allowed.</p>

--- a/test-suite/tests/ab-with-input-040.xml
+++ b/test-suite/tests/ab-with-input-040.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-040</t:title>
   <t:description>
     <p>Tests p:with-input: p:documentation and implicit inline not allowed</p>

--- a/test-suite/tests/ab-with-input-041.xml
+++ b/test-suite/tests/ab-with-input-041.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-041</t:title>
   <t:description>
     <p>Tests p:with-input: p:pipeinfo and implicit inline not allowed</p>

--- a/test-suite/tests/ab-with-input-042.xml
+++ b/test-suite/tests/ab-with-input-042.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-042</t:title>
   <t:description>
     <p>Tests p:with-input: p:inline and implicit inline not allowed</p>

--- a/test-suite/tests/ab-with-input-043.xml
+++ b/test-suite/tests/ab-with-input-043.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-043</t:title>
   <t:description>
     <p>Tests p:with-input: p:document and implicit inline not allowed</p>

--- a/test-suite/tests/ab-with-input-044.xml
+++ b/test-suite/tests/ab-with-input-044.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-044</t:title>
   <t:description>
     <p>Tests p:with-input: p:pipe and implicit inline not allowed</p>

--- a/test-suite/tests/ab-with-input-045.xml
+++ b/test-suite/tests/ab-with-input-045.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-045</t:title>
   <t:description>
     <p>Tests p:with-input: implicit inline and p:documentation not allowed</p>

--- a/test-suite/tests/ab-with-input-046.xml
+++ b/test-suite/tests/ab-with-input-046.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-046</t:title>
   <t:description>
     <p>Tests p:with-input: implicit inline and p:pipeinfo not allowed</p>

--- a/test-suite/tests/ab-with-input-047.xml
+++ b/test-suite/tests/ab-with-input-047.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-047</t:title>
   <t:description>
     <p>Tests p:with-input: implicit inline and p:inline not allowed </p>

--- a/test-suite/tests/ab-with-input-048.xml
+++ b/test-suite/tests/ab-with-input-048.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-048</t:title>
   <t:description>
     <p>Tests p:with-input: implicit inline and p:document not allowed</p>

--- a/test-suite/tests/ab-with-input-049.xml
+++ b/test-suite/tests/ab-with-input-049.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-049</t:title>
   <t:description>
     <p>Tests p:with-input: implicit inline and p:pipe not allowed</p>

--- a/test-suite/tests/ab-with-input-050.xml
+++ b/test-suite/tests/ab-with-input-050.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-050</t:title>
   <t:description>
     <p>Tests p:with-input: implicit inline and p:empty not allowed</p>

--- a/test-suite/tests/ab-with-input-051.xml
+++ b/test-suite/tests/ab-with-input-051.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0044">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0044">
   <t:title>with-input-051</t:title>
   <t:description>
     <p>Tests p:with-input: p:empty and implicit inline not allowed</p>

--- a/test-suite/tests/ab-with-input-053.xml
+++ b/test-suite/tests/ab-with-input-053.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0079">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0079">
   <t:title>with-input-053</t:title>
   <t:description>
     <p>Tests p:with-input: No comments or processing instructions allowed as siblings with implicit inlines</p>

--- a/test-suite/tests/ab-with-input-054.xml
+++ b/test-suite/tests/ab-with-input-054.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0079">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0079">
   <t:title>with-input-054</t:title>
   <t:description>
     <p>Tests p:with-input: No non empty text nodes allowed as siblings with implicit inlines</p>

--- a/test-suite/tests/ab-with-input-055.xml
+++ b/test-suite/tests/ab-with-input-055.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0032">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0032">
   <t:title>with-input-055</t:title>
   <t:description>
     <p>Tests p:with-input: Tests primary input port is connected.</p>

--- a/test-suite/tests/ab-with-input-056.xml
+++ b/test-suite/tests/ab-with-input-056.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0032">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0032">
   <t:title>with-input-056</t:title>
   <t:description>
     <p>Tests p:with-input: Tests primary input port is connected.</p>

--- a/test-suite/tests/ab-with-input-057.xml
+++ b/test-suite/tests/ab-with-input-057.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0032">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0032">
   <t:title>with-input-057</t:title>
   <t:description>
     <p>Tests p:with-input: Tests primary input port is connected. (p:documentation and p:pipeinfo are no connections)</p>

--- a/test-suite/tests/ab-with-input-058.xml
+++ b/test-suite/tests/ab-with-input-058.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0003">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0003">
   <t:title>with-input-058</t:title>
   <t:description>
     <p>Tests p:with-input: Tests error XS0003 is raised if non-primary input port is not connected.</p>

--- a/test-suite/tests/ab-with-input-059.xml
+++ b/test-suite/tests/ab-with-input-059.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0003">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0003">
   <t:title>with-input-059</t:title>
   <t:description>
     <p>Tests p:with-input: Tests error XS0003 is raised if non-primary input port is not connected.</p>

--- a/test-suite/tests/ab-with-input-060.xml
+++ b/test-suite/tests/ab-with-input-060.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0003">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0003">
   <t:title>with-input-060</t:title>
   <t:description>
     <p>Tests p:with-input: Tests p:with-input: Tests error XS0003 is raised if non-primary input port is not connected.</p>

--- a/test-suite/tests/ab-with-input-061.xml
+++ b/test-suite/tests/ab-with-input-061.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0086">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0086">
   <t:title>with-input-061</t:title>
   <t:description>
     <p>Tests p:with-input: Tests port is not bound twice.</p>

--- a/test-suite/tests/ab-with-input-062.xml
+++ b/test-suite/tests/ab-with-input-062.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0086">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0086">
   <t:title>with-input-062</t:title>
   <t:description>
     <p>Tests p:with-input: Tests port is not bound twice.</p>

--- a/test-suite/tests/ab-with-input-063.xml
+++ b/test-suite/tests/ab-with-input-063.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0086">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0086">
   <t:title>with-input-063</t:title>
   <t:description>
     <p>Tests p:with-input: Tests port is not bound twice.</p>

--- a/test-suite/tests/ab-with-input-064.xml
+++ b/test-suite/tests/ab-with-input-064.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0086">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0086">
   <t:title>with-input-064</t:title>
   <t:description>
     <p>Tests p:with-input: Tests port is not bound twice.</p>

--- a/test-suite/tests/ab-with-input-select-007.xml
+++ b/test-suite/tests/ab-with-input-select-007.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0016">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0016">
     <t:title>with-input-select-007</t:title>
     <t:description>
         <p>Tests that XD0016 is raised, when @select returns value that is not a node.</p>

--- a/test-suite/tests/ab-with-input-select-008.xml
+++ b/test-suite/tests/ab-with-input-select-008.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XD0016">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0016">
     <t:title>with-input-select-008</t:title>
     <t:description>
         <p>Tests that XD0016 is raised, when @select returns an attribute.</p>


### PR DESCRIPTION
A great many tests specify an error code of "err:xxxx" but fail to declare the err: namespace.
The code value is a QName, not a string :-)
