### PR TITLE
Added missing namespace binding in test

### DIFF
--- a/test-suite/pipelines/doc-prop-001.xpl
+++ b/test-suite/pipelines/doc-prop-001.xpl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
                 version="3.0">
   <p:output port="result"/>

--- a/test-suite/pipelines/doc-prop-002.xpl
+++ b/test-suite/pipelines/doc-prop-002.xpl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
                 version="3.0">
   <p:output port="result"/>

--- a/test-suite/pipelines/doc-prop-003.xpl
+++ b/test-suite/pipelines/doc-prop-003.xpl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
                 version="3.0">
   <p:output port="result"/>

--- a/test-suite/pipelines/doc-prop-004.xpl
+++ b/test-suite/pipelines/doc-prop-004.xpl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
                 version="3.0">
   <p:output port="result"/>

--- a/test-suite/pipelines/doc-prop-005.xpl
+++ b/test-suite/pipelines/doc-prop-005.xpl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:cx="http://xmlcalabash.com/ns/extensions"
                 name="main"
                 version="3.0">
   <p:output port="result"/>

--- a/test-suite/tests/ab-contenttypes-006.xml
+++ b/test-suite/tests/ab-contenttypes-006.xml
@@ -11,7 +11,7 @@
         <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
             <p:output port="result"/>        
             <p:identity>
-                <p:with-input><p:inline document-properties="map{xs:QName('content-type'):'text/plain'}">text</p:inline></p:with-input>
+                <p:with-input><p:inline content-type="text/plain">text</p:inline></p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>

--- a/test-suite/tests/ab-contenttypes-007.xml
+++ b/test-suite/tests/ab-contenttypes-007.xml
@@ -11,7 +11,7 @@
         <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
             <p:output port="result" content-types="application/xml"/>        
             <p:identity>
-                <p:with-input><p:inline document-properties="map{xs:QName('content-type'):'text/plain'}">text</p:inline></p:with-input>
+                <p:with-input><p:inline content-type="text/plain">text</p:inline></p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>

--- a/test-suite/tests/ab-inline-001.xml
+++ b/test-suite/tests/ab-inline-001.xml
@@ -12,7 +12,7 @@
       <p:output port="result" />
       <p:identity>
         <p:with-input >
-          <p:inline document-properties="map{'content-type':'text/plain'}" encoding="not-supported"
+          <p:inline content-type="text/plain" encoding="not-supported"
             >Dies ist ein Text.</p:inline>
         </p:with-input>
       </p:identity>

--- a/test-suite/tests/ab-inline-002.xml
+++ b/test-suite/tests/ab-inline-002.xml
@@ -11,7 +11,7 @@
       <p:output port="result" />
       <p:identity>
         <p:with-input >
-          <p:inline document-properties="map{xs:QName('content-type'):'text/plain; charset=UTF-8'}">Dies ist ein Text.</p:inline>
+          <p:inline content-type="text/plain; charset=UTF-8">Dies ist ein Text.</p:inline>
         </p:with-input>
       </p:identity>
     </p:declare-step>    

--- a/test-suite/tests/ab-inline-003.xml
+++ b/test-suite/tests/ab-inline-003.xml
@@ -11,7 +11,7 @@
       <p:output port="result" />
       <p:identity>
         <p:with-input >
-          <p:inline encoding="base64" document-properties="map{xs:QName('content-type'):'text/plain'}">Dies ist ein Text.</p:inline>
+          <p:inline encoding="base64" content-type="text/plain">Dies ist ein Text.</p:inline>
         </p:with-input>
       </p:identity>
     </p:declare-step>    

--- a/test-suite/tests/ab-inline-004.xml
+++ b/test-suite/tests/ab-inline-004.xml
@@ -11,7 +11,7 @@
       
       <p:identity>
         <p:with-input >
