### PR TITLE
Fix syntax of map parameters; they're not AVTs anymore

### DIFF
--- a/test-suite/pipelines/opt-drp.xpl
+++ b/test-suite/pipelines/opt-drp.xpl
@@ -10,6 +10,6 @@
     </p:with-input>
   </p:identity>
 
-  <p:parameters parameters="{ map {{ 'p': count(//p) }} }"/>
+  <p:parameters parameters="map { 'p': count(//p) }"/>
 
 </p:declare-step>

--- a/test-suite/pipelines/parameters-001.xpl
+++ b/test-suite/pipelines/parameters-001.xpl
@@ -4,6 +4,6 @@
                 version="3.0">
   <p:output port="result"/>
 
-  <p:parameters parameters="{ map {{ 'a': 1, 'b': 2 }} }"/>
+  <p:parameters parameters="map { 'a': 1, 'b': 2 }"/>
 
 </p:declare-step>

--- a/test-suite/tests/opt-drp.xml
+++ b/test-suite/tests/opt-drp.xml
@@ -5,7 +5,7 @@
       <t:title>Optional p:inline wrapper</t:title>
       <t:revision-history>
          <t:revision initials="nw">
-            <t:date>2017-10-11</t:date>
+            <t:date>2018-10-11</t:date>
             <t:description>
                <p>Fixed syntax of @parameters; maps are always expressions.</p>
             </t:description>

--- a/test-suite/tests/opt-drp.xml
+++ b/test-suite/tests/opt-drp.xml
@@ -4,9 +4,15 @@
    <t:info>
       <t:title>Optional p:inline wrapper</t:title>
       <t:revision-history>
+         <t:revision initials="nw">
+            <t:date>2017-10-11</t:date>
+            <t:description>
+               <p>Fixed syntax of @parameters; maps are always expressions.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2017-09-24T17:47:42+01:00</t:date>
-            <t:author>
+            <t:author initials="nw">
                <t:name>Norman Walsh</t:name>
             </t:author>
             <t:description>

--- a/test-suite/tests/parameters-001.xml
+++ b/test-suite/tests/parameters-001.xml
@@ -5,7 +5,7 @@
       <t:title>Parameters 001</t:title>
       <t:revision-history>
          <t:revision initials="nw">
-            <t:date>2017-10-11</t:date>
+            <t:date>2018-10-11</t:date>
             <t:description>
                <p>Fixed syntax of @parameters; maps are always expressions.</p>
             </t:description>

--- a/test-suite/tests/parameters-001.xml
+++ b/test-suite/tests/parameters-001.xml
@@ -4,9 +4,15 @@
    <t:info>
       <t:title>Parameters 001</t:title>
       <t:revision-history>
+         <t:revision initials="nw">
+            <t:date>2017-10-11</t:date>
+            <t:description>
+               <p>Fixed syntax of @parameters; maps are always expressions.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2017-09-24T17:47:42+01:00</t:date>
-            <t:author>
+            <t:author initials="nw">
                <t:name>Norman Walsh</t:name>
             </t:author>
             <t:description>


### PR DESCRIPTION
This is a simple syntax fix. @xml-project , I'm just going to merge it if it passes.