### PR TITLE
Corrected tests and a new one

### DIFF
--- a/test-suite/tests/ab-contenttypes-003.xml
+++ b/test-suite/tests/ab-contenttypes-003.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XD0038">
+        expected="pass">
     <t:title>Contenttypes 003</t:title>
     <t:description>
-        <p>Tests XD0038 is raised when document does not match (default) content-types on p:input</p>
+        <p>Tests default value for missing @content-types on p:inline is "*/*".</p>
     </t:description>
     
     <t:pipeline>
@@ -13,8 +12,22 @@
                 <p:inline content-type="text/plain">Some text</p:inline>
             </p:input>
             
-            <p:output port="result"/>        
-            <p:identity />
+            <p:output port="result"/>
+            <p:wrap-sequence wrapper="result" />
         </p:declare-step>
     </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
+            <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c" />
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="result">Root element is not result.</s:assert>
+                    <s:assert test="/result/text()='Some text'">The root element does not have the right text child.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>     
+    </t:schematron>
+    
 </t:test>

--- a/test-suite/tests/ab-contenttypes-006.xml
+++ b/test-suite/tests/ab-contenttypes-006.xml
@@ -1,18 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XD0042">
+        expected="pass">
     <t:title>Contenttypes 006</t:title>
     <t:description>
-        <p>Tests XD0042 is raised when document does not match implicit content-types on p:output</p>
+        <p>Tests that output port with no @content-types accepts non-XML document.</p>
     </t:description>
     
     <t:pipeline>
-        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
+                                      xmlns:test="http://test">
             <p:output port="result"/>        
-            <p:identity>
-                <p:with-input><p:inline content-type="text/plain">text</p:inline></p:with-input>
-            </p:identity>
+            
+            <p:declare-step type="test:step">
+                <p:output port="result" />
+                <p:identity>
+                    <p:with-input><p:inline content-type="text/plain">text</p:inline></p:with-input>
+                </p:identity>
+            </p:declare-step>
+            
+            <test:step />
+            <p:wrap-sequence wrapper="result"/>
         </p:declare-step>
     </t:pipeline>
+    
+    <t:schematron>
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
+            <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c" />
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="result">Root element is not result.</s:assert>
+                    <s:assert test="/result/text()='text'">The root element does not have the right text child.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>     
+    </t:schematron>
 </t:test>

--- a/test-suite/tests/ab-contenttypes-010xml.xml
+++ b/test-suite/tests/ab-contenttypes-010xml.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+    xmlns:err="http://www.w3.org/ns/xproc-error"
+    expected="fail" code="err:XD0038">
+    <t:title>Contenttypes 010</t:title>
+    <t:description>
+        <p>Tests XD0038 is raised when document does not match (content-types on p:input</p>
+    </t:description>
+    
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:input port="source" content-types="application/xml">
+                <p:inline content-type="text/plain">Some text</p:inline>
+            </p:input>
+            
+            <p:output port="result"/>        
+            <p:identity />
+        </p:declare-step>
+    </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-p-document029.xml
+++ b/test-suite/tests/ab-p-document029.xml
@@ -21,13 +21,16 @@
     
     <t:schematron>
         <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
-            <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+            <s:ns uri="http://www.w3.org/2005/xpath-functions" prefix="x"/>
             <s:pattern>
                 <s:rule context="/">
-                    <s:assert test="c:data">There is no root element c:data.</s:assert>
-                    <s:assert test="c:data/@content-type='application/json'">@content-type is not 'application/json'.</s:assert>
-                    <s:assert test="c:data/@encoding='base64'">@encoding is not 'base64'.</s:assert>
-                    <s:assert test="c:data/text()='eyJrZXkiOiJ2YWx1ZSJ9'">Content is not correctly encoded.</s:assert>
+                    <s:assert test="x:map">There is no root element 'map' (in xpath-functions-namespace).</s:assert>
+                    <s:assert test="count(x:map/*)=1">'map' does not have exactly one child element.</s:assert>
+                    <s:assert test="x:map/x:string">'map' does not have a child element named 'string'.</s:assert>
+                    <s:assert test="x:map/x:string/text()='value'">'map/string' does not have a text node child 'value'.</s:assert>
+                    <s:assert test="count(x:map/x:string/@*)=1">'map/string' does not have exactly one attribute.</s:assert>
+                    <s:assert test="x:map/x:string/@key">'map/string' does not have an attribute named 'key'.</s:assert>
+                    <s:assert test="x:map/x:string/@key/text()='key'">Attribute 'key' does not have the text value of 'key'.</s:assert>
                 </s:rule>
             </s:pattern>
         </s:schema>     


### PR DESCRIPTION
- Yesterdays PR with correction of default content-types
- Your test with an explicit content-types that should fail
- Corrected test ab-p-document029.xml (Casting JSON to XML): Not sure the Schematron is completely right because my current branch does not include implementation of p:cast-content-type yet.