-          <p:inline encoding="base64" document-properties="map{xs:QName('content-type'):'text/plain'}">VGhpcyBpcyBhIHRlc3Qgd2l0aCDDpCDDtiDDvC4=</p:inline>
+          <p:inline encoding="base64" content-type="text/plain">VGhpcyBpcyBhIHRlc3Qgd2l0aCDDpCDDtiDDvC4=</p:inline>
         </p:with-input>
       </p:identity>
       

--- a/test-suite/tests/ab-inline-005.xml
+++ b/test-suite/tests/ab-inline-005.xml
@@ -11,7 +11,7 @@
       
       <p:identity>
         <p:with-input >
-          <p:inline encoding="base64" document-properties="map{xs:QName('content-type'):'text/plain; charset=UTF-8'}">VGhpcyBpcyBhIHRlc3Qgd2l0aCDDpCDDtiDDvC4=</p:inline>
+          <p:inline encoding="base64" content-type="text/plain; charset=UTF-8">VGhpcyBpcyBhIHRlc3Qgd2l0aCDDpCDDtiDDvC4=</p:inline>
         </p:with-input>
       </p:identity>
       

--- a/test-suite/tests/ab-inline-006.xml
+++ b/test-suite/tests/ab-inline-006.xml
@@ -11,7 +11,7 @@
       
       <p:identity>
         <p:with-input >
-          <p:inline encoding="base64" document-properties="map{xs:QName('content-type'):'text/plain; charset=ISO-8859-1'}">VGhpcyBpcyBhIHRlc3Qgd2l0aCDkIPYg/C4=</p:inline>
+          <p:inline encoding="base64" content-type="text/plain; charset=ISO-8859-1">VGhpcyBpcyBhIHRlc3Qgd2l0aCDkIPYg/C4=</p:inline>
         </p:with-input>
       </p:identity>
       

--- a/test-suite/tests/ab-inline-007.xml
+++ b/test-suite/tests/ab-inline-007.xml
@@ -13,7 +13,7 @@
       
       <p:identity>
         <p:with-input >
-          <p:inline encoding="base64" document-properties="map{xs:QName('content-type'):'text/plain; charset=notsupported'}">VGhpcyBpcyBhIHRlc3Qgd2l0aCDkIPYg/C4=</p:inline>
+          <p:inline encoding="base64" content-type="text/plain; charset=notsupported">VGhpcyBpcyBhIHRlc3Qgd2l0aCDkIPYg/C4=</p:inline>
         </p:with-input>
       </p:identity>
       

--- a/test-suite/tests/ab-inline-008.xml
+++ b/test-suite/tests/ab-inline-008.xml
@@ -11,7 +11,7 @@
       <p:variable name="var" select="'test'"/>
       <p:identity>
         <p:with-input>
-          <p:inline expand-text="false" document-properties="map{xs:QName('content-type'):'text/plain'}">This is a {$var}.</p:inline>
+          <p:inline expand-text="false" content-type="text/plain">This is a {$var}.</p:inline>
         </p:with-input>
       </p:identity>
       

--- a/test-suite/tests/ab-inline-009.xml
+++ b/test-suite/tests/ab-inline-009.xml
@@ -11,7 +11,7 @@
       <p:variable name="var" select="'test'"/>
       <p:identity>
         <p:with-input>
-          <p:inline expand-text="true" document-properties="map{xs:QName('content-type'):'text/plain'}">This is a {$var}.</p:inline>
+          <p:inline expand-text="true" content-type="text/plain">This is a {$var}.</p:inline>
         </p:with-input>
       </p:identity>
       

--- a/test-suite/tests/ab-inline-010.xml
+++ b/test-suite/tests/ab-inline-010.xml
@@ -11,7 +11,7 @@
       
       <p:identity>
         <p:with-input select="p:document-properties-document(.)">
-          <p:inline expand-text='false' document-properties="map{xs:QName('content-type'):'application/json'}">{"key":"value"}</p:inline>
+          <p:inline expand-text='false' content-type="application/json">{"key":"value"}</p:inline>
         </p:with-input>
       </p:identity>
       

