### PR TITLE
Corrected tests and adapt to changes in the spec

### DIFF
--- a/test-suite/schematron/ab-simple-doc.sch
+++ b/test-suite/schematron/ab-simple-doc.sch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron"
+          xmlns:p="http://www.w3.org/ns/xproc"
+          xmlns:rng="http://relaxng.org/ns/structure/1.0">
+   <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+
+   <s:pattern>
+     <s:rule context="/*">
+       <s:assert test="self::doc">The document root is not doc.</s:assert>
+       <s:assert test="count(/doc/*) = 0">doc is not an empty element.</s:assert>
+     </s:rule>
+   </s:pattern>
+</s:schema>

--- a/test-suite/tests/ab-with-input-006.xml
+++ b/test-suite/tests/ab-with-input-006.xml
@@ -3,7 +3,7 @@
         expected="fail" code="err:XS0085">
   <t:title>with-input-006</t:title>
   <t:description>
-    <p>Tests p:with-input with @href and @pipe: XS0081 to be raised</p>
+    <p>Tests p:with-input with @href and @pipe: XS0085 to be raised</p>
   </t:description>
   <t:pipeline>
     <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">

--- a/test-suite/tests/ab-with-input-035.xml
+++ b/test-suite/tests/ab-with-input-035.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0044">
+        expected="fail" code="err:XS0089">
   <t:title>with-input-035</t:title>
   <t:description>
     <p>Tests p:with-input: Checks only one p:empty is allowed as connection.</p>

--- a/test-suite/tests/ab-with-input-036.xml
+++ b/test-suite/tests/ab-with-input-036.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0044">
+        expected="fail" code="err:XS0089">
   <t:title>with-input-036</t:title>
   <t:description>
     <p>Tests p:with-input: Checks p:empty and p:inline are not allowed as connection.</p>

--- a/test-suite/tests/ab-with-input-037.xml
+++ b/test-suite/tests/ab-with-input-037.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0044">
+        expected="fail" code="err:XS0089">
   <t:title>with-input-037</t:title>
   <t:description>
     <p>Tests p:with-input: Checks p:empty and p:pipe are not allowed as connection.</p>

--- a/test-suite/tests/ab-with-input-038.xml
+++ b/test-suite/tests/ab-with-input-038.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0044">
+        expected="fail" code="err:XS0089">
   <t:title>with-input-038</t:title>
   <t:description>
     <p>Tests p:with-input: Checks p:empty and p:document are not allowed as connection.</p>

--- a/test-suite/tests/ab-with-input-040.xml
+++ b/test-suite/tests/ab-with-input-040.xml
@@ -1,9 +1,9 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0044">
+        expected="pass">
   <t:title>with-input-040</t:title>
   <t:description>
-    <p>Tests p:with-input: p:documentation and implicit inline not allowed</p>
+    <p>Tests p:with-input: Combinations of p:documentation and implicit inline are allowed.</p>
   </t:description>
   <t:pipeline>
     <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
@@ -19,4 +19,6 @@
     </p:declare-step>
 
   </t:pipeline>
+  <t:schematron src="../schematron/ab-simple-doc.sch"/>
+
 </t:test>

--- a/test-suite/tests/ab-with-input-041.xml
+++ b/test-suite/tests/ab-with-input-041.xml
@@ -1,9 +1,9 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0044">
+        expected="pass">
   <t:title>with-input-041</t:title>
   <t:description>
-    <p>Tests p:with-input: p:pipeinfo and implicit inline not allowed</p>
+    <p>Tests p:with-input: Combinations of p:pipeinfo and implicit inline are allowed.</p>
   </t:description>
   <t:pipeline>
     <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
@@ -19,4 +19,6 @@
     </p:declare-step>
 
   </t:pipeline>
+  <t:schematron src="../schematron/ab-simple-doc.sch"/>
+  
 </t:test>

--- a/test-suite/tests/ab-with-input-045.xml
+++ b/test-suite/tests/ab-with-input-045.xml
@@ -1,9 +1,9 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0044">
+        expected="pass">
   <t:title>with-input-045</t:title>
   <t:description>
-    <p>Tests p:with-input: implicit inline and p:documentation not allowed</p>
+    <p>Tests p:with-input: Combinations of implicit inline and p:documentation are allowed</p>
   </t:description>
   <t:pipeline>
     <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
@@ -19,4 +19,6 @@
     </p:declare-step>
 
   </t:pipeline>
+  <t:schematron src="../schematron/ab-simple-doc.sch"/>
+  
 </t:test>

--- a/test-suite/tests/ab-with-input-046.xml
+++ b/test-suite/tests/ab-with-input-046.xml
@@ -1,9 +1,9 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0044">
+        expected="pass">
   <t:title>with-input-046</t:title>
   <t:description>
-    <p>Tests p:with-input: implicit inline and p:pipeinfo not allowed</p>
+    <p>Tests p:with-input: Combinations of implicit inline and p:pipeinfo are allowed</p>
   </t:description>
   <t:pipeline>
     <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
@@ -19,4 +19,6 @@
     </p:declare-step>
 
   </t:pipeline>
+  <t:schematron src="../schematron/ab-simple-doc.sch"/>
+  
 </t:test>

--- a/test-suite/tests/ab-with-input-051.xml
+++ b/test-suite/tests/ab-with-input-051.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0044">
+        expected="fail" code="err:XS0089">
   <t:title>with-input-051</t:title>
   <t:description>
     <p>Tests p:with-input: p:empty and implicit inline not allowed</p>


### PR DESCRIPTION
1. Tests stating that p:documentation/p:pipeinfo are not allowed in implicit inlines are corrected.

1. Tests resulting in XS0044 are changed to newly introduced (more precise) XS0089.