### PR TITLE
Improve tests related to DTD validation with p:document

### DIFF
--- a/test-suite/documents/ab-doc-dtd.xml
+++ b/test-suite/documents/ab-doc-dtd.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE doc [
     <!ELEMENT doc ANY>
+    <!ATTLIST doc default CDATA #FIXED "true">
 ]>
-<doc />
+<doc/>

--- a/test-suite/documents/ab-invalid-doc-dtd.xml
+++ b/test-suite/documents/ab-invalid-doc-dtd.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE doc [
+    <!ELEMENT doc ANY>
+    <!ATTLIST doc default CDATA #FIXED "true">
+]>
+<doc default="false"/>

--- a/test-suite/tests/ab-p-document013.xml
+++ b/test-suite/tests/ab-p-document013.xml
@@ -23,6 +23,9 @@
                 <s:rule context="/">
                     <s:assert test="doc">The document root is not doc.</s:assert>
                 </s:rule>
+                <s:rule context="/doc">
+                    <s:assert test="@default='true'">#FIXED attribute missing.</s:assert>
+                </s:rule>
             </s:pattern>
         </s:schema>     
     </t:schematron>

--- a/test-suite/tests/ab-p-document034.xml
+++ b/test-suite/tests/ab-p-document034.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XD0023">
+    <t:title>p:document 034</t:title>
+    <t:description>
+        <p>Tests p:document with dtd-validate='true' and DTD error (dtd in doc).</p>
+    </t:description>
+
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result"/>        
+
+            <p:identity>
+                <p:with-input>
+                    <p:document href="../documents/ab-invalid-doc-dtd.xml"
+                                parameters="map{'dtd-validate': true()}"/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-p-document035.xml
+++ b/test-suite/tests/ab-p-document035.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="pass">
+    <t:title>p:document 035</t:title>
+    <t:description>
+        <p>Tests p:document with dtd-validate='false' and DTD error (dtd in doc).</p>
+    </t:description>
+
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result"/>        
+
+            <p:identity>
+                <p:with-input>
+                    <p:document href="../documents/ab-invalid-doc-dtd.xml"
+                                parameters="map{'dtd-validate': false()}"/>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="doc">The document root is not doc.</s:assert>
+                </s:rule>
+                <s:rule context="/doc">
+                    <s:assert test="@default='false'">Invalid #FIXED corrected.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>     
+    </t:schematron>
+    
+</t:test>


### PR DESCRIPTION
1. Use a `#FIXED` attribute to check that declarations are being processed
2. Use an invalid `#FIXED` attribute to check that parsing fails if validation is requested
3. And succeeds if it is not.