--- a/test-suite/tests/ab-inline-011.xml
+++ b/test-suite/tests/ab-inline-011.xml
@@ -11,7 +11,7 @@
       
       <p:identity>
         <p:with-input select="p:document-properties-document(.)">
-          <p:inline expand-text='true' document-properties="map{xs:QName('content-type'):'application/json'}">{{"key":"value"}}</p:inline>
+          <p:inline expand-text='true' content-type="application/json">{{"key":"value"}}</p:inline>
         </p:with-input>
       </p:identity>
       

--- a/test-suite/tests/ab-inline-012.xml
+++ b/test-suite/tests/ab-inline-012.xml
@@ -14,7 +14,7 @@
       
       <p:identity>
         <p:with-input>
-          <p:inline expand-text='false' document-properties="map{xs:QName('content-type'):'application/json'}">{"key":</p:inline>
+          <p:inline expand-text='false' content-type="application/json">{"key":</p:inline>
         </p:with-input>
       </p:identity>
       

--- a/test-suite/tests/ab-with-input-select-006.xml
+++ b/test-suite/tests/ab-with-input-select-006.xml
@@ -11,7 +11,7 @@
             <p:output port="result" />
             <p:identity>
                 <p:with-input select="/xsl:stylesheet/xsl:template[1]" >
-                    <p:inline document-properties="map{xs:QName('content-type'):'application/xslt+xml'}">
+                    <p:inline content-type="application/xslt+xml">
                         <xsl:stylesheet version="2.0">
                             <xsl:template match="/">
                                 <xsl:text>result</xsl:text>

--- a/test-suite/tests/p-inline-002.xml
+++ b/test-suite/tests/p-inline-002.xml
@@ -7,7 +7,7 @@
 
   <p:identity name="inline">
     <p:with-input port="source">
-      <p:inline document-properties="map { xs:QName('content-type'): 'text/plain' }"
+      <p:inline content-type="text/plain"
                 >Hello, world.</p:inline>
     </p:with-input>
   </p:identity>

--- a/test-suite/tests/p-inline-003.xml
+++ b/test-suite/tests/p-inline-003.xml
@@ -7,7 +7,7 @@
 
   <p:identity name="inline">
     <p:with-input port="source">
-      <p:inline encoding="base64" document-properties="map {xs:QName('content-type'): 'image/png' }">iVBORw0KGgoAAAANSUhEUgAAAIAAAAAdCAYAAABixmRWAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
+      <p:inline encoding="base64" content-type="image/png">iVBORw0KGgoAAAANSUhEUgAAAIAAAAAdCAYAAABixmRWAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
 AAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAA
 CXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4QoICxwdF+yMrAAADXpJREFUaN7tW2lsFOUb/83u
 0u2W7W7psQW6bekWKAiUS8EiCgasqEEh0RBMjEGjwXgn6he/6QdRMRgUvGI8IzGeoKBcBkWwgD04

--- a/test-suite/tests/p-inline-004.xml
+++ b/test-suite/tests/p-inline-004.xml
@@ -9,7 +9,7 @@
 
   <p:identity name="inline">
     <p:with-input port="source">
-      <p:inline encoding="unknown" document-properties="map { 'content-type': 'image/png' }">
+      <p:inline encoding="unknown" content-type="image/png">
 iVBORw0KGgoAAAANSUhEUgAAAIAAAAAdCAYAAABixmRWAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
       </p:inline>
     </p:with-input>

--- a/test-suite/tests/p-inline-006.xml
+++ b/test-suite/tests/p-inline-006.xml
@@ -9,7 +9,7 @@
 
   <p:identity name="inline">
     <p:with-input port="source">
-      <p:inline encoding="base64" document-properties="map {xs:QName('content-type'): 'image/png' }">
+      <p:inline encoding="base64" content-type="image/png">
 iVBORw0KGgoAAAANSUhEUgAAAIAAAAAdCAYAAABixmRWAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
 <no-markup-please/>
       </p:inline>


### PR DESCRIPTION
Some tests call "cx:option-value", but prefix cx is not bound.
Fixed this.