### PR TITLE
Fix for issue #68

### DIFF
--- a/test-suite/tests/ab-connection-008.xml
+++ b/test-suite/tests/ab-connection-008.xml
@@ -5,6 +5,15 @@
       <t:title>Connection 008</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,7 @@
       <p>Tests a default connection on inner step is used, when no binding is supplied.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"  xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
@@ -30,7 +39,7 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test"/>
+         <test:step />
         </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-connection-009.xml
+++ b/test-suite/tests/ab-connection-009.xml
@@ -5,6 +5,15 @@
       <t:title>Connection 009</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,7 @@
       <p>Tests a default connection on inner step is NOT used, when binding is supplied.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
@@ -30,11 +39,11 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test">
-            <p:with-input>
-               <doc2 xmlns=""/>
-            </p:with-input>
-         </test:step>
+            <test:step>
+               <p:with-input>
+                  <doc2 xmlns=""/>
+               </p:with-input>
+            </test:step>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-connection-010.xml
+++ b/test-suite/tests/ab-connection-010.xml
@@ -5,6 +5,15 @@
       <t:title>Connection 010</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,7 @@
       <p>Tests a default connection on inner step is NOT used, when explicitly bound to empty.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0" xmlns:test="http://test">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
@@ -30,11 +39,11 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test">
-            <p:with-input>
-               <p:empty/>
-            </p:with-input>
-         </test:step>
+            <test:step >
+               <p:with-input>
+                  <p:empty/>
+               </p:with-input>
+            </test:step>
             
             <p:wrap-sequence wrapper="result"/>
         </p:declare-step>

--- a/test-suite/tests/ab-connection-011.xml
+++ b/test-suite/tests/ab-connection-011.xml
@@ -7,6 +7,15 @@
       <t:title>Connection 011</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -21,21 +30,21 @@
       <p>Tests that an explicit empty binding to a non-sequence port raises an error.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"  xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
                 <p:output port="result" sequence="true"/>
                 <p:input port="source">
-                    <doc xmlns=""/>
+                   <doc xmlns=""/>
                 </p:input>
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test">
-            <p:with-input>
-               <p:empty/>
-            </p:with-input>
+            <test:step>
+               <p:with-input>
+                  <p:empty/>
+               </p:with-input>
          </test:step>
             
             <p:wrap-sequence wrapper="result"/>

--- a/test-suite/tests/ab-connection-012.xml
+++ b/test-suite/tests/ab-connection-012.xml
@@ -7,6 +7,15 @@
       <t:title>Connection 012</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -21,7 +30,7 @@
       <p>Tests that an empty default binding to a non-sequence port raises an error, if no value is supplied.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
@@ -32,7 +41,7 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test"/>
+            <test:step />
             
             <p:wrap-sequence wrapper="result"/>
         </p:declare-step>

--- a/test-suite/tests/ab-connection-013.xml
+++ b/test-suite/tests/ab-connection-013.xml
@@ -5,6 +5,15 @@
       <t:title>Connection 013</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,7 @@
       <p>Tests that an empty default binding to a non-sequence port does not raises an error, if a value is supplied.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
@@ -30,11 +39,11 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test">
-            <p:with-input>
-               <doc xmlns=""/>
-            </p:with-input>
-         </test:step>
+            <test:step >
+               <p:with-input>
+                  <doc xmlns=""/>
+               </p:with-input>
+            </test:step>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-connection-014.xml
+++ b/test-suite/tests/ab-connection-014.xml
@@ -7,6 +7,15 @@
       <t:title>Connection 014</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -21,21 +30,21 @@
       <p>Tests that a select on default binding to a non-sequence port raises an error, if no value is supplied.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
                 <p:output port="result" sequence="true"/>
                 <p:input port="source" select="//element">
                    <doc xmlns="">
-                  <element/>
-                  <element/>
-               </doc>
+                     <element/>
+                     <element/>
+                  </doc>
                 </p:input>
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test"/>
+            <test:step />
             
             <p:wrap-sequence wrapper="result"/>
         </p:declare-step>

--- a/test-suite/tests/ab-connection-015.xml
+++ b/test-suite/tests/ab-connection-015.xml
@@ -5,6 +5,15 @@
       <t:title>Connection 015</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,7 @@
       <p>Tests that a static document (supplied as default binding) is used, if no document is supplied.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
@@ -30,7 +39,7 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test"/>
+            <test:step />
             
         </p:declare-step>
    </t:pipeline>

--- a/test-suite/tests/ab-connection-016.xml
+++ b/test-suite/tests/ab-connection-016.xml
@@ -7,6 +7,15 @@
       <t:title>Connection 016</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -21,7 +30,7 @@
       <p>Tests that XD0006 is raised, if default binding for a non-sequence input port contains more than one document and non binding is supplied.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
@@ -33,7 +42,7 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test"/>            
+            <test:step />            
         </p:declare-step>
    </t:pipeline>
 </t:test>

--- a/test-suite/tests/ab-connection-017.xml
+++ b/test-suite/tests/ab-connection-017.xml
@@ -7,6 +7,15 @@
       <t:title>Connection 017</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -21,7 +30,7 @@
       <p>Tests that XD0006 is raised, if more than one document is supplied to a non-sequence port.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
