### PR TITLE
Tests adapted to changed specs

### DIFF
--- a/test-suite/tests/ab-p-document020.xml
+++ b/test-suite/tests/ab-p-document020.xml
@@ -2,7 +2,7 @@
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
     <t:title>p:document 020</t:title>
     <t:description>
-        <p>Tests p:document with a simple text document in UTF-8 (no document-properties).</p>
+        <p>Tests p:document with a simple text document in UTF-8 (no charset!).</p>
     </t:description>
 
     <t:pipeline>
@@ -11,7 +11,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/text-file-utf-8.txt"/>
+                    <p:document href="../documents/text-file-utf-8.txt" content-type="text/plain"/>
                 </p:with-input>
             </p:identity>
             <p:wrap-sequence wrapper="doc" />

--- a/test-suite/tests/ab-p-document021.xml
+++ b/test-suite/tests/ab-p-document021.xml
@@ -11,7 +11,7 @@
 
             <p:identity>
                 <p:with-input select="p:document-properties-document(.)">
-                    <p:document href="../documents/JSon-doc1.json"/>
+                    <p:document href="../documents/JSon-doc1.json" content-type="application/json"/>
                 </p:with-input>
             </p:identity>
 

--- a/test-suite/tests/ab-p-document023.xml
+++ b/test-suite/tests/ab-p-document023.xml
@@ -13,7 +13,7 @@
 
             <p:identity>
                 <p:with-input select="p:document-properties-document(.)">
-                    <p:document href="../documents/JSon-doc1.json" parameters="map{'duplicates':'reject'}"/>
+                    <p:document href="../documents/JSon-doc1.json" content-type="application/json" parameters="map{'duplicates':'reject'}"/>
                 </p:with-input>
             </p:identity>
 

--- a/test-suite/tests/ab-p-document024.xml
+++ b/test-suite/tests/ab-p-document024.xml
@@ -11,7 +11,7 @@
 
             <p:identity>
                 <p:with-input select="p:document-properties-document(.)">
-                    <p:document href="../documents/JSon-doc1.json" parameters="map{'undefined-key':'with-value'}"/>
+                    <p:document href="../documents/JSon-doc1.json" content-type="application/json" parameters="map{'undefined-key':'with-value'}"/>
                 </p:with-input>
             </p:identity>
 

--- a/test-suite/tests/ab-p-document025.xml
+++ b/test-suite/tests/ab-p-document025.xml
@@ -13,7 +13,7 @@
 
             <p:identity>
                 <p:with-input select="p:document-properties-document(.)">
-                    <p:document href="../documents/JSon-doc1.json" parameters="map{'duplicates': 'illegal'}"/>
+                    <p:document href="../documents/JSon-doc1.json" content-type="application/json" parameters="map{'duplicates': 'illegal'}"/>
                 </p:with-input>
             </p:identity>
 

--- a/test-suite/tests/ab-p-document026.xml
+++ b/test-suite/tests/ab-p-document026.xml
@@ -13,7 +13,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/defective-json-document.json" parameters="map{'liberal': false()}"/>
+                    <p:document href="../documents/defective-json-document.json" content-type="application/json" parameters="map{'liberal': false()}"/>
                 </p:with-input>
             </p:identity>
 

--- a/test-suite/tests/ab-p-document028.xml
+++ b/test-suite/tests/ab-p-document028.xml
@@ -11,7 +11,9 @@
             <p:output port="result" />
             
             <p:identity >
-                <p:with-input select="p:document-properties-document(.)" href="../documents/ab-doc.zip" />
+                <p:with-input select="p:document-properties-document(.)">
+                    <p:document href="../documents/ab-doc.zip"  content-type="application/octet-stream" />
+                </p:with-input> 
             </p:identity>
             
         </p:declare-step>

--- a/test-suite/tests/ab-p-document029.xml
+++ b/test-suite/tests/ab-p-document029.xml
@@ -11,7 +11,9 @@
             <p:output port="result" />
             
             <p:cast-content-type content-type="application/xml" >
-                <p:with-input href="../documents/JSon-doc1.json"/>
+                <p:with-input>
+                    <p:document href="../documents/JSon-doc1.json" content-type="application/json" />
+                </p:with-input> 
             </p:cast-content-type>
             
         </p:declare-step>


### PR DESCRIPTION
Change all tests where p:document needs a content-type attribute now or where href-short-cut is no longer possible.