### PR TITLE
Replace cx:option-value with p:document-properties-document()

### DIFF
--- a/test-suite/pipelines/doc-prop-001.xpl
+++ b/test-suite/pipelines/doc-prop-001.xpl
@@ -13,6 +13,8 @@
     </p:with-input>
   </p:identity>
 
-  <cx:option-value option="{p:document-property(., 'a')}"/>
+  <p:identity>
+    <p:with-input port="source" select="p:document-properties-document(.)/p:document-properties/a"/>
+  </p:identity>
 
 </p:declare-step>

--- a/test-suite/pipelines/doc-prop-002.xpl
+++ b/test-suite/pipelines/doc-prop-002.xpl
@@ -12,6 +12,8 @@
     </p:with-input>
   </p:identity>
 
-  <cx:option-value option="{p:document-property(., 'a')}"/>
+  <p:identity>
+    <p:with-input port="source" select="p:document-properties-document(.)/p:document-properties/a"/>
+  </p:identity>
 
 </p:declare-step>

--- a/test-suite/pipelines/doc-prop-003.xpl
+++ b/test-suite/pipelines/doc-prop-003.xpl
@@ -12,6 +12,8 @@
     </p:with-input>
   </p:identity>
 
-  <cx:option-value option="{p:document-property(., 'a')}"/>
+  <p:identity>
+    <p:with-input port="source" select="p:document-properties-document(.)/p:document-properties/a"/>
+  </p:identity>
 
 </p:declare-step>

--- a/test-suite/pipelines/doc-prop-004.xpl
+++ b/test-suite/pipelines/doc-prop-004.xpl
@@ -15,6 +15,8 @@
 
   <p:variable name="a" select="."/>
 
-  <cx:option-value option="{p:document-property($a, 'a')}"/>
+  <p:identity>
+    <p:with-input port="source" select="p:document-properties-document($a)/p:document-properties/a"/>
+  </p:identity>
 
 </p:declare-step>

--- a/test-suite/pipelines/doc-prop-005.xpl
+++ b/test-suite/pipelines/doc-prop-005.xpl
@@ -8,6 +8,8 @@
   <p:variable name="a" select="3 + 4"/>
 
   <!-- this should fail, $a isn't a document -->
-  <cx:option-value option="{p:document-property($a, 'a')}"/>
+  <p:identity>
+    <p:with-input port="source" select="p:document-properties-document($a)/p:document-properties/a"/>
+  </p:identity>
 
 </p:declare-step>

--- a/test-suite/schematron/doc-prop.sch
+++ b/test-suite/schematron/doc-prop.sch
@@ -4,7 +4,7 @@
 
    <s:pattern>
      <s:rule context="/*">
-       <s:assert test="self::c:result">The pipeline root is not c:result.</s:assert>
+       <s:assert test="self::a">The pipeline root is not “a”.</s:assert>
        <s:assert test="string(.) = '1'">The property value is not 1</s:assert>
      </s:rule>
    </s:pattern>


### PR DESCRIPTION
Now that we have `p:document-properties-document()` there's no need for my bespoke step for extracting a value and wrapping it in an element.

I'm not absolutely sure that `doc-prop-005.xpl` is correct. And if it is correct, I'm reasonably certain that the error code it uses is wrong.