@@ -32,11 +41,11 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test">
-            <p:with-input>
-                    <doc xmlns=""/>
-                    <doc xmlns=""/>
-                </p:with-input>
+            <test:step >
+               <p:with-input>
+                  <doc xmlns=""/>
+                  <doc xmlns=""/>
+               </p:with-input>
          </test:step>            
         </p:declare-step>
    </t:pipeline>

--- a/test-suite/tests/ab-connection-018.xml
+++ b/test-suite/tests/ab-connection-018.xml
@@ -5,6 +5,15 @@
       <t:title>Connection 018</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-09-15T11:06:16+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,7 @@
       <p>Tests that XD0006 is not raised, when defective default binding is not used.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
@@ -31,11 +40,11 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test">
-            <p:with-input>
-                    <doc xmlns=""/>
+            <test:step >
+               <p:with-input>
+                  <doc xmlns=""/>
                 </p:with-input>
-         </test:step>            
+            </test:step>            
         </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-contenttypes-006.xml
+++ b/test-suite/tests/ab-contenttypes-006.xml
@@ -5,6 +5,15 @@
       <t:title>Contenttypes 006</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-10-03T16:59:51+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -55,7 +64,8 @@
       <p>Tests that output port with no @content-types accepts non-XML document.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
+         xmlns:test="http://test" version="3.0">
             <p:output port="result"/>        
             
             <p:declare-step type="test:step">
@@ -67,7 +77,7 @@
                 </p:identity>
             </p:declare-step>
             
-            <test:step xmlns:test="http://test"/>
+            <test:step />
             <p:wrap-sequence wrapper="result"/>
         </p:declare-step>
    </t:pipeline>

--- a/test-suite/tests/ab-with-input-select-002.xml
+++ b/test-suite/tests/ab-with-input-select-002.xml
@@ -5,6 +5,15 @@
       <t:title>with-input-select-002</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-02-02T17:42:37+01:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,8 @@
       <p>Test select on p:with-input select="comment()"</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0">
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="*/comment()">

--- a/test-suite/tests/ab-with-input-select-003.xml
+++ b/test-suite/tests/ab-with-input-select-003.xml
@@ -5,6 +5,15 @@
       <t:title>with-input-select-003</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-02-02T17:42:37+01:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,8 @@
       <p>Test select on p:with-input select="processing-instruction()"</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
+         xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0">
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="*/processing-instruction()">

--- a/test-suite/tests/ab-with-input-select-004.xml
+++ b/test-suite/tests/ab-with-input-select-004.xml
@@ -5,6 +5,15 @@
       <t:title>with-input-select-004</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-02-02T17:42:37+01:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,8 @@
       <p>Test select on p:with-input select="text()"</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
+         xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0">
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="*/text()">

--- a/test-suite/tests/ab-with-input-select-006.xml
+++ b/test-suite/tests/ab-with-input-select-006.xml
@@ -5,6 +5,15 @@
       <t:title>with-input-select-006</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-07-07T17:01:39+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -46,12 +55,13 @@
       <p>Tests that content-type is changed to application/xml when selecting from XLST document.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
+            xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="/xsl:stylesheet/xsl:template[1]">
                     <p:inline content-type="application/xslt+xml">
-                        <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+                        <xsl:stylesheet  version="2.0">
                      <xsl:template match="/">
                         <xsl:text>result</xsl:text>
                      </xsl:template>

--- a/test-suite/tests/p-inline-001.xml
+++ b/test-suite/tests/p-inline-001.xml
@@ -5,6 +5,15 @@
       <t:title>p:inline 001</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-02-18T08:23:14+01:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,7 +34,8 @@
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
+         xmlns:c=""http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">

--- a/test-suite/tests/p-inline-002.xml
+++ b/test-suite/tests/p-inline-002.xml
@@ -5,6 +5,15 @@
       <t:title>p:inline 002</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-07-07T17:01:39+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -61,7 +70,8 @@
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
+         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">

--- a/test-suite/tests/p-inline-003.xml
+++ b/test-suite/tests/p-inline-003.xml
@@ -5,6 +5,15 @@
       <t:title>p:inline 003</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-07-07T17:01:39+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -61,7 +70,8 @@
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">

--- a/test-suite/tests/p-inline-004.xml
+++ b/test-suite/tests/p-inline-004.xml
@@ -7,6 +7,15 @@
       <t:title>p:inline 004</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-07-07T17:01:39+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -54,7 +63,8 @@
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
+         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">

--- a/test-suite/tests/p-inline-005.xml
+++ b/test-suite/tests/p-inline-005.xml
@@ -7,6 +7,15 @@
       <t:title>p:inline 005</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-04-03T16:57:32+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -36,7 +45,8 @@
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
+         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">

--- a/test-suite/tests/p-inline-006.xml
+++ b/test-suite/tests/p-inline-006.xml
@@ -7,6 +7,15 @@
       <t:title>p:inline 006</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2018-10-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description>
+               <p>Fixing broken test (namespace removed)</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-07-07T17:01:39+02:00</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -63,7 +72,8 @@
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
+         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">


### PR DESCRIPTION
Not sure I found all, but surely got most of them.
The problem was: Namespace declarations were removed from p:declare-step, so they were not defined for e.g. `<p:wrap-sequence wrapper="c:result" />` or `<p:declare-step type="x:step" />`.

May be there are some I have misted in the tests expected to fail. But we will find them as time goes by.