### PR TITLE
Move the HTML namespace from the root onto the t:description elements

### DIFF
--- a/test-suite/tests/ab-connection-001.xml
+++ b/test-suite/tests/ab-connection-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connections 001</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that an implicit primary output port is auto connected to the output of the last step of the subpipeline.</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
       
          <p:identity>
             <p:with-input port="source">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-connection-002.xml
+++ b/test-suite/tests/ab-connection-002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 002</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that an explicit primary output port is auto connected to the output of the last step of the subpipeline.</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
       
          <p:identity>
             <p:with-input port="source">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-connection-003.xml
+++ b/test-suite/tests/ab-connection-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0007">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0007">
    <t:info>
       <t:title>Connection 003</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixed error code expected.</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Improve the description of the test.</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
@@ -38,7 +34,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -47,7 +43,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
@@ -55,7 +51,7 @@
       <t:specref spec="xproc" linkend="primary-input-output"/>
       <t:specref linkend="p.output"/>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>If an output port on a compound step is not a primary output port, then it will not
       be connected to the last step in the subpipeline. In this test, the pipeline’s
       <code>result</code> output port is not connected, so it receives no documents. It is

--- a/test-suite/tests/ab-connection-004.xml
+++ b/test-suite/tests/ab-connection-004.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 004</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests explicit connection between output port and step in subpipeline.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +33,7 @@
       
          <p:identity name="producer">
             <p:with-input port="source">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-connection-005.xml
+++ b/test-suite/tests/ab-connection-005.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 005</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests explicit connection between an explicit primary output port and step in subpipeline.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +33,7 @@
       
          <p:identity name="producer">
             <p:with-input port="source">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-connection-006.xml
+++ b/test-suite/tests/ab-connection-006.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 006</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests explicit connection between an explicit non primary output port and step in subpipeline.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +33,7 @@
       
          <p:identity name="producer">
             <p:with-input port="source">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-connection-007.xml
+++ b/test-suite/tests/ab-connection-007.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 007</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that the primary output port of the last step of a subpipeline is not connected to the pipelines primary output port, if the later has an explicit connection.</p>
    </t:description>
    <t:pipeline>
@@ -44,19 +42,19 @@
       
          <p:identity name="one">
             <p:with-input port="source">
-               <one xmlns=""/>
+               <one/>
             </p:with-input>
          </p:identity>
       
          <p:identity name="two">
             <p:with-input>
-               <two xmlns=""/>
+               <two/>
             </p:with-input>
          </p:identity>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="one">The root is not one.</s:assert>

--- a/test-suite/tests/ab-connection-008.xml
+++ b/test-suite/tests/ab-connection-008.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 008</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,32 +16,32 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a default connection on inner step is used, when no binding is supplied.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"  xmlns:test="http://test" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
                 <p:output port="result"/>
                 <p:input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:input>
                 <p:identity/>
             </p:declare-step>
             
-         <test:step />
+         <test:step/>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The root is not doc.</s:assert>

--- a/test-suite/tests/ab-connection-009.xml
+++ b/test-suite/tests/ab-connection-009.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 009</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a default connection on inner step is NOT used, when binding is supplied.</p>
    </t:description>
    <t:pipeline>
@@ -34,20 +32,20 @@
             <p:declare-step type="test:step">
                 <p:output port="result"/>
                 <p:input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:input>
                 <p:identity/>
             </p:declare-step>
             
             <test:step>
                <p:with-input>
-                  <doc2 xmlns=""/>
+                  <doc2/>
                </p:with-input>
             </test:step>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc2">The root is not doc2.</s:assert>

--- a/test-suite/tests/ab-connection-010.xml
+++ b/test-suite/tests/ab-connection-010.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 010</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,28 +16,28 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a default connection on inner step is NOT used, when explicitly bound to empty.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0" xmlns:test="http://test">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
                 <p:output port="result" sequence="true"/>
                 <p:input port="source" sequence="true">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:input>
                 <p:identity/>
             </p:declare-step>
             
-            <test:step >
+            <test:step>
                <p:with-input>
                   <p:empty/>
                </p:with-input>
@@ -49,7 +47,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root is not result.</s:assert>

--- a/test-suite/tests/ab-connection-011.xml
+++ b/test-suite/tests/ab-connection-011.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Connection 011</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -20,23 +16,23 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that an explicit empty binding to a non-sequence port raises an error.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"  xmlns:test="http://test" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>
             
             <p:declare-step type="test:step">
                 <p:output port="result" sequence="true"/>
                 <p:input port="source">
-                   <doc xmlns=""/>
+                   <doc/>
                 </p:input>
                 <p:identity/>
             </p:declare-step>

--- a/test-suite/tests/ab-connection-012.xml
+++ b/test-suite/tests/ab-connection-012.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Connection 012</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that an empty default binding to a non-sequence port raises an error, if no value is supplied.</p>
    </t:description>
    <t:pipeline>
@@ -41,7 +37,7 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step />
+            <test:step/>
             
             <p:wrap-sequence wrapper="result"/>
         </p:declare-step>

--- a/test-suite/tests/ab-connection-013.xml
+++ b/test-suite/tests/ab-connection-013.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 013</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that an empty default binding to a non-sequence port does not raises an error, if a value is supplied.</p>
    </t:description>
    <t:pipeline>
@@ -39,15 +37,15 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step >
+            <test:step>
                <p:with-input>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:with-input>
             </test:step>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The root is not doc.</s:assert>

--- a/test-suite/tests/ab-connection-014.xml
+++ b/test-suite/tests/ab-connection-014.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Connection 014</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that a select on default binding to a non-sequence port raises an error, if no value is supplied.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             <p:declare-step type="test:step">
                 <p:output port="result" sequence="true"/>
                 <p:input port="source" select="//element">
-                   <doc xmlns="">
+                   <doc>
                      <element/>
                      <element/>
                   </doc>
@@ -44,7 +40,7 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step />
+            <test:step/>
             
             <p:wrap-sequence wrapper="result"/>
         </p:declare-step>

--- a/test-suite/tests/ab-connection-015.xml
+++ b/test-suite/tests/ab-connection-015.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 015</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that a static document (supplied as default binding) is used, if no document is supplied.</p>
    </t:description>
    <t:pipeline>
@@ -39,12 +37,12 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step />
+            <test:step/>
             
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The root is not doc.</s:assert>

--- a/test-suite/tests/ab-connection-016.xml
+++ b/test-suite/tests/ab-connection-016.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Connection 016</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD0006 is raised, if default binding for a non-sequence input port contains more than one document and non binding is supplied.</p>
    </t:description>
    <t:pipeline>
@@ -42,7 +38,7 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step />            
+            <test:step/>            
         </p:declare-step>
    </t:pipeline>
 </t:test>

--- a/test-suite/tests/ab-connection-017.xml
+++ b/test-suite/tests/ab-connection-017.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Connection 017</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD0006 is raised, if more than one document is supplied to a non-sequence port.</p>
    </t:description>
    <t:pipeline>
@@ -41,10 +37,10 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step >
+            <test:step>
                <p:with-input>
-                  <doc xmlns=""/>
-                  <doc xmlns=""/>
+                  <doc/>
+                  <doc/>
                </p:with-input>
          </test:step>            
         </p:declare-step>

--- a/test-suite/tests/ab-connection-018.xml
+++ b/test-suite/tests/ab-connection-018.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 018</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD0006 is not raised, when defective default binding is not used.</p>
    </t:description>
    <t:pipeline>
@@ -40,15 +38,15 @@
                 <p:identity/>
             </p:declare-step>
             
-            <test:step >
+            <test:step>
                <p:with-input>
-                  <doc xmlns=""/>
+                  <doc/>
                 </p:with-input>
             </test:step>            
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The root is not doc.</s:assert>

--- a/test-suite/tests/ab-connection-019.xml
+++ b/test-suite/tests/ab-connection-019.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 019</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks that DRP counts a connection for short-cut AVT.</p>
    </t:description>
    <t:pipeline>
@@ -24,18 +22,18 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">4</doc>
+                    <doc>4</doc>
                 </p:with-input>
             </p:identity>
             <p:add-attribute attribute-name="att" attribute-value="{/doc}">
                 <p:with-input>
-                    <result xmlns=""/>
+                    <result/>
                 </p:with-input>
             </p:add-attribute>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root is not result.</s:assert>

--- a/test-suite/tests/ab-connection-020.xml
+++ b/test-suite/tests/ab-connection-020.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 020</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks that DRP counts a connection for short-cut AVT and primary input port.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">4</doc>
+                    <doc>4</doc>
                 </p:with-input>
             </p:identity>
             <p:add-attribute attribute-name="att" attribute-value="{/doc}"/>
@@ -32,7 +30,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The root is not doc.</s:assert>

--- a/test-suite/tests/ab-connection-021.xml
+++ b/test-suite/tests/ab-connection-021.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 021</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks that DRP counts a connection for AVT in @href on p:with-input.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" file="../documents/ab-doc.xml"/>
+                    <doc file="../documents/ab-doc.xml"/>
                 </p:with-input>
             </p:identity>
            
@@ -35,7 +33,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The root is not doc.</s:assert>

--- a/test-suite/tests/ab-connection-022.xml
+++ b/test-suite/tests/ab-connection-022.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 022</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks that DRP counts a connection for AVT in @href on p:document.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" file="../documents/ab-doc.xml"/>
+                    <doc file="../documents/ab-doc.xml"/>
                 </p:with-input>
             </p:identity>
            
@@ -37,7 +35,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The root is not doc.</s:assert>

--- a/test-suite/tests/ab-connection-023.xml
+++ b/test-suite/tests/ab-connection-023.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 023</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixed two tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks that DRP counts a connection for TVT as child of p:inline.</p>
    </t:description>
    <t:pipeline>
@@ -33,14 +31,14 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" value="4"/>
+                    <doc value="4"/>
                 </p:with-input>
             </p:identity>
            
             <p:identity>
                 <p:with-input>
                     <p:inline>
-                        <result xmlns="">{xs:string(/doc/@value)}</result>
+                        <result>{xs:string(/doc/@value)}</result>
                     </p:inline>
                 </p:with-input>
             </p:identity>
@@ -48,7 +46,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root is not result.</s:assert>

--- a/test-suite/tests/ab-connection-024.xml
+++ b/test-suite/tests/ab-connection-024.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Connection 024</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixed two tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks that DRP counts a connection for TVT in implicit inline.</p>
    </t:description>
    <t:pipeline>
@@ -33,20 +31,20 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" value="4"/>
+                    <doc value="4"/>
                 </p:with-input>
             </p:identity>
            
             <p:identity>
                 <p:with-input>
-                    <result xmlns="">{xs:string(/doc/@value)}</result>
+                    <result>{xs:string(/doc/@value)}</result>
                 </p:with-input>
             </p:identity>
 
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root is not result.</s:assert>

--- a/test-suite/tests/ab-contenttypes-001.xml
+++ b/test-suite/tests/ab-contenttypes-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Contenttypes 001</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,19 +16,19 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0077 is raised for defective content-types on p:input</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source" select="/doc/element" content-types="invalid">
-                <doc xmlns="">
+                <doc>
                <element>text</element>
             </doc>
             </p:input>

--- a/test-suite/tests/ab-contenttypes-002.xml
+++ b/test-suite/tests/ab-contenttypes-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Contenttypes 002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,19 +16,19 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0077 is raised for defective content-types on p:output</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source" select="/doc/element">
-                <doc xmlns="">
+                <doc>
                <element>text</element>
             </doc>
             </p:input>

--- a/test-suite/tests/ab-contenttypes-003.xml
+++ b/test-suite/tests/ab-contenttypes-003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Contenttypes 003</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected default of @content-types to be *.*</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Added test to make sure p:pipe is no child of p:input. Making content-type statically in the last remaining tests.</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -36,7 +34,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -45,13 +43,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests default value for missing @content-types on p:inline is "*/*".</p>
    </t:description>
    <t:pipeline>
@@ -65,7 +63,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
          <s:pattern>

--- a/test-suite/tests/ab-contenttypes-004.xml
+++ b/test-suite/tests/ab-contenttypes-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0038">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0038">
    <t:info>
       <t:title>Contenttypes 004</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Added test to make sure p:pipe is no child of p:input. Making content-type statically in the last remaining tests.</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0038 is raised when document does not match explicit content-types on p:input</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-contenttypes-005.xml
+++ b/test-suite/tests/ab-contenttypes-005.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0038">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0038">
    <t:info>
       <t:title>Contenttypes 005</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Added test to make sure p:pipe is no child of p:input. Making content-type statically in the last remaining tests.</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0038 is raised when document does not match explicit content-types on p:input</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-contenttypes-006.xml
+++ b/test-suite/tests/ab-contenttypes-006.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Contenttypes 006</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected default of @content-types to be *.*</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -36,7 +34,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -45,7 +43,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -54,18 +52,17 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that output port with no @content-types accepts non-XML document.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
-         xmlns:test="http://test" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">
             <p:output port="result"/>        
             
             <p:declare-step type="test:step">
@@ -77,12 +74,12 @@
                 </p:identity>
             </p:declare-step>
             
-            <test:step />
+            <test:step/>
             <p:wrap-sequence wrapper="result"/>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
          <s:pattern>

--- a/test-suite/tests/ab-contenttypes-007.xml
+++ b/test-suite/tests/ab-contenttypes-007.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0042">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0042">
    <t:info>
       <t:title>Contenttypes 007</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0042 is raised when document does not match explicit content-types on p:output</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-contenttypes-008.xml
+++ b/test-suite/tests/ab-contenttypes-008.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0042">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0042">
    <t:info>
       <t:title>Contenttypes 008</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected an error</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0042 is raised when document does not match explicit content-types on p:output</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-contenttypes-009.xml
+++ b/test-suite/tests/ab-contenttypes-009.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0038">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0038">
    <t:info>
       <t:title>Contenttypes 009</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0038 is raised when an externally supplied document does not match explicit content-types on p:input</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-contenttypes-010xml.xml
+++ b/test-suite/tests/ab-contenttypes-010xml.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0038">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0038">
    <t:info>
       <t:title>Contenttypes 010</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>One new and one corrected test.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0038 is raised when document does not match (content-types on p:input</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-doc-prop-001.xml
+++ b/test-suite/tests/ab-doc-prop-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-001</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties with a variable in map constructor</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-001.xpl"/>

--- a/test-suite/tests/ab-doc-prop-002.xml
+++ b/test-suite/tests/ab-doc-prop-002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-002</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties with an option in map constructor</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-002.xpl"/>

--- a/test-suite/tests/ab-doc-prop-003.xml
+++ b/test-suite/tests/ab-doc-prop-003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-003</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties with a static variable in map constructor</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-003.xpl"/>

--- a/test-suite/tests/ab-doc-prop-004.xml
+++ b/test-suite/tests/ab-doc-prop-004.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-004</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties with a static option in map constructor</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-004.xpl"/>

--- a/test-suite/tests/ab-doc-prop-005.xml
+++ b/test-suite/tests/ab-doc-prop-005.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-005</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties with reference to context item in map constructor</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-005.xpl"/>

--- a/test-suite/tests/ab-doc-prop-006.xml
+++ b/test-suite/tests/ab-doc-prop-006.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-006</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties on static evaluated documents</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-006.xpl"/>

--- a/test-suite/tests/ab-doc-prop-007.xml
+++ b/test-suite/tests/ab-doc-prop-007.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-007</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties on static evaluated documents using static variable</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-007.xpl"/>

--- a/test-suite/tests/ab-doc-prop-008.xml
+++ b/test-suite/tests/ab-doc-prop-008.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-008</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties on static evaluated documents using static option</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-008.xpl"/>

--- a/test-suite/tests/ab-doc-prop-009.xml
+++ b/test-suite/tests/ab-doc-prop-009.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-009</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties on static evaluated documents using static variable selecting from inline</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-009.xpl"/>

--- a/test-suite/tests/ab-doc-prop-010.xml
+++ b/test-suite/tests/ab-doc-prop-010.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-doc-props-010</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Ten new tests for document-properties</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties on static evaluated documents using static variable selecting from p:document</p>
    </t:description>
    <t:pipeline src="../pipelines/ab-doc-prop-010.xpl"/>

--- a/test-suite/tests/ab-document-properties-doc001.xml
+++ b/test-suite/tests/ab-document-properties-doc001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-document-properties-document-001</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties-document for created xml document</p>
    </t:description>
    <t:pipeline>
@@ -25,7 +23,7 @@
          <p:identity>
             <p:with-input select="p:document-properties-document(.)">
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
          </p:identity>
@@ -33,7 +31,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-document-properties-doc002.xml
+++ b/test-suite/tests/ab-document-properties-doc002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-document-properties-document-002</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties-document for an xml document in a variable</p>
    </t:description>
    <t:pipeline>
@@ -23,19 +21,19 @@
          <p:output port="result"/>
      
          <p:variable name="var" select=".">
-            <doc xmlns=""/>
+            <doc/>
          </p:variable>
       
          <p:identity>
             <p:with-input select="p:document-properties-document($var)">
-               <dummy xmlns=""/>
+               <dummy/>
             </p:with-input>
          </p:identity>
 
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-document-properties-doc003.xml
+++ b/test-suite/tests/ab-document-properties-doc003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-document-properties-document-003</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties-document for a document loaded with doc()</p>
    </t:description>
    <t:pipeline>
@@ -24,14 +22,14 @@
           
          <p:identity>
             <p:with-input>
-               <result xmlns="">{p:document-properties-document(doc('../documents/ab-doc.xml'))}</result>
+               <result>{p:document-properties-document(doc('../documents/ab-doc.xml'))}</result>
             </p:with-input>
          </p:identity>
 
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-document-properties-doc004.xml
+++ b/test-suite/tests/ab-document-properties-doc004.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-document-properties-document-004</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests document-properties-document for a variable set via doc()</p>
    </t:description>
    <t:pipeline>
@@ -25,14 +23,14 @@
       
          <p:identity>
             <p:with-input>
-               <result xmlns="">{p:document-properties-document($var)}</result>
+               <result>{p:document-properties-document($var)}</result>
             </p:with-input>
          </p:identity>
 
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-err-d0006-001.xml
+++ b/test-suite/tests/ab-err-d0006-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Error test XD006 001</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD006 is raised when a non sequence port receives p:empty</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-err-d0006-002.xml
+++ b/test-suite/tests/ab-err-d0006-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Error test XD006 002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD0006 is raised when more than one document arrives on a non-sequence port</p>
    </t:description>
    <t:pipeline>
@@ -45,10 +41,10 @@
             <p:add-attribute match="/doc" attribute-name="att" attribute-value="val">
                 <p:with-input>
                     <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
                     <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
                 </p:with-input>
             </p:add-attribute>

--- a/test-suite/tests/ab-err-d0006-003.xml
+++ b/test-suite/tests/ab-err-d0006-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Error test XD006 003</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD006 is raised when more than one document arrives on a non-sequence port</p>
    </t:description>
    <t:pipeline>
@@ -34,10 +30,10 @@
             <p:output port="result"/>
             <p:input port="source">
                 <p:inline>
-               <doc xmlns=""/>
+               <doc/>
             </p:inline>
                 <p:inline>
-               <doc xmlns=""/>
+               <doc/>
             </p:inline>
             </p:input>
             

--- a/test-suite/tests/ab-err-d0006-004.xml
+++ b/test-suite/tests/ab-err-d0006-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Error test XD006 004</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD006 is raised when more than one document arrives on a non-sequence port</p>
    </t:description>
    <t:pipeline>
@@ -34,7 +30,7 @@
             <p:output port="result"/>
             <p:input port="source">
                 <p:inline>
-               <doc xmlns=""/>
+               <doc/>
             </p:inline>
             </p:input>
             

--- a/test-suite/tests/ab-err-s0037-001.xml
+++ b/test-suite/tests/ab-err-s0037-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0037">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0037">
    <t:info>
       <t:title>Error test XS0037 001</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0037 is raised, when subpipeline contains non whitespace text nodes.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             This is illegal text
             <p:identity name="identity">
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-err-s0037-002.xml
+++ b/test-suite/tests/ab-err-s0037-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0037">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0037">
    <t:info>
       <t:title>Error test XS0037 002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0037 is raised, when atomic step call contains non whitespace text nodes.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
             
             <p:identity name="identity">
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
                 This is illegal text
             </p:identity>

--- a/test-suite/tests/ab-err-s0037-003.xml
+++ b/test-suite/tests/ab-err-s0037-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0037">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0037">
    <t:info>
       <t:title>Error test XS0037 003</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected the error code.</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author initials="nw">
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that <code>err:XS0037</code> is raised when <code>p:input</code>
       contains non whitespace text nodes.</p>
    </t:description>

--- a/test-suite/tests/ab-err-s0037-004.xml
+++ b/test-suite/tests/ab-err-s0037-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0037">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0037">
    <t:info>
       <t:title>Error test XS0037 004</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected the error code.</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author initials="nw">
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that <code>err:XS0037</code> is raised when <code>p:with-input</code>
       contains non whitespace text nodes.</p>
    </t:description>

--- a/test-suite/tests/ab-err-s0037-005.xml
+++ b/test-suite/tests/ab-err-s0037-005.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0037">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0037">
    <t:info>
       <t:title>Error test XS0037 005</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected the error code.</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author initials="nw">
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that <code>err:XS0037</code> is raised when <code>p:output</code>
       contains non whitespace text nodes.</p>
    </t:description>
@@ -47,7 +43,7 @@
 
             <p:identity name="identity">
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-err-s0096-001.xml
+++ b/test-suite/tests/ab-err-s0096-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Error test XS0096 001</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0096 is raised when sequence type in @as on p:variable is not valid: Wrong quantifier</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-err-s0096-002.xml
+++ b/test-suite/tests/ab-err-s0096-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Error test XS0096 002</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0096 is raised when sequence type in @as on p:option is not valid: Wrong quantifier</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-err-s0096-003.xml
+++ b/test-suite/tests/ab-err-s0096-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Error test XS0096 003</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0096 is raised when sequence type in @as on p:with-option is not valid: Wrong quantifier</p>
    </t:description>
    <t:pipeline>
@@ -26,7 +22,7 @@
             
             <p:add-attribute match="/" attribute-name="a">
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
                 <p:with-option name="attribute-value" as="xs:integer-" select="5"/>
             </p:add-attribute>

--- a/test-suite/tests/ab-err-s0096-004.xml
+++ b/test-suite/tests/ab-err-s0096-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Error test XS0096 004</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0096 is raised when sequence type in @as on p:variable is not valid: Unknown type</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-err-s0096-005.xml
+++ b/test-suite/tests/ab-err-s0096-005.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Error test XS0096 005</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0096 is raised when sequence type in @as on p:option is not valid: Unknown type</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-err-s0096-006.xml
+++ b/test-suite/tests/ab-err-s0096-006.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Error test XS0096 006</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0096 is raised when sequence type in @as on p:with-option is not valid: Unknown type</p>
    </t:description>
    <t:pipeline>
@@ -26,7 +22,7 @@
             
             <p:add-attribute match="/" attribute-name="a">
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
                 <p:with-option name="attribute-value" as="foo" select="5"/>
             </p:add-attribute>

--- a/test-suite/tests/ab-err-s0096-007.xml
+++ b/test-suite/tests/ab-err-s0096-007.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Error test XS0096 007</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0096 is raised when @as value is syntactically wrong, even if variable is never used.</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-err-s0096-008.xml
+++ b/test-suite/tests/ab-err-s0096-008.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Error test XS0096 008</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0096 is raised when @as value is syntactically wrong, even if the option is never used.</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-err-s0098-001.xml
+++ b/test-suite/tests/ab-err-s0098-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0098">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0098">
    <t:info>
       <t:title>Error XS0098 - 001</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Tests for new error xs:0098</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0098 is raised if @pipe is used on a static variable.</p>
    </t:description>
    <t:pipeline>
@@ -26,7 +22,7 @@
             <p:variable static="true" name="variable" select="10" pipe=""/>
             <p:identity>
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-err-s0098-002.xml
+++ b/test-suite/tests/ab-err-s0098-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0098">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0098">
    <t:info>
       <t:title>Error XS0098 - 002</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Tests for new error xs:0098</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0098 is raised if p:pipe is a child on a static variable.</p>
    </t:description>
    <t:pipeline>
@@ -28,7 +24,7 @@
             </p:variable>
             <p:identity>
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-inline-001.xml
+++ b/test-suite/tests/ab-inline-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0069">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0069">
    <t:info>
       <t:title>ab-inline-001</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0069 is raised when encoding contains unsupported method.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-inline-002.xml
+++ b/test-suite/tests/ab-inline-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0055">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0055">
    <t:info>
       <t:title>ab-inline-002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD0055 is raised when content-type contains charset and encoding is not present.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-inline-003.xml
+++ b/test-suite/tests/ab-inline-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0040">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0040">
    <t:info>
       <t:title>ab-inline-003</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD0040 is raised when encoding is base64 and content is not properly encoded.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-inline-004.xml
+++ b/test-suite/tests/ab-inline-004.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-inline-004</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
@@ -36,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a base64 encoded text is decoded correctly for text document (no charset)</p>
    </t:description>
    <t:pipeline>
@@ -59,7 +57,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The document root is not result.</s:assert>

--- a/test-suite/tests/ab-inline-005.xml
+++ b/test-suite/tests/ab-inline-005.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-inline-005</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
@@ -36,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a base64 encoded text is decoded correctly for text document (charset="UTF-8")</p>
    </t:description>
    <t:pipeline>
@@ -59,7 +57,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The document root is not result.</s:assert>

--- a/test-suite/tests/ab-inline-006.xml
+++ b/test-suite/tests/ab-inline-006.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-inline-006</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
@@ -36,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a base64 encoded text is decoded correctly for text document (charset='ISO-8859-1')</p>
    </t:description>
    <t:pipeline>
@@ -59,7 +57,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The document root is not result.</s:assert>

--- a/test-suite/tests/ab-inline-007.xml
+++ b/test-suite/tests/ab-inline-007.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0039">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0039">
    <t:info>
       <t:title>ab-inline-007</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0039 is raised when encoding is specified, but charset is not supported.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-inline-008.xml
+++ b/test-suite/tests/ab-inline-008.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-inline-008</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests text document with tvt (expand-text='false')</p>
    </t:description>
    <t:pipeline>
@@ -50,7 +48,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The document root is not result.</s:assert>

--- a/test-suite/tests/ab-inline-009.xml
+++ b/test-suite/tests/ab-inline-009.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-inline-009</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests text document with tvt (expand-text='true')</p>
    </t:description>
    <t:pipeline>
@@ -50,7 +48,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The document root is not result.</s:assert>

--- a/test-suite/tests/ab-inline-010.xml
+++ b/test-suite/tests/ab-inline-010.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-inline-010</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests an inline json construction</p>
    </t:description>
    <t:pipeline>
@@ -49,7 +47,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-inline-011.xml
+++ b/test-suite/tests/ab-inline-011.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>ab-inline-011</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests an inline json construction (with expand-text='true')</p>
    </t:description>
    <t:pipeline>
@@ -49,7 +47,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-inline-012.xml
+++ b/test-suite/tests/ab-inline-012.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0057">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0057">
    <t:info>
       <t:title>ab-inline-012</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests an error is raised for a defective inline json construction</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-input-001.xml
+++ b/test-suite/tests/ab-input-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0038">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0038">
    <t:info>
       <t:title>Input 001</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0038 is raised when p:input has no attribute "port".</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-002.xml
+++ b/test-suite/tests/ab-input-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Input 002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0077 is raised when p:input's @port is not an NCName.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-003.xml
+++ b/test-suite/tests/ab-input-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0008">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0008">
    <t:info>
       <t:title>Input 003</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS00008 is raised when p:input has an unknown attribute.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-004.xml
+++ b/test-suite/tests/ab-input-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Input 004</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0077 is raised when @primary on p:input is no boolean.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-005.xml
+++ b/test-suite/tests/ab-input-005.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Input 005</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0077 is raised when @sequence on p:input is no boolean.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-006.xml
+++ b/test-suite/tests/ab-input-006.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0011">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0011">
    <t:info>
       <t:title>Input 006</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0011 is raised two input port with the same name are declared.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-007.xml
+++ b/test-suite/tests/ab-input-007.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0011">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0011">
    <t:info>
       <t:title>Input 007</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0011 is raised when an input port and an output port are declared with the same name.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
             <p:output port="source"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-008.xml
+++ b/test-suite/tests/ab-input-008.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0014">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0014">
    <t:info>
       <t:title>Input 008</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0014 is raised when two input ports are declared as primary.</p>
    </t:description>
    <t:pipeline>
@@ -37,7 +33,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-009.xml
+++ b/test-suite/tests/ab-input-009.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0008">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0008">
    <t:info>
       <t:title>Input 009</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0008 is raised when @pipe is used on p:input.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-010.xml
+++ b/test-suite/tests/ab-input-010.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0044">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0044">
    <t:info>
       <t:title>Input 010</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0044 is raised when p:pipe is a child on p:input.</p>
    </t:description>
    <t:pipeline>
@@ -38,7 +34,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-011.xml
+++ b/test-suite/tests/ab-input-011.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>Input 011</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0081 is raised when p:input has @href and p:empty as a child.</p>
    </t:description>
    <t:pipeline>
@@ -38,7 +34,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-012.xml
+++ b/test-suite/tests/ab-input-012.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>Input 012</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,27 +16,27 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0081 is raised when p:input has @href and p:inline as a child.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source" href="some-thing">
                 <p:inline>
-               <doc xmlns=""/>
+               <doc/>
             </p:inline>
             </p:input>
             
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-013.xml
+++ b/test-suite/tests/ab-input-013.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>Input 013</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0081 is raised when p:input has @href and p:document as a child.</p>
    </t:description>
    <t:pipeline>
@@ -38,7 +34,7 @@
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-014.xml
+++ b/test-suite/tests/ab-input-014.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>Input 014</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,25 +16,25 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XS0081 is raised when p:input has @href and implicit only content as a child.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source" href="some-thing">
-                <doc xmlns=""/>
+                <doc/>
             </p:input>
             
             <p:output port="result"/>        
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-input-015.xml
+++ b/test-suite/tests/ab-input-015.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 015</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that p:documentation is allowed on p:input with @href.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-input-016.xml
+++ b/test-suite/tests/ab-input-016.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 016</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that p:pipeinfo is allowed on p:input with @href.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-input-017.xml
+++ b/test-suite/tests/ab-input-017.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 017</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:input with @href.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-input-018.xml
+++ b/test-suite/tests/ab-input-018.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 018</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:input with p:document as child.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-input-019.xml
+++ b/test-suite/tests/ab-input-019.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 019</t:title>
       <t:revision-history>
@@ -9,20 +7,20 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:input with p:inline as child.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source">
                 <p:inline>
-               <doc xmlns=""/>
+               <doc/>
             </p:inline>
             </p:input>
             

--- a/test-suite/tests/ab-input-020.xml
+++ b/test-suite/tests/ab-input-020.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 020</t:title>
       <t:revision-history>
@@ -9,19 +7,19 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:input with implicit inline as child.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source">
-                <doc xmlns=""/>
+                <doc/>
             </p:input>
             
             <p:output port="result"/>        

--- a/test-suite/tests/ab-input-021.xml
+++ b/test-suite/tests/ab-input-021.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 021</t:title>
       <t:revision-history>
@@ -9,20 +7,20 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:input with external xml document binding.</p>
    </t:description>
    <t:input port="source" src="../documents/ab-doc.xml"/>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source">
-                <doc xmlns=""/>
+                <doc/>
             </p:input>
             
             <p:output port="result"/>        

--- a/test-suite/tests/ab-input-022.xml
+++ b/test-suite/tests/ab-input-022.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 022</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:input with avt on @href in p:document binding.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-input-023.xml
+++ b/test-suite/tests/ab-input-023.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 023</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:input with avt on @href.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-input-024.xml
+++ b/test-suite/tests/ab-input-024.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 024</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
@@ -18,20 +16,20 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests tvt on p:input's default binding</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:option name="option" select="'option value'" static="true"/>           
             <p:input port="source">
-                <doc xmlns="">{$option}</doc>
+                <doc>{$option}</doc>
             </p:input>
             
             <p:output port="result"/>        
@@ -39,7 +37,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The root is not doc.</s:assert>

--- a/test-suite/tests/ab-input-025.xml
+++ b/test-suite/tests/ab-input-025.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Input 025</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
@@ -18,19 +16,19 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests select on p:input</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source" select="/doc/element" sequence="true">
-                <doc xmlns="">
+                <doc>
                <element>text</element>
                <element>text</element>
             </doc>
@@ -41,7 +39,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The document root is not result.</s:assert>

--- a/test-suite/tests/ab-input-026.xml
+++ b/test-suite/tests/ab-input-026.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Input 026</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0006 is raised, when a non-sequence port is not externally bound.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-input-027.xml
+++ b/test-suite/tests/ab-input-027.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0006">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0006">
    <t:info>
       <t:title>Input 027</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0006 is raised, when a non-sequence port is not externally bound.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-input-028.xml
+++ b/test-suite/tests/ab-input-028.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0016">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0016">
    <t:info>
       <t:title>Input 028</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,19 +16,19 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0016 is raised, when @select return something, that is not a node.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source" select="count(/doc/@*)">
-                <doc xmlns="" att1="1" att2="2"/>
+                <doc att1="1" att2="2"/>
             </p:input>
             <p:output port="result"/>
             

--- a/test-suite/tests/ab-input-029.xml
+++ b/test-suite/tests/ab-input-029.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0016">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0016">
    <t:info>
       <t:title>Input 029</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,19 +16,19 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>reached 300</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0016 is raised, when @select returns an attribute.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source" select="/doc/@*">
-                <doc xmlns="" att1="1" att2="2"/>
+                <doc att1="1" att2="2"/>
             </p:input>
             <p:output port="result"/>
             

--- a/test-suite/tests/ab-input-030.xml
+++ b/test-suite/tests/ab-input-030.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0044">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0044">
    <t:info>
       <t:title>Input 030</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Added test to make sure p:pipe is no child of p:input. Making content-type statically in the last remaining tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0044 is raised, when p:input has a p:pipe child.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-option-001.xml
+++ b/test-suite/tests/ab-option-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0038">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0038">
    <t:info>
       <t:title>Option declaration 001</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests option is declared with a name.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-002.xml
+++ b/test-suite/tests/ab-option-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0028">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0028">
    <t:info>
       <t:title>Option declaration 002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests option is not declared with a name in XProc's namespace.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-003.xml
+++ b/test-suite/tests/ab-option-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0087">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0087">
    <t:info>
       <t:title>Option declaration 003</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests option is not declared with a name that has an undeclared namespace prefix.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-004.xml
+++ b/test-suite/tests/ab-option-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Option declaration 004</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0096 is raised, if option is declared with an incorrect sequence type in @as</p>
    </t:description>
    <t:pipeline>
@@ -45,7 +41,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-005.xml
+++ b/test-suite/tests/ab-option-005.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Option declaration 005</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests option is declared with a correct boolean value in @required</p>
    </t:description>
    <t:pipeline>
@@ -45,7 +41,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-006.xml
+++ b/test-suite/tests/ab-option-006.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0017">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0017">
    <t:info>
       <t:title>Option declaration 006</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests option is required and has a default value</p>
    </t:description>
    <t:pipeline>
@@ -45,7 +41,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-007.xml
+++ b/test-suite/tests/ab-option-007.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0004">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0004">
    <t:info>
       <t:title>Option declaration 007</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks no options with the name same are declared.</p>
    </t:description>
    <t:pipeline>
@@ -46,7 +42,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-008.xml
+++ b/test-suite/tests/ab-option-008.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 008</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks required option is used correctly.</p>
    </t:description>
    <t:pipeline>
@@ -25,14 +23,14 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:option name="option" select="'test-value'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-009.xml
+++ b/test-suite/tests/ab-option-009.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0018">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0018">
    <t:info>
       <t:title>Option declaration 009</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks error is raised, if required option is not bound.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-010.xml
+++ b/test-suite/tests/ab-option-010.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0036">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0036">
    <t:info>
       <t:title>Option declaration 010</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks error is raised, if value of required option does not match sequence type.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-011.xml
+++ b/test-suite/tests/ab-option-011.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 011</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks value of option is casted to expected type.</p>
    </t:description>
    <t:pipeline>
@@ -25,14 +23,14 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:option name="option" select="1"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-012.xml
+++ b/test-suite/tests/ab-option-012.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 012</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option with no default value is treated right.</p>
    </t:description>
    <t:pipeline>
@@ -25,14 +23,14 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:option name="option" select="'Some value'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-013.xml
+++ b/test-suite/tests/ab-option-013.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 013</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option with no default value and no value supplied evaluates as empty sequence.</p>
    </t:description>
    <t:pipeline>
@@ -34,13 +32,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{count($option)}</doc>
+                    <doc>{count($option)}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-014.xml
+++ b/test-suite/tests/ab-option-014.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 014</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option with no default value and no value supplied evaluates as empty sequence.</p>
    </t:description>
    <t:pipeline>
@@ -35,13 +33,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{count($var)}</doc>
+                    <doc>{count($var)}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-015.xml
+++ b/test-suite/tests/ab-option-015.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 015</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks non required option with no default value and no value supplied (= ()) passes type test.</p>
    </t:description>
    <t:pipeline>
@@ -34,13 +32,13 @@
            
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{count($option)}</doc>
+                    <doc>{count($option)}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-016.xml
+++ b/test-suite/tests/ab-option-016.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 016</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option with default value is treated right.</p>
    </t:description>
    <t:pipeline>
@@ -34,14 +32,14 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:option name="option" select="'Some value'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-017.xml
+++ b/test-suite/tests/ab-option-017.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 017</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option with default value is treated right.</p>
    </t:description>
    <t:pipeline>
@@ -25,13 +23,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-018.xml
+++ b/test-suite/tests/ab-option-018.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0036">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0036">
    <t:info>
       <t:title>Option declaration 018</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,26 +16,23 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option with default value is type checked.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
-            <p:option name="option"
-                   required="false"
-                   select="'default value'"
-                   as="xs:boolean"/>
+            <p:option name="option" required="false" select="'default value'" as="xs:boolean"/>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-019.xml
+++ b/test-suite/tests/ab-option-019.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0036">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0036">
    <t:info>
       <t:title>Option declaration 019</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,26 +16,23 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option with default value is type checked.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
-            <p:option name="option"
-                   required="false"
-                   select="'default value'"
-                   as="xs:boolean"/>
+            <p:option name="option" required="false" select="'default value'" as="xs:boolean"/>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-020.xml
+++ b/test-suite/tests/ab-option-020.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 020</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option with default value is type casted.</p>
    </t:description>
    <t:pipeline>
@@ -25,13 +23,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-021.xml
+++ b/test-suite/tests/ab-option-021.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0036">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0036">
    <t:info>
       <t:title>Option declaration 021</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Changed two tests.</p>
             </t:description>
          </t:revision>
@@ -20,26 +16,23 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option with default value is type checked.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
-            <p:option name="option"
-                   required="false"
-                   select="'this is not a boolean'"
-                   as="xs:boolean"/>
+            <p:option name="option" required="false" select="'this is not a boolean'" as="xs:boolean"/>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-022.xml
+++ b/test-suite/tests/ab-option-022.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 022</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks not required option depends on required option.</p>
    </t:description>
    <t:pipeline>
@@ -26,14 +24,14 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:option name="option1" select="'text'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-023.xml
+++ b/test-suite/tests/ab-option-023.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0071">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0071">
    <t:info>
       <t:title>Option declaration 023</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks self reference of options is not allowed.</p>
    </t:description>
    <t:pipeline>
@@ -45,7 +41,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-024.xml
+++ b/test-suite/tests/ab-option-024.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0071">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0071">
    <t:info>
       <t:title>Option declaration 024</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XS0071 (statically invalid @select) even if an option value is provided. (See #506)</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-025.xml
+++ b/test-suite/tests/ab-option-025.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Option declaration 025</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XS0096 (invalid sequence type) is raised when default value is used.</p>
    </t:description>
    <t:pipeline>
@@ -54,7 +50,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-026.xml
+++ b/test-suite/tests/ab-option-026.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0071">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0071">
    <t:info>
       <t:title>Option declaration 026</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XS0071 is raised for a static invalid XPath expression, even if it is never used. (See #506)</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-027.xml
+++ b/test-suite/tests/ab-option-027.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0071">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0071">
    <t:info>
       <t:title>Option declaration 027</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XS0071 (invalid xpath expression) is raised even if option value is provided. See Issue #506</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$option}</doc>
+                    <doc>{$option}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-029.xml
+++ b/test-suite/tests/ab-option-029.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0036">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0036">
    <t:info>
       <t:title>Option declaration 029</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks non required option with no default value and no value supplied (= ()) is type checked.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
            
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{count($option)}</doc>
+                    <doc>{count($option)}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-030.xml
+++ b/test-suite/tests/ab-option-030.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0095">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0095">
    <t:info>
       <t:title>Option declaration 030</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XS0095 is raised, if option is declared required and static.</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-031.xml
+++ b/test-suite/tests/ab-option-031.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Option declaration 031</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XS0077 is raised, if @visibility on p:option is not (public|private).</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-032.xml
+++ b/test-suite/tests/ab-option-032.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 032</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks option can be declared with @visibility (public|private).</p>
    </t:description>
    <t:pipeline>
@@ -26,13 +24,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-option-033.xml
+++ b/test-suite/tests/ab-option-033.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Option declaration 033</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XS0077 is raised, if @static on p:option is not (true|false).</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-option-034.xml
+++ b/test-suite/tests/ab-option-034.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Option declaration 034</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks option can be declared with @static (true|false).</p>
    </t:description>
    <t:pipeline>
@@ -26,13 +24,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-output-declaration-001.xml
+++ b/test-suite/tests/ab-output-declaration-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Output port declaration 001</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests for error XS0077 to be raised, when @primary on p:output is not 'true' or 'false'.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-output-declaration-002.xml
+++ b/test-suite/tests/ab-output-declaration-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Output port declaration 002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests for error XS0077 to be raised, when @sequence on p:output is not 'true' or 'false'.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-output-declaration-003.xml
+++ b/test-suite/tests/ab-output-declaration-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0014">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0014">
    <t:info>
       <t:title>Output port declaration 003</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests for error XS0014 to be raised, if two output ports are declared to be primary.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-output-declaration-004.xml
+++ b/test-suite/tests/ab-output-declaration-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0011">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0011">
    <t:info>
       <t:title>Output port declaration 004</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests for error XS0011 to be raised, if two output ports are declared with the same name.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-p-document001.xml
+++ b/test-suite/tests/ab-p-document001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 001</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with an absolute uri in @href</p>
    </t:description>
    <t:pipeline>
@@ -30,7 +28,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://docbook.org/ns/docbook" prefix="db"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document002.xml
+++ b/test-suite/tests/ab-p-document002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 002</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a relative uri in @href: Base uri of p:document to be used.</p>
    </t:description>
    <t:pipeline>
@@ -24,14 +22,13 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="langspec.xml"
-                           xml:base="https://www.w3.org/TR/2010/REC-xproc-20100511/"/>
+                    <p:document href="langspec.xml" xml:base="https://www.w3.org/TR/2010/REC-xproc-20100511/"/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://docbook.org/ns/docbook" prefix="db"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document003.xml
+++ b/test-suite/tests/ab-p-document003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 003</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a relative uri in @href: Implicit base uri of p:document to be used.</p>
    </t:description>
    <t:pipeline>
@@ -30,7 +28,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document004.xml
+++ b/test-suite/tests/ab-p-document004.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 004</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document set document-property 'base-uri' correct: Relative uri in @href: Base uri of p:document to be used.</p>
    </t:description>
    <t:pipeline>
@@ -24,8 +22,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="langspec.xml"
-                           xml:base="https://www.w3.org/TR/2010/REC-xproc-20100511/"/>
+                    <p:document href="langspec.xml" xml:base="https://www.w3.org/TR/2010/REC-xproc-20100511/"/>
                 </p:with-input>
             </p:identity>
             
@@ -35,7 +32,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document005.xml
+++ b/test-suite/tests/ab-p-document005.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 005</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>adding @content-type on p:document</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document to overwrite system content-type correctly.</p>
    </t:description>
    <t:pipeline>
@@ -48,7 +46,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document006.xml
+++ b/test-suite/tests/ab-p-document006.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 006</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with relative @href. Makes sure that document-property "base-uri" is NOT use to resolve it.</p>
    </t:description>
    <t:pipeline>
@@ -33,14 +31,13 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/ab-doc.xml"
-                           document-properties="map{xs:QName('base-uri'):'http://www.w3.org'}"/>
+                    <p:document href="../documents/ab-doc.xml" document-properties="map{xs:QName('base-uri'):'http://www.w3.org'}"/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document007.xml
+++ b/test-suite/tests/ab-p-document007.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 007</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixed wrong condition in schematron test</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with relative @href and 'base-uri' in document-properties: Makes sure that document-property "base-uri" is set correctly.</p>
    </t:description>
    <t:pipeline>
@@ -42,8 +40,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/ab-doc.xml"
-                           document-properties="map{xs:QName('base-uri'):'http://www.w3.org'}"/>
+                    <p:document href="../documents/ab-doc.xml" document-properties="map{xs:QName('base-uri'):'http://www.w3.org'}"/>
                 </p:with-input>
             </p:identity>
             
@@ -53,7 +50,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document008.xml
+++ b/test-suite/tests/ab-p-document008.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0011">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0011">
    <t:info>
       <t:title>p:document 008</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with @href to a non existing resource: XD0011 expected.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-p-document009.xml
+++ b/test-suite/tests/ab-p-document009.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0011">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0011">
    <t:info>
       <t:title>p:document 009</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href to a non existing resource: XD0011 expected.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-p-document010.xml
+++ b/test-suite/tests/ab-p-document010.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0011">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0011">
    <t:info>
       <t:title>p:document 010</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with @href to a not well-formed document: XD0011 expected.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-p-document011.xml
+++ b/test-suite/tests/ab-p-document011.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0011">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0011">
    <t:info>
       <t:title>p:document 011</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href to a not well-formed document: XD0011 expected.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-p-document012.xml
+++ b/test-suite/tests/ab-p-document012.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0023">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0023">
    <t:info>
       <t:title>p:document 012</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with dtd-validate='true' and no DTD in doc: Fails according to issue #512.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-p-document013.xml
+++ b/test-suite/tests/ab-p-document013.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 013</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Use a fixed attribute value to check that validation is occurring</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with dtd-validate='true' and DTD validation (dtd in doc).</p>
    </t:description>
    <t:pipeline>
@@ -33,14 +31,13 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/ab-doc-dtd.xml"
-                           parameters="map{'dtd-validate': true()}"/>
+                    <p:document href="../documents/ab-doc-dtd.xml" parameters="map{'dtd-validate': true()}"/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document014.xml
+++ b/test-suite/tests/ab-p-document014.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 014</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with dtd-validate='true' and DTD validation (external dtd).</p>
    </t:description>
    <t:pipeline>
@@ -24,14 +22,13 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/ab-doc-dtd-external.xml"
-                           parameters="map{'dtd-validate':true()}"/>
+                    <p:document href="../documents/ab-doc-dtd-external.xml" parameters="map{'dtd-validate':true()}"/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document015.xml
+++ b/test-suite/tests/ab-p-document015.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0011 err:XD0023">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0011 err:XD0023">
    <t:info>
       <t:title>p:document 015</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Allow multiple error codes; add more metadata</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests invalid p:document with dtd-validate='true'.</p>
    </t:description>
    <t:pipeline>
@@ -44,8 +40,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/ab-invalid-doc-dtd-external.xml"
-                           parameters="map{'dtd-validate': true()}"/>
+                    <p:document href="../documents/ab-invalid-doc-dtd-external.xml" parameters="map{'dtd-validate': true()}"/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-p-document016.xml
+++ b/test-suite/tests/ab-p-document016.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 016</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>adding @content-type on p:document</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a simple text document in UTF-8 (no charset in content-type).</p>
    </t:description>
    <t:pipeline>
@@ -50,7 +48,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document017.xml
+++ b/test-suite/tests/ab-p-document017.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 017</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>adding @content-type on p:document</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a simple text document in UTF-8 (charset specified in content-type).</p>
    </t:description>
    <t:pipeline>
@@ -42,8 +40,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/text-file-utf-8.txt"
-                           content-type="text/plain; charset=utf-8"/>
+                    <p:document href="../documents/text-file-utf-8.txt" content-type="text/plain; charset=utf-8"/>
                 </p:with-input>
             </p:identity>
             <p:wrap-sequence wrapper="doc"/>
@@ -51,7 +48,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document018.xml
+++ b/test-suite/tests/ab-p-document018.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 018</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>adding @content-type on p:document</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a simple text document in ISO-8859-1 (charset specified in content-type).</p>
    </t:description>
    <t:pipeline>
@@ -42,8 +40,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/text-file-iso-8859-1.txt"
-                           content-type="text/plain; charset=iso-8859-1"/>
+                    <p:document href="../documents/text-file-iso-8859-1.txt" content-type="text/plain; charset=iso-8859-1"/>
                 </p:with-input>
             </p:identity>
             <p:wrap-sequence wrapper="doc"/>
@@ -51,7 +48,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document019.xml
+++ b/test-suite/tests/ab-p-document019.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0060">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0060">
    <t:info>
       <t:title>p:document 019</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>adding @content-type on p:document</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -38,7 +34,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
@@ -47,13 +43,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a simple text document in an unsupported encoding.</p>
    </t:description>
    <t:pipeline>
@@ -62,8 +58,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/text-file-iso-8859-1.txt"
-                           content-type="text/plain; charset=unsupported"/>
+                    <p:document href="../documents/text-file-iso-8859-1.txt" content-type="text/plain; charset=unsupported"/>
                 </p:with-input>
             </p:identity>
             <p:wrap-sequence wrapper="doc"/>

--- a/test-suite/tests/ab-p-document020.xml
+++ b/test-suite/tests/ab-p-document020.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 020</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Changed test because content-type='text/plain' is now required.</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a simple text document in UTF-8 (no charset!).</p>
    </t:description>
    <t:pipeline>
@@ -41,7 +39,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document021.xml
+++ b/test-suite/tests/ab-p-document021.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 021</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Now I have all tests where p:document needs a content-type according to the new specs</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a JSON-document (no content-type). Tests document-properties are set right.</p>
    </t:description>
    <t:pipeline>
@@ -40,7 +38,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document022.xml
+++ b/test-suite/tests/ab-p-document022.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 022</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>adding @content-type on p:document</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a JSON-document (content-type set to application/json). Tests document-properties are set right.</p>
    </t:description>
    <t:pipeline>
@@ -49,7 +47,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document023.xml
+++ b/test-suite/tests/ab-p-document023.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0058">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0058">
    <t:info>
       <t:title>p:document 023</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Now I have all tests where p:document needs a content-type according to the new specs</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a JSON-document: Error MOX003 expected because 'duplicates'='reject'</p>
    </t:description>
    <t:pipeline>
@@ -44,9 +40,7 @@
 
             <p:identity>
                 <p:with-input select="p:document-properties-document(.)">
-                    <p:document href="../documents/JSon-doc1.json"
-                           content-type="application/json"
-                           parameters="map{'duplicates':'reject'}"/>
+                    <p:document href="../documents/JSon-doc1.json" content-type="application/json" parameters="map{'duplicates':'reject'}"/>
                 </p:with-input>
             </p:identity>
 

--- a/test-suite/tests/ab-p-document024.xml
+++ b/test-suite/tests/ab-p-document024.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 024</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Now I have all tests where p:document needs a content-type according to the new specs</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a JSON-document, checks XPath 3.1's option parameter conventions is respected: Undefined key in 'parameter'.</p>
    </t:description>
    <t:pipeline>
@@ -33,16 +31,14 @@
 
             <p:identity>
                 <p:with-input select="p:document-properties-document(.)">
-                    <p:document href="../documents/JSon-doc1.json"
-                           content-type="application/json"
-                           parameters="map{'undefined-key':'with-value'}"/>
+                    <p:document href="../documents/JSon-doc1.json" content-type="application/json" parameters="map{'undefined-key':'with-value'}"/>
                 </p:with-input>
             </p:identity>
 
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document025.xml
+++ b/test-suite/tests/ab-p-document025.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0059">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0059">
    <t:info>
       <t:title>p:document 025</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Now I have all tests where p:document needs a content-type according to the new specs</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a JSON-document: Error MOX004 expected because 'duplicates' has illegal value.</p>
    </t:description>
    <t:pipeline>
@@ -44,9 +40,7 @@
 
             <p:identity>
                 <p:with-input select="p:document-properties-document(.)">
-                    <p:document href="../documents/JSon-doc1.json"
-                           content-type="application/json"
-                           parameters="map{'duplicates': 'illegal'}"/>
+                    <p:document href="../documents/JSon-doc1.json" content-type="application/json" parameters="map{'duplicates': 'illegal'}"/>
                 </p:with-input>
             </p:identity>
 

--- a/test-suite/tests/ab-p-document026.xml
+++ b/test-suite/tests/ab-p-document026.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0057">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0057">
    <t:info>
       <t:title>p:document 026</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Now I have all tests where p:document needs a content-type according to the new specs</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a JSON-document: Error MOX002 expected for defective document and liberal=false.</p>
    </t:description>
    <t:pipeline>
@@ -44,9 +40,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/defective-json-document.json"
-                           content-type="application/json"
-                           parameters="map{'liberal': false()}"/>
+                    <p:document href="../documents/defective-json-document.json" content-type="application/json" parameters="map{'liberal': false()}"/>
                 </p:with-input>
             </p:identity>
 

--- a/test-suite/tests/ab-p-document027.xml
+++ b/test-suite/tests/ab-p-document027.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 027</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with a binary document.</p>
    </t:description>
    <t:pipeline>
@@ -39,7 +37,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
          <s:pattern>

--- a/test-suite/tests/ab-p-document028.xml
+++ b/test-suite/tests/ab-p-document028.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 028</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix #46</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Now I have all tests where p:document needs a content-type according to the new specs</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document that a binary document preserves unknown content-type.</p>
    </t:description>
    <t:pipeline>
@@ -49,7 +47,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document029.xml
+++ b/test-suite/tests/ab-p-document029.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 029</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix ab-p-document029.xml</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>One new and one corrected test.</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Now I have all tests where p:document needs a content-type according to the new specs</p>
             </t:description>
          </t:revision>
@@ -36,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with json document is correctly loaded.</p>
    </t:description>
    <t:pipeline>
@@ -58,7 +56,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/2005/xpath-functions" prefix="x"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document030.xml
+++ b/test-suite/tests/ab-p-document030.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 030</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with variable reference in @href.</p>
    </t:description>
    <t:pipeline>
@@ -31,7 +29,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document031.xml
+++ b/test-suite/tests/ab-p-document031.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 031</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with variable reference in @href.</p>
    </t:description>
    <t:pipeline>
@@ -29,7 +27,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document032.xml
+++ b/test-suite/tests/ab-p-document032.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 032</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with reference to context item in @href.</p>
    </t:description>
    <t:pipeline>
@@ -23,7 +21,7 @@
             <p:output port="result"/>
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">../documents/ab-doc.xml</doc>
+                    <doc>../documents/ab-doc.xml</doc>
                 </p:with-input>
             </p:identity>
             
@@ -33,7 +31,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document033.xml
+++ b/test-suite/tests/ab-p-document033.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 033</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with reference to context item in @href.</p>
    </t:description>
    <t:pipeline>
@@ -23,7 +21,7 @@
             <p:output port="result"/>
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">../documents/ab-doc.xml</doc>
+                    <doc>../documents/ab-doc.xml</doc>
                 </p:with-input>
             </p:identity>
             
@@ -35,7 +33,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-p-document034.xml
+++ b/test-suite/tests/ab-p-document034.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0023">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0023">
    <t:info>
       <t:title>p:document 034</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Make sure that parsing works correctly for dtd-validation=true/false</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with dtd-validate='true' and DTD error (dtd in doc).</p>
    </t:description>
    <t:pipeline>
@@ -26,8 +22,7 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/ab-invalid-doc-dtd.xml"
-                           parameters="map{'dtd-validate': true()}"/>
+                    <p:document href="../documents/ab-invalid-doc-dtd.xml" parameters="map{'dtd-validate': true()}"/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-p-document035.xml
+++ b/test-suite/tests/ab-p-document035.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 035</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Make sure that parsing works correctly for dtd-validation=true/false</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document with dtd-validate='false' and DTD error (dtd in doc).</p>
    </t:description>
    <t:pipeline>
@@ -24,14 +22,13 @@
 
             <p:identity>
                 <p:with-input>
-                    <p:document href="../documents/ab-invalid-doc-dtd.xml"
-                           parameters="map{'dtd-validate': false()}"/>
+                    <p:document href="../documents/ab-invalid-doc-dtd.xml" parameters="map{'dtd-validate': false()}"/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-p-document036.xml
+++ b/test-suite/tests/ab-p-document036.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:document 036</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix #46</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:document @content-type overwrites system known content-type.</p>
    </t:description>
    <t:pipeline>
@@ -31,7 +29,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns uri="http://www.w3.org/ns/xproc" prefix="p"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-static-option-var-001.xml
+++ b/test-suite/tests/ab-static-option-var-001.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 001</t:title>
         <t:revision-history>
@@ -10,31 +7,31 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in @select of a dynamic option.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
         
-            <p:option name="option" select="$static-option" />
+            <p:option name="option" select="$static-option"/>
         
             <p:identity>
-                <p:with-input><doc xmlns="">{$option}</doc></p:with-input>
+                <p:with-input><doc>{$option}</doc></p:with-input>
             </p:identity>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-002.xml
+++ b/test-suite/tests/ab-static-option-var-002.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 002</t:title>
         <t:revision-history>
@@ -10,29 +7,29 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in dynamic inlines.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
         
             <p:identity>
-                <p:with-input><doc xmlns="">{$static-option}</doc></p:with-input>
+                <p:with-input><doc>{$static-option}</doc></p:with-input>
             </p:identity>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-003.xml
+++ b/test-suite/tests/ab-static-option-var-003.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 003</t:title>
         <t:revision-history>
@@ -10,30 +7,30 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in static inlines.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
             <p:input port="source">
-                <doc xmlns="">{$static-option}</doc>
+                <doc>{$static-option}</doc>
             </p:input>            
             
-            <p:identity />
+            <p:identity/>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-004.xml
+++ b/test-suite/tests/ab-static-option-var-004.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 004</t:title>
         <t:revision-history>
@@ -10,32 +7,32 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in @select of static options.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
-            <p:option static="true" name="another-static" select="$static-option" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
+            <p:option static="true" name="another-static" select="$static-option"/>
             
             <p:input port="source">
-                <doc  xmlns="">{$another-static}</doc>
+                <doc>{$another-static}</doc>
             </p:input>            
             
-            <p:identity />
+            <p:identity/>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-005.xml
+++ b/test-suite/tests/ab-static-option-var-005.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 005</t:title>
         <t:revision-history>
@@ -10,39 +7,38 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in @select of static options of child steps.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc" 
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
-                <p:option static="true" name="another-static" select="$static-option" />
+                <p:output port="result"/>
+                <p:option static="true" name="another-static" select="$static-option"/>
             
                 <p:input port="source">
-                    <doc xmlns="">{$another-static}</doc>
+                    <doc>{$another-static}</doc>
                 </p:input>            
             
-                <p:identity />
+                <p:identity/>
             </p:declare-step>
             
-            <dummy:test />
+            <dummy:test/>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-006.xml
+++ b/test-suite/tests/ab-static-option-var-006.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 006</t:title>
         <t:revision-history>
@@ -10,38 +7,37 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in child steps.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc" 
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
+                <p:output port="result"/>
             
                 <p:input port="source">
-                    <doc  xmlns="">{$static-option}</doc>
+                    <doc>{$static-option}</doc>
                 </p:input>            
             
-                <p:identity />
+                <p:identity/>
             </p:declare-step>
             
-            <dummy:test />
+            <dummy:test/>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-007.xml
+++ b/test-suite/tests/ab-static-option-var-007.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 007</t:title>
         <t:revision-history>
@@ -10,35 +7,35 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in avt of static inline.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
                        
             <p:input port="source">
                 <p:inline document-properties="map{'a': $static-option}">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:inline>
             </p:input>            
             
-            <p:identity >
-                <p:with-input select="p:document-properties-document(.)/p:document-properties/a" />
+            <p:identity>
+                <p:with-input select="p:document-properties-document(.)/p:document-properties/a"/>
             </p:identity>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-008.xml
+++ b/test-suite/tests/ab-static-option-var-008.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 008</t:title>
         <t:revision-history>
@@ -10,24 +7,24 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in avt of dynamic inline.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
 
-            <p:identity >
-                <p:with-input select="p:document-properties-document(.)/p:document-properties/a" >
+            <p:identity>
+                <p:with-input select="p:document-properties-document(.)/p:document-properties/a">
                     <p:inline document-properties="map{'a': $static-option}">
-                        <doc />
+                        <doc xmlns="http://www.w3.org/1999/xhtml"/>
                     </p:inline>
                 </p:with-input>
             </p:identity>
@@ -36,7 +33,7 @@
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-009.xml
+++ b/test-suite/tests/ab-static-option-var-009.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 009</t:title>
         <t:revision-history>
@@ -10,23 +7,23 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in option short-cut.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
 
             <p:add-attribute match="/doc" attribute-name="a" attribute-value="{$static-option}">
                 <p:with-input>
-                        <doc xmlns=""/>
+                        <doc/>
                 </p:with-input>
             </p:add-attribute>
         
@@ -34,7 +31,7 @@
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-010.xml
+++ b/test-suite/tests/ab-static-option-var-010.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns="http://www.w3.org/1999/xhtml"
-    expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 010</t:title>
         <t:revision-history>
@@ -9,24 +7,24 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in p:with-option.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
             <p:output port="result"/>
             <p:option static="true" name="static-option" select="18"/>
 
             <p:add-attribute match="/doc" attribute-name="a">
                 <p:with-option name="attribute-value" select="$static-option"/>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:add-attribute>
 
@@ -34,7 +32,7 @@
     </t:pipeline>
 
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
 
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-011.xml
+++ b/test-suite/tests/ab-static-option-var-011.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 011</t:title>
         <t:revision-history>
@@ -10,24 +7,24 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in @select of static variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
-            <p:variable static="true" name="static-var" select="$static-option" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
+            <p:variable static="true" name="static-var" select="$static-option"/>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$static-var}</doc>
+                    <doc>{$static-var}</doc>
                 </p:with-input>
             </p:identity>
         
@@ -35,7 +32,7 @@
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-012.xml
+++ b/test-suite/tests/ab-static-option-var-012.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 012</t:title>
         <t:revision-history>
@@ -10,25 +7,25 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in @select of dynamic variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="18"/>
             
-            <p:variable name="var" select="$static-option" />
+            <p:variable name="var" select="$static-option"/>
             
             <p:identity>
                 <p:with-input>
-                        <doc xmlns="">{$var}</doc>
+                        <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         
@@ -36,7 +33,7 @@
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-013.xml
+++ b/test-suite/tests/ab-static-option-var-013.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns="http://www.w3.org/1999/xhtml" expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 013</t:title>
         <t:revision-history>
@@ -9,18 +7,17 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that two sibling steps can declare a static option with the same name.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
             <p:output port="result"/>
 
             <p:declare-step type="dummy:test1">
@@ -29,7 +26,7 @@
 
                 <p:identity>
                     <p:with-input>
-                        <doc1 xmlns="">{$static-option}</doc1>
+                        <doc1>{$static-option}</doc1>
                     </p:with-input>
                 </p:identity>
             </p:declare-step>
@@ -40,7 +37,7 @@
 
                 <p:identity>
                     <p:with-input>
-                        <doc2 xmlns="">{$static-option}</doc2>
+                        <doc2>{$static-option}</doc2>
                     </p:with-input>
                 </p:identity>
             </p:declare-step>
@@ -55,7 +52,7 @@
     </t:pipeline>
 
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
 
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-014.xml
+++ b/test-suite/tests/ab-static-option-var-014.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 014</t:title>
         <t:revision-history>
@@ -11,24 +7,23 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be shadowed by another static option.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="14" />
-            <p:option static="true" name="static-option" select="15" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="14"/>
+            <p:option static="true" name="static-option" select="15"/>
             
             <p:identity>
-                <p:with-input><doc xmlns=""/></p:with-input>
+                <p:with-input><doc/></p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>

--- a/test-suite/tests/ab-static-option-var-015.xml
+++ b/test-suite/tests/ab-static-option-var-015.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 015</t:title>
         <t:revision-history>
@@ -10,19 +7,18 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be shadowed by another static option on a child
             step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
             <p:output port="result"/>
             <p:option static="true" name="static-option" select="14"/>
 
@@ -32,7 +28,7 @@
 
                 <p:identity>
                     <p:with-input>
-                        <doc xmlns=""/>
+                        <doc/>
                     </p:with-input>
                 </p:identity>
             </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-016.xml
+++ b/test-suite/tests/ab-static-option-var-016.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 016</t:title>
         <t:revision-history>
@@ -11,24 +7,23 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be shadowed by another dynamic option.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="14" />
-            <p:option name="static-option" select="15" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="14"/>
+            <p:option name="static-option" select="15"/>
             
             <p:identity>
-                <p:with-input><doc xmlns=""/></p:with-input>
+                <p:with-input><doc/></p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>

--- a/test-suite/tests/ab-static-option-var-017.xml
+++ b/test-suite/tests/ab-static-option-var-017.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 017</t:title>
         <t:revision-history>
@@ -10,25 +7,24 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be shadowed by static variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
             <p:output port="result"/>
             <p:option static="true" name="static-option" select="14"/>
             <p:variable static="true" name="static-option" select="15"/>
 
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-018.xml
+++ b/test-suite/tests/ab-static-option-var-018.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 017</t:title>
         <t:revision-history>
@@ -11,24 +7,23 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be shadowed by dynamic variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="14" />
-            <p:variable name="static-option" select="15" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="14"/>
+            <p:variable name="static-option" select="15"/>
             
             <p:identity>
-                <p:with-input><doc xmlns=""/></p:with-input>
+                <p:with-input><doc/></p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>

--- a/test-suite/tests/ab-static-option-var-019.xml
+++ b/test-suite/tests/ab-static-option-var-019.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 019</t:title>
         <t:revision-history>
@@ -11,31 +7,30 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be shadowed by a dynamic option on a child step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="14" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="14"/>
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
-                <p:option name="static-option" select="15" />
+                <p:output port="result"/>
+                <p:option name="static-option" select="15"/>
             
                 <p:identity>
-                    <p:with-input><doc xmlns=""/></p:with-input>
+                    <p:with-input><doc/></p:with-input>
                 </p:identity>
             </p:declare-step>
             
-            <dummy:test />
+            <dummy:test/>
         </p:declare-step>
     </t:pipeline>
  

--- a/test-suite/tests/ab-static-option-var-020.xml
+++ b/test-suite/tests/ab-static-option-var-020.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 020</t:title>
         <t:revision-history>
@@ -11,18 +7,17 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be shadowed by a static variable on a child step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
             <p:output port="result"/>
             <p:option static="true" name="static-option" select="14"/>
 
@@ -32,7 +27,7 @@
 
                 <p:identity>
                     <p:with-input>
-                        <doc xmlns=""/>
+                        <doc/>
                     </p:with-input>
                 </p:identity>
             </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-021.xml
+++ b/test-suite/tests/ab-static-option-var-021.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 021</t:title>
         <t:revision-history>
@@ -11,31 +7,30 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be shadowed by a dynamic variable on a child step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:option static="true" name="static-option" select="14" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:option static="true" name="static-option" select="14"/>
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
-                <p:variable name="static-option" select="15" />
+                <p:output port="result"/>
+                <p:variable name="static-option" select="15"/>
             
                 <p:identity>
-                    <p:with-input><doc xmlns=""/></p:with-input>
+                    <p:with-input><doc/></p:with-input>
                 </p:identity>
             </p:declare-step>
             
-            <dummy:test />
+            <dummy:test/>
         </p:declare-step>
     </t:pipeline>
  

--- a/test-suite/tests/ab-static-option-var-022.xml
+++ b/test-suite/tests/ab-static-option-var-022.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0092">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0092">
     <t:info>
         <t:title>Static variables/option 022</t:title>
         <t:revision-history>
@@ -11,32 +7,31 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be changed with p:with-option.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
             
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
-                <p:option static="true" name="static-option" select="15" />
+                <p:output port="result"/>
+                <p:option static="true" name="static-option" select="15"/>
             
                 <p:identity>
-                    <p:with-input><doc xmlns=""/></p:with-input>
+                    <p:with-input><doc/></p:with-input>
                 </p:identity>
             </p:declare-step>
             
-            <dummy:test >
-                <p:with-option name="static-option" select="16" />
+            <dummy:test>
+                <p:with-option name="static-option" select="16"/>
             </dummy:test>
         </p:declare-step>
     </t:pipeline>

--- a/test-suite/tests/ab-static-option-var-023.xml
+++ b/test-suite/tests/ab-static-option-var-023.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0092">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0092">
     <t:info>
         <t:title>Static variables/option 023</t:title>
         <t:revision-history>
@@ -11,31 +7,30 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can not be changed with an option short cut.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
             
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
-                <p:option static="true" name="static-option" select="15" />
+                <p:output port="result"/>
+                <p:option static="true" name="static-option" select="15"/>
             
                 <p:identity>
-                    <p:with-input><doc xmlns=""/></p:with-input>
+                    <p:with-input><doc/></p:with-input>
                 </p:identity>
             </p:declare-step>
             
-            <dummy:test static-option="16" />
+            <dummy:test static-option="16"/>
         </p:declare-step>
     </t:pipeline>
  

--- a/test-suite/tests/ab-static-option-var-024.xml
+++ b/test-suite/tests/ab-static-option-var-024.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XD0050">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0050">
     <t:info>
         <t:title>Static variables/option 024</t:title>
         <t:revision-history>
@@ -11,42 +7,41 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option is not visible in a sibling step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
             
             <p:declare-step type="dummy:test1">
-                <p:output port="result" />
-                <p:option static="true" name="static-option" select="15" />
+                <p:output port="result"/>
+                <p:option static="true" name="static-option" select="15"/>
                 
                 <p:identity name="test1-one">
-                    <p:with-input><doc xmlns="">{$static-option}</doc></p:with-input>
+                    <p:with-input><doc>{$static-option}</doc></p:with-input>
                 </p:identity>
             </p:declare-step>
             
             <p:declare-step type="dummy:test2">
-                <p:output port="result" />
+                <p:output port="result"/>
                 
                 <p:identity name="test2-one">
-                    <p:with-input><doc xmlns="">{$static-option}</doc></p:with-input>
+                    <p:with-input><doc>{$static-option}</doc></p:with-input>
                 </p:identity>
             </p:declare-step>
             
             <dummy:test1 name="one"/> 
-            <dummy:test2 name="two" />
+            <dummy:test2 name="two"/>
             
             <p:wrap-sequence wrapper="result">
-                <p:with-input pipe="@one @two" />
+                <p:with-input pipe="@one @two"/>
             </p:wrap-sequence>
             
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-025.xml
+++ b/test-suite/tests/ab-static-option-var-025.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XD0050">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0050">
     <t:info>
         <t:title>Static variables/option 025</t:title>
         <t:revision-history>
@@ -11,37 +7,36 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option is not visible in a parent step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
             
             <p:declare-step type="dummy:test1">
-                <p:output port="result" />
-                <p:option static="true" name="static-option" select="15" />
+                <p:output port="result"/>
+                <p:option static="true" name="static-option" select="15"/>
                 
                 <p:identity name="test1-one">
-                    <p:with-input><doc xmlns="">{$static-option}</doc></p:with-input>
+                    <p:with-input><doc>{$static-option}</doc></p:with-input>
                 </p:identity>
             </p:declare-step>
             
             
             <dummy:test1 name="one"/>
             <p:identity name="two">
-                <p:with-input><doc xmlns="">{$static-option}</doc></p:with-input>
+                <p:with-input><doc>{$static-option}</doc></p:with-input>
             </p:identity>
             
             <p:wrap-sequence wrapper="result">
-                <p:with-input pipe="@one @two" />
+                <p:with-input pipe="@one @two"/>
             </p:wrap-sequence>
             
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-026.xml
+++ b/test-suite/tests/ab-static-option-var-026.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 026</t:title>
         <t:revision-history>
@@ -10,31 +7,31 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in @select of a dynamic option.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
         
-            <p:option name="option" select="$static-variable" />
+            <p:option name="option" select="$static-variable"/>
         
             <p:identity>
-                <p:with-input><doc xmlns="">{$option}</doc></p:with-input>
+                <p:with-input><doc>{$option}</doc></p:with-input>
             </p:identity>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-027.xml
+++ b/test-suite/tests/ab-static-option-var-027.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 027</t:title>
         <t:revision-history>
@@ -10,29 +7,29 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in dynamic inlines.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
         
             <p:identity>
-                <p:with-input><doc xmlns="">{$static-variable}</doc></p:with-input>
+                <p:with-input><doc>{$static-variable}</doc></p:with-input>
             </p:identity>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-028.xml
+++ b/test-suite/tests/ab-static-option-var-028.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 028</t:title>
         <t:revision-history>
@@ -10,30 +7,30 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in static inlines.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
             <p:input port="source">
-                <doc xmlns="">{$static-variable}</doc>
+                <doc>{$static-variable}</doc>
             </p:input>            
             
-            <p:identity />
+            <p:identity/>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-029.xml
+++ b/test-suite/tests/ab-static-option-var-029.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 029</t:title>
         <t:revision-history>
@@ -10,32 +7,32 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in @select of static variables.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
-            <p:variable static="true" name="another-variable" select="$static-variable" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
+            <p:variable static="true" name="another-variable" select="$static-variable"/>
             
             <p:input port="source">
-                <doc  xmlns="">{$another-variable}</doc>
+                <doc>{$another-variable}</doc>
             </p:input>            
             
-            <p:identity />
+            <p:identity/>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-030.xml
+++ b/test-suite/tests/ab-static-option-var-030.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 030</t:title>
         <t:revision-history>
@@ -10,39 +7,38 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in @select of static variable of child steps.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc" 
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
-                <p:variable static="true" name="another-variable" select="$static-variable" />
+                <p:output port="result"/>
+                <p:variable static="true" name="another-variable" select="$static-variable"/>
             
                 <p:input port="source">
-                    <doc xmlns="">{$another-variable}</doc>
+                    <doc>{$another-variable}</doc>
                 </p:input>            
             
-                <p:identity />
+                <p:identity/>
             </p:declare-step>
             
-            <dummy:test />
+            <dummy:test/>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-031.xml
+++ b/test-suite/tests/ab-static-option-var-031.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 031</t:title>
         <t:revision-history>
@@ -10,38 +7,37 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in child steps.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc" 
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
+                <p:output port="result"/>
             
                 <p:input port="source">
-                    <doc  xmlns="">{$static-variable}</doc>
+                    <doc>{$static-variable}</doc>
                 </p:input>            
             
-                <p:identity />
+                <p:identity/>
             </p:declare-step>
             
-            <dummy:test />
+            <dummy:test/>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-032.xml
+++ b/test-suite/tests/ab-static-option-var-032.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 032</t:title>
         <t:revision-history>
@@ -10,35 +7,35 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in avt of static inline.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
                        
             <p:input port="source">
                 <p:inline document-properties="map{'a': $static-variable}">
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:inline>
             </p:input>            
             
-            <p:identity >
-                <p:with-input select="p:document-properties-document(.)/p:document-properties/a" />
+            <p:identity>
+                <p:with-input select="p:document-properties-document(.)/p:document-properties/a"/>
             </p:identity>
         
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-033.xml
+++ b/test-suite/tests/ab-static-option-var-033.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 033</t:title>
         <t:revision-history>
@@ -10,24 +7,24 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in avt of dynamic inline.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
 
-            <p:identity >
-                <p:with-input select="p:document-properties-document(.)/p:document-properties/a" >
+            <p:identity>
+                <p:with-input select="p:document-properties-document(.)/p:document-properties/a">
                     <p:inline document-properties="map{'a': $static-variable}">
-                        <doc />
+                        <doc xmlns="http://www.w3.org/1999/xhtml"/>
                     </p:inline>
                 </p:with-input>
             </p:identity>
@@ -36,7 +33,7 @@
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-034.xml
+++ b/test-suite/tests/ab-static-option-var-034.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 034</t:title>
         <t:revision-history>
@@ -10,23 +7,23 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in option short-cut.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
 
             <p:add-attribute match="/doc" attribute-name="a" attribute-value="{$static-variable}">
                 <p:with-input>
-                        <doc xmlns=""/>
+                        <doc/>
                 </p:with-input>
             </p:add-attribute>
         
@@ -34,7 +31,7 @@
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-035.xml
+++ b/test-suite/tests/ab-static-option-var-035.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns="http://www.w3.org/1999/xhtml"
-    expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 035</t:title>
         <t:revision-history>
@@ -9,24 +7,24 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in p:with-option.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
             <p:output port="result"/>
             <p:variable static="true" name="static-variable" select="18"/>
 
             <p:add-attribute match="/doc" attribute-name="a">
                 <p:with-option name="attribute-value" select="$static-variable"/>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:add-attribute>
 
@@ -34,7 +32,7 @@
     </t:pipeline>
 
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
 
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-036.xml
+++ b/test-suite/tests/ab-static-option-var-036.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 036</t:title>
         <t:revision-history>
@@ -10,24 +7,24 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in @select of static variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
-            <p:variable static="true" name="static-var" select="$static-variable" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
+            <p:variable static="true" name="static-var" select="$static-variable"/>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$static-var}</doc>
+                    <doc>{$static-var}</doc>
                 </p:with-input>
             </p:identity>
         
@@ -35,7 +32,7 @@
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-037.xml
+++ b/test-suite/tests/ab-static-option-var-037.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 037</t:title>
         <t:revision-history>
@@ -10,25 +7,25 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in @select of dynamic variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
-            <p:variable static="true" name="static-variable" select="18" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-variable" select="18"/>
             
-            <p:variable name="var" select="$static-variable" />
+            <p:variable name="var" select="$static-variable"/>
             
             <p:identity>
                 <p:with-input>
-                        <doc xmlns="">{$var}</doc>
+                        <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         
@@ -36,7 +33,7 @@
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
             
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-038.xml
+++ b/test-suite/tests/ab-static-option-var-038.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns="http://www.w3.org/1999/xhtml" expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
     <t:info>
         <t:title>Static variables/option 038</t:title>
         <t:revision-history>
@@ -9,18 +7,17 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that two sibling steps can declare a static variable with the same name.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
             <p:output port="result"/>
 
             <p:declare-step type="dummy:test1">
@@ -29,7 +26,7 @@
 
                 <p:identity>
                     <p:with-input>
-                        <doc1 xmlns="">{$static-variable}</doc1>
+                        <doc1>{$static-variable}</doc1>
                     </p:with-input>
                 </p:identity>
             </p:declare-step>
@@ -40,7 +37,7 @@
 
                 <p:identity>
                     <p:with-input>
-                        <doc2 xmlns="">{$static-variable}</doc2>
+                        <doc2>{$static-variable}</doc2>
                     </p:with-input>
                 </p:identity>
             </p:declare-step>
@@ -55,7 +52,7 @@
     </t:pipeline>
 
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
 
             <s:pattern>

--- a/test-suite/tests/ab-static-option-var-039.xml
+++ b/test-suite/tests/ab-static-option-var-039.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 039</t:title>
         <t:revision-history>
@@ -11,24 +7,23 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can not be shadowed by another static option.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:variable static="true" name="static" select="14" />
-            <p:option static="true" name="static" select="15" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static" select="14"/>
+            <p:option static="true" name="static" select="15"/>
             
             <p:identity>
-                <p:with-input><doc xmlns=""/></p:with-input>
+                <p:with-input><doc/></p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>

--- a/test-suite/tests/ab-static-option-var-040.xml
+++ b/test-suite/tests/ab-static-option-var-040.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 040</t:title>
         <t:revision-history>
@@ -10,19 +7,18 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can not be shadowed by another static option on a child
             step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
             <p:output port="result"/>
             <p:variable static="true" name="static" select="14"/>
 
@@ -32,7 +28,7 @@
 
                 <p:identity>
                     <p:with-input>
-                        <doc xmlns=""/>
+                        <doc/>
                     </p:with-input>
                 </p:identity>
             </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-041.xml
+++ b/test-suite/tests/ab-static-option-var-041.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 041</t:title>
         <t:revision-history>
@@ -11,24 +7,23 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can not be shadowed by another dynamic option.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:variable static="true" name="static" select="14" />
-            <p:option name="static" select="15" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static" select="14"/>
+            <p:option name="static" select="15"/>
             
             <p:identity>
-                <p:with-input><doc xmlns=""/></p:with-input>
+                <p:with-input><doc/></p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>

--- a/test-suite/tests/ab-static-option-var-042.xml
+++ b/test-suite/tests/ab-static-option-var-042.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 042</t:title>
         <t:revision-history>
@@ -10,25 +7,24 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can not be shadowed by static variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
             <p:output port="result"/>
             <p:variable static="true" name="static-option" select="14"/>
             <p:variable static="true" name="static-option" select="15"/>
 
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-043.xml
+++ b/test-suite/tests/ab-static-option-var-043.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 043</t:title>
         <t:revision-history>
@@ -11,24 +7,23 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can not be shadowed by dynamic variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:variable static="true" name="static-option" select="14" />
-            <p:variable name="static-option" select="15" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-option" select="14"/>
+            <p:variable name="static-option" select="15"/>
             
             <p:identity>
-                <p:with-input><doc xmlns=""/></p:with-input>
+                <p:with-input><doc/></p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>

--- a/test-suite/tests/ab-static-option-var-044.xml
+++ b/test-suite/tests/ab-static-option-var-044.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 044</t:title>
         <t:revision-history>
@@ -11,31 +7,30 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can not be shadowed by a dynamic option on a child step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:variable static="true" name="static-option" select="14" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-option" select="14"/>
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
-                <p:option name="static-option" select="15" />
+                <p:output port="result"/>
+                <p:option name="static-option" select="15"/>
             
                 <p:identity>
-                    <p:with-input><doc xmlns=""/></p:with-input>
+                    <p:with-input><doc/></p:with-input>
                 </p:identity>
             </p:declare-step>
             
-            <dummy:test />
+            <dummy:test/>
         </p:declare-step>
     </t:pipeline>
  

--- a/test-suite/tests/ab-static-option-var-045.xml
+++ b/test-suite/tests/ab-static-option-var-045.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 045</t:title>
         <t:revision-history>
@@ -11,18 +7,17 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can not be shadowed by a static variable on a child step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
             <p:output port="result"/>
             <p:variable static="true" name="static-option" select="14"/>
 
@@ -32,7 +27,7 @@
 
                 <p:identity>
                     <p:with-input>
-                        <doc xmlns=""/>
+                        <doc/>
                     </p:with-input>
                 </p:identity>
             </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-046.xml
+++ b/test-suite/tests/ab-static-option-var-046.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0091">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0091">
     <t:info>
         <t:title>Static variables/option 046</t:title>
         <t:revision-history>
@@ -11,31 +7,30 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can not be shadowed by a dynamic variable on a child step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-                                                  xmlns:dummy="http://dummy">
-            <p:output port="result" />
-            <p:variable static="true" name="static-option" select="14" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
+            <p:variable static="true" name="static-option" select="14"/>
             
             <p:declare-step type="dummy:test">
-                <p:output port="result" />
-                <p:variable name="static-option" select="15" />
+                <p:output port="result"/>
+                <p:variable name="static-option" select="15"/>
             
                 <p:identity>
-                    <p:with-input><doc xmlns=""/></p:with-input>
+                    <p:with-input><doc/></p:with-input>
                 </p:identity>
             </p:declare-step>
             
-            <dummy:test />
+            <dummy:test/>
         </p:declare-step>
     </t:pipeline>
  

--- a/test-suite/tests/ab-static-option-var-047.xml
+++ b/test-suite/tests/ab-static-option-var-047.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XD0050">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0050">
     <t:info>
         <t:title>Static variables/option 047</t:title>
         <t:revision-history>
@@ -11,42 +7,41 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable is not visible in a sibling step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
             
             <p:declare-step type="dummy:test1">
-                <p:output port="result" />
-                <p:variable static="true" name="static-variable" select="15" />
+                <p:output port="result"/>
+                <p:variable static="true" name="static-variable" select="15"/>
                 
                 <p:identity name="test1-one">
-                    <p:with-input><doc xmlns="">{$static-variable}</doc></p:with-input>
+                    <p:with-input><doc>{$static-variable}</doc></p:with-input>
                 </p:identity>
             </p:declare-step>
             
             <p:declare-step type="dummy:test2">
-                <p:output port="result" />
+                <p:output port="result"/>
                 
                 <p:identity name="test2-one">
-                    <p:with-input><doc xmlns="">{$static-variable}</doc></p:with-input>
+                    <p:with-input><doc>{$static-variable}</doc></p:with-input>
                 </p:identity>
             </p:declare-step>
             
             <dummy:test1 name="one"/> 
-            <dummy:test2 name="two" />
+            <dummy:test2 name="two"/>
             
             <p:wrap-sequence wrapper="result">
-                <p:with-input pipe="@one @two" />
+                <p:with-input pipe="@one @two"/>
             </p:wrap-sequence>
             
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-048.xml
+++ b/test-suite/tests/ab-static-option-var-048.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XD0050">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0050">
     <t:info>
         <t:title>Static variables/option 048</t:title>
         <t:revision-history>
@@ -11,37 +7,36 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable is not visible in a parent step.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:dummy="http://dummy">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:dummy="http://dummy" name="main" version="3.0">
+            <p:output port="result"/>
             
             <p:declare-step type="dummy:test1">
-                <p:output port="result" />
-                <p:variable static="true" name="static-variable" select="15" />
+                <p:output port="result"/>
+                <p:variable static="true" name="static-variable" select="15"/>
                 
                 <p:identity name="test1-one">
-                    <p:with-input><doc xmlns="">{$static-variable}</doc></p:with-input>
+                    <p:with-input><doc>{$static-variable}</doc></p:with-input>
                 </p:identity>
             </p:declare-step>
             
             
             <dummy:test1 name="one"/>
             <p:identity name="two">
-                <p:with-input><doc xmlns="">{$static-variable}</doc></p:with-input>
+                <p:with-input><doc>{$static-variable}</doc></p:with-input>
             </p:identity>
             
             <p:wrap-sequence wrapper="result">
-                <p:with-input pipe="@one @two" />
+                <p:with-input pipe="@one @two"/>
             </p:wrap-sequence>
             
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-049.xml
+++ b/test-suite/tests/ab-static-option-var-049.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="pass">
     <t:info>
         <t:title>Static variables/option 049</t:title>
         <t:revision-history>
@@ -11,34 +7,34 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in inline binding of a static variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:variable static="true" name="var1" select="5" />
-            <p:variable static="true" name="var2" select="/doc/text()" >
-                <doc xmlns="">{$var1}</doc>
+            <p:variable static="true" name="var1" select="5"/>
+            <p:variable static="true" name="var2" select="/doc/text()">
+                <doc>{$var1}</doc>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc2 xmlns="">{$var2}</doc2>
+                    <doc2>{$var2}</doc2>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:pattern>
                 <s:rule context="/">
                     <s:assert test="doc2">The pipeline root is not doc2.</s:assert>

--- a/test-suite/tests/ab-static-option-var-050.xml
+++ b/test-suite/tests/ab-static-option-var-050.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="pass">
     <t:info>
         <t:title>Static variables/option 050</t:title>
         <t:revision-history>
@@ -11,34 +7,34 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in inline binding of a static variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:option static="true" name="option" select="5" />
-            <p:variable static="true" name="var2" select="/doc/text()" >
-                <doc xmlns="">{$option}</doc>
+            <p:option static="true" name="option" select="5"/>
+            <p:variable static="true" name="var2" select="/doc/text()">
+                <doc>{$option}</doc>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc2 xmlns="">{$var2}</doc2>
+                    <doc2>{$var2}</doc2>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:pattern>
                 <s:rule context="/">
                     <s:assert test="doc2">The pipeline root is not doc2.</s:assert>

--- a/test-suite/tests/ab-static-option-var-051.xml
+++ b/test-suite/tests/ab-static-option-var-051.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="pass">
     <t:info>
         <t:title>Static variables/option 051</t:title>
         <t:revision-history>
@@ -11,34 +7,34 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static option can be used in document binding of a static variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:option static="true" name="option" select="'../documents/ab-doc2.xml'" />
-            <p:variable static="true" name="var2" select="/doc/@att" >
-                <p:document href="{$option}" />
+            <p:option static="true" name="option" select="'../documents/ab-doc2.xml'"/>
+            <p:variable static="true" name="var2" select="/doc/@att">
+                <p:document href="{$option}"/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc2 xmlns="">{$var2}</doc2>
+                    <doc2>{$var2}</doc2>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:pattern>
                 <s:rule context="/">
                     <s:assert test="doc2">The pipeline root is not doc2.</s:assert>

--- a/test-suite/tests/ab-static-option-var-052.xml
+++ b/test-suite/tests/ab-static-option-var-052.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="pass">
     <t:info>
         <t:title>Static variables/option 052</t:title>
         <t:revision-history>
@@ -11,34 +7,34 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that a static variable can be used in document binding of a static variable.</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:variable static="true" name="variable" select="'../documents/ab-doc2.xml'" />
-            <p:variable static="true" name="var2" select="/doc/@att" >
-                <p:document href="{$variable}" />
+            <p:variable static="true" name="variable" select="'../documents/ab-doc2.xml'"/>
+            <p:variable static="true" name="var2" select="/doc/@att">
+                <p:document href="{$variable}"/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc2 xmlns="">{$var2}</doc2>
+                    <doc2>{$var2}</doc2>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
     </t:pipeline>
     
     <t:schematron>
-        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
             <s:pattern>
                 <s:rule context="/">
                     <s:assert test="doc2">The pipeline root is not doc2.</s:assert>

--- a/test-suite/tests/ab-static-option-var-053.xml
+++ b/test-suite/tests/ab-static-option-var-053.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0071">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0071">
     <t:info>
         <t:title>Static variables/option 053</t:title>
         <t:revision-history>
@@ -11,25 +7,25 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that it is an error to have a dynamic option in @select of a static option</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:option name="dynamic" select="13" />
-            <p:option name="static" static="true" select="$dynamic" />
+            <p:option name="dynamic" select="13"/>
+            <p:option name="static" static="true" select="$dynamic"/>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" />
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-054.xml
+++ b/test-suite/tests/ab-static-option-var-054.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0071">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0071">
     <t:info>
         <t:title>Static variables/option 054</t:title>
         <t:revision-history>
@@ -11,25 +7,25 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that it is an error to have a dynamic option in @select of a static variable</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:option name="dynamic" select="13" />
-            <p:variable name="static" static="true" select="$dynamic" />
+            <p:option name="dynamic" select="13"/>
+            <p:variable name="static" static="true" select="$dynamic"/>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" />
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-055.xml
+++ b/test-suite/tests/ab-static-option-var-055.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XD0050">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0050">
     <t:info>
         <t:title>Static variables/option 055</t:title>
         <t:revision-history>
@@ -11,27 +7,27 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that it is an error to have a dynamic option in implicit inline binding of a static variable</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:option name="dynamic" select="13" />
-            <p:variable name="static" static="true" select="." >
-                <doc>{$dynamic}</doc>
+            <p:option name="dynamic" select="13"/>
+            <p:variable name="static" static="true" select=".">
+                <doc xmlns="http://www.w3.org/1999/xhtml">{$dynamic}</doc>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" />
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-056.xml
+++ b/test-suite/tests/ab-static-option-var-056.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XD0050">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0050">
     <t:info>
         <t:title>Static variables/option 056</t:title>
         <t:revision-history>
@@ -11,27 +7,27 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that it is an error to have a dynamic option in explicit inline binding of a static variable</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:option name="dynamic" select="13" />
-            <p:variable name="static" static="true" select="." >
-                <p:inline><doc>{$dynamic}</doc></p:inline>
+            <p:option name="dynamic" select="13"/>
+            <p:variable name="static" static="true" select=".">
+                <p:inline><doc xmlns="http://www.w3.org/1999/xhtml">{$dynamic}</doc></p:inline>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" />
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-057.xml
+++ b/test-suite/tests/ab-static-option-var-057.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XD0050">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0050">
     <t:info>
         <t:title>Static variables/option 057</t:title>
         <t:revision-history>
@@ -11,27 +7,27 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that it is an error to have a dynamic option in p:document binding of a static variable</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:option name="dynamic" select="13" />
-            <p:variable name="static" static="true" select="." >
-                <p:document href="{$dynamic}" />
+            <p:option name="dynamic" select="13"/>
+            <p:variable name="static" static="true" select=".">
+                <p:document href="{$dynamic}"/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" />
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-static-option-var-058.xml
+++ b/test-suite/tests/ab-static-option-var-058.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-    xmlns:err="http://www.w3.org/ns/xproc-error"
-    xmlns="http://www.w3.org/1999/xhtml"
-    expected="fail" code="err:XS0071 err:XD0050">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0071 err:XD0050">
     <t:info>
         <t:title>Static variables/option 058</t:title>
         <t:revision-history>
@@ -11,25 +7,25 @@
                 <t:author>
                     <t:name>Achim Berndzen</t:name>
                 </t:author>
-                <t:description>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
                     <p>Initial test</p>
                 </t:description>
             </t:revision>
         </t:revision-history>
     </t:info>
-    <t:description>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests that it is an error to have a dynamic option in @href binding of a static variable</p>
     </t:description>
     <t:pipeline>
-        <p:declare-step name="main" version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
-            <p:output port="result" />
+        <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="main" version="3.0">
+            <p:output port="result"/>
             
-            <p:option name="dynamic" select="13" />
-            <p:variable name="static" static="true" select="." href="{$dynamic}" />
+            <p:option name="dynamic" select="13"/>
+            <p:variable name="static" static="true" select="." href="{$dynamic}"/>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="" />
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-001.xml
+++ b/test-suite/tests/ab-variable-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0038">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0038">
    <t:info>
       <t:title>Variable declaration 001</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests variable is declared with a name.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-002.xml
+++ b/test-suite/tests/ab-variable-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0038">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0038">
    <t:info>
       <t:title>Variable declaration 002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests variable is declared with an @select.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-003.xml
+++ b/test-suite/tests/ab-variable-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0008">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0008">
    <t:info>
       <t:title>Variable declaration 003</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests only allowed attributes on p:variable</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-004.xml
+++ b/test-suite/tests/ab-variable-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0028">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0028">
    <t:info>
       <t:title>Variable declaration 004</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable does not have a name in XProc's namespace.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-005.xml
+++ b/test-suite/tests/ab-variable-005.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0087">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0087">
    <t:info>
       <t:title>Variable declaration 005</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable does not have a name with an undeclared prefix.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-006.xml
+++ b/test-suite/tests/ab-variable-006.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Variable declaration 006</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -38,13 +34,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0049 is raised if a variable has an incorrect sequence type.</p>
    </t:description>
    <t:pipeline>
@@ -54,7 +50,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-006a.xml
+++ b/test-suite/tests/ab-variable-006a.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
       <t:title>Variable declaration 006a</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0096 is raised if a variable has an incorrect sequence type, even if it is not used.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-007.xml
+++ b/test-suite/tests/ab-variable-007.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0085">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0085">
    <t:info>
       <t:title>Variable declaration 007</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @pipe and @href.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-008.xml
+++ b/test-suite/tests/ab-variable-008.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>Variable declaration 008</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,25 +16,25 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @href and an implicit inline as child.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:variable name="var" select="4" href="some-uri">
-                <doc xmlns=""/>
+                <doc/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-009.xml
+++ b/test-suite/tests/ab-variable-009.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>Variable declaration 009</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @href and an explicit inline as child.</p>
    </t:description>
    <t:pipeline>
@@ -34,13 +30,13 @@
             <p:output port="result"/>
             <p:variable name="var" select="4" href="some-uri">
                 <p:inline>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:inline>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-010.xml
+++ b/test-suite/tests/ab-variable-010.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>Variable declaration 010</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @href and a p:document as child.</p>
    </t:description>
    <t:pipeline>
@@ -38,7 +34,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-011.xml
+++ b/test-suite/tests/ab-variable-011.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>Variable declaration 011</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @href and a p:empty as child.</p>
    </t:description>
    <t:pipeline>
@@ -38,7 +34,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-012.xml
+++ b/test-suite/tests/ab-variable-012.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>Variable declaration 012</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @href and a p:pipe as child.</p>
    </t:description>
    <t:pipeline>
@@ -38,7 +34,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-013.xml
+++ b/test-suite/tests/ab-variable-013.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>Variable declaration 013</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,25 +16,25 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @pipe and an implicit inline as child.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:variable name="var" select="4" pipe="step@port">
-                <doc xmlns=""/>
+                <doc/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-014.xml
+++ b/test-suite/tests/ab-variable-014.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>Variable declaration 014</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @pipe and an inline as child.</p>
    </t:description>
    <t:pipeline>
@@ -34,13 +30,13 @@
             <p:output port="result"/>
             <p:variable name="var" select="4" pipe="step@port">
                 <p:inline>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:inline>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-015.xml
+++ b/test-suite/tests/ab-variable-015.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>Variable declaration 015</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @pipe and a p:document as child.</p>
    </t:description>
    <t:pipeline>
@@ -38,7 +34,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-016.xml
+++ b/test-suite/tests/ab-variable-016.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>Variable declaration 016</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @pipe and p:empty as child.</p>
    </t:description>
    <t:pipeline>
@@ -38,7 +34,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-017.xml
+++ b/test-suite/tests/ab-variable-017.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>Variable declaration 017</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration does not have @pipe and p:pipe as child.</p>
    </t:description>
    <t:pipeline>
@@ -38,7 +34,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-018.xml
+++ b/test-suite/tests/ab-variable-018.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0036">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0036">
    <t:info>
       <t:title>Variable declaration 018</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration raises an error (XD0036) if select result does not match required type.</p>
    </t:description>
    <t:pipeline>
@@ -45,7 +41,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-018a.xml
+++ b/test-suite/tests/ab-variable-018a.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 018a</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XD0036 is not raised if select result in p:variable does not match required type, but the variable is not used.</p>
    </t:description>
    <t:pipeline>
@@ -25,13 +23,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-019.xml
+++ b/test-suite/tests/ab-variable-019.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 019</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration properly casted/promoted.</p>
    </t:description>
    <t:pipeline>
@@ -25,13 +23,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var instance of xs:decimal}</doc>
+                    <doc>{$var instance of xs:decimal}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-020.xml
+++ b/test-suite/tests/ab-variable-020.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 020</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a variable declaration with select result matches sequence-type.</p>
    </t:description>
    <t:pipeline>
@@ -25,13 +23,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var instance of xs:decimal}</doc>
+                    <doc>{$var instance of xs:decimal}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-021.xml
+++ b/test-suite/tests/ab-variable-021.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0008">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0008">
    <t:info>
       <t:title>Variable declaration 021</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -29,26 +25,26 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XD0008 is raised if more than one document appears as connection of p:variable and @connection is missing.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:variable name="var" select="5">
-                <doc xmlns=""/>
-                <doc xmlns=""/>
+                <doc/>
+                <doc/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-021a.xml
+++ b/test-suite/tests/ab-variable-021a.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 021</t:title>
       <t:revision-history>
@@ -9,32 +7,32 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XD0008 is NOT raised if more than one document appears as connection of p:variable and @connection is missing and the variable is not used.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:variable name="var" select="5">
-                <doc xmlns=""/>
-                <doc xmlns=""/>
+                <doc/>
+                <doc/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-022.xml
+++ b/test-suite/tests/ab-variable-022.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0008">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0008">
    <t:info>
       <t:title>Variable declaration 022</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -29,26 +25,26 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XD0008 is raised if more than one document appears as connection of p:variable and @connection is false.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:variable name="var" select="5" collection="false">
-                <doc xmlns=""/>
-                <doc xmlns=""/>
+                <doc/>
+                <doc/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-022a.xml
+++ b/test-suite/tests/ab-variable-022a.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 022</t:title>
       <t:revision-history>
@@ -9,32 +7,32 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XD0008 is NOT raised if more than one document appears as connection of p:variable and @connection is false and the variable is not used.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:variable name="var" select="5" collection="false">
-                <doc xmlns=""/>
-                <doc xmlns=""/>
+                <doc/>
+                <doc/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-023.xml
+++ b/test-suite/tests/ab-variable-023.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 023</t:title>
       <t:revision-history>
@@ -9,32 +7,32 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Check XD008 is not raised if more than one document appears as connection of p:variable and @connection is true.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:variable name="var" select="5" collection="true">
-                <doc xmlns=""/>
-                <doc xmlns=""/>
+                <doc/>
+                <doc/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-024.xml
+++ b/test-suite/tests/ab-variable-024.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0077">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0077">
    <t:info>
       <t:title>Variable declaration 024</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,26 +25,26 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Checks XS0077 is raised if @collection on p:variable is not a boolean value.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:variable name="var" select="5" collection="foo">
-                <doc xmlns=""/>
-                <doc xmlns=""/>
+                <doc/>
+                <doc/>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-variable-025.xml
+++ b/test-suite/tests/ab-variable-025.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 025</t:title>
       <t:revision-history>
@@ -9,31 +7,31 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting from an implicit inline document.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:variable name="var" select="/doc/text()">
-                <doc xmlns="">value</doc>
+                <doc>value</doc>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-026.xml
+++ b/test-suite/tests/ab-variable-026.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 026</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting from an explit inline document.</p>
    </t:description>
    <t:pipeline>
@@ -23,19 +21,19 @@
             <p:output port="result"/>
             <p:variable name="var" select="/doc/text()">
                 <p:inline>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:inline>
             </p:variable>
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-027.xml
+++ b/test-suite/tests/ab-variable-027.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 027</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting from default readable port.</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -41,13 +39,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-028.xml
+++ b/test-suite/tests/ab-variable-028.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 028</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting p:pipe.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity name="first">
                 <p:with-input>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -34,13 +32,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-029.xml
+++ b/test-suite/tests/ab-variable-029.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 029</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting @pipe in full form.</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
             
             <p:identity name="first">
                 <p:with-input>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -41,13 +39,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-030.xml
+++ b/test-suite/tests/ab-variable-030.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 030</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting @pipe with only port.</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
             
             <p:identity name="first">
                 <p:with-input>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -41,13 +39,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-031.xml
+++ b/test-suite/tests/ab-variable-031.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 031</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting @pipe with only step.</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
             
             <p:identity name="first">
                 <p:with-input>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -41,13 +39,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-032.xml
+++ b/test-suite/tests/ab-variable-032.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 032</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting p:pipe with only step.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity name="first">
                 <p:with-input>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -34,13 +32,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-033.xml
+++ b/test-suite/tests/ab-variable-033.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 033</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting p:pipe with only port.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity name="first">
                 <p:with-input>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -34,13 +32,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-034.xml
+++ b/test-suite/tests/ab-variable-034.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 034</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting p:pipe with neither port nor step.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity name="first">
                 <p:with-input>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -34,13 +32,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-035.xml
+++ b/test-suite/tests/ab-variable-035.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 035</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting @pipe with neither port nor step.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity name="first">
                 <p:with-input>
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -32,13 +30,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-036.xml
+++ b/test-suite/tests/ab-variable-036.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 036</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -18,19 +16,19 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test a p:variable selecting implicit from container's primary input port.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:input port="source">
-                <doc xmlns="">value</doc>
+                <doc>value</doc>
             </p:input>
             <p:output port="result"/>
             
@@ -38,13 +36,13 @@
             
             <p:identity>
                 <p:with-input>
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-037.xml
+++ b/test-suite/tests/ab-variable-037.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 037</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests fro p:variable</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a p:variable does not change default readable port.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns="">value</doc>
+                    <doc>value</doc>
                 </p:with-input>
             </p:identity>
             
@@ -34,7 +32,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-038.xml
+++ b/test-suite/tests/ab-variable-038.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 038</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a p:variable is implicitly connected to the containers primary input port.</p>
    </t:description>
    <t:pipeline>
@@ -26,7 +24,7 @@
             <p:variable name="var" select="/doc/text()"/>
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
             
@@ -36,10 +34,10 @@
         </p:declare-step>
    </t:pipeline>
    <t:input port="source">
-      <doc xmlns="">value</doc>
+      <doc>value</doc>
    </t:input>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-039.xml
+++ b/test-suite/tests/ab-variable-039.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 039</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a p:variable is explicitly connectable to the containers primary input port.</p>
    </t:description>
    <t:pipeline>
@@ -28,17 +26,17 @@
             </p:variable>
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
 
         </p:declare-step>
    </t:pipeline>
    <t:input port="source">
-      <doc xmlns="">value</doc>
+      <doc>value</doc>
    </t:input>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-040.xml
+++ b/test-suite/tests/ab-variable-040.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 040</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a p:variable is explicitly connectable to the containers primary input port (using just @step) .</p>
    </t:description>
    <t:pipeline>
@@ -28,17 +26,17 @@
             </p:variable>
             <p:identity>
                 <p:with-input port="source">
-                    <doc xmlns="">{$var}</doc>
+                    <doc>{$var}</doc>
                 </p:with-input>
             </p:identity>
 
         </p:declare-step>
    </t:pipeline>
    <t:input port="source">
-      <doc xmlns="">value</doc>
+      <doc>value</doc>
    </t:input>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-variable-041.xml
+++ b/test-suite/tests/ab-variable-041.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 041</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a p:variable counts as connecting an output port.</p>
    </t:description>
    <t:pipeline>
@@ -24,20 +22,20 @@
             
             <p:identity name="producer">
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
             
             <p:variable name="prop" select="5"/>
             <p:identity>
                 <p:with-input>
-                    <result xmlns="">{$prop}</result>
+                    <result>{$prop}</result>
                 </p:with-input>
             </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The pipeline root is not result.</s:assert>

--- a/test-suite/tests/ab-variable-042.xml
+++ b/test-suite/tests/ab-variable-042.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Variable declaration 041</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests a p:variable does not change primary accessible port.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity name="producer">
                 <p:with-input>
-                    <doc xmlns=""/>
+                    <doc/>
                 </p:with-input>
             </p:identity>
             
@@ -33,7 +31,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The pipeline root is not doc.</s:assert>

--- a/test-suite/tests/ab-with-input-001.xml
+++ b/test-suite/tests/ab-with-input-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-001</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with missing @port on atomic step is connection for primary input port.</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
           
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-002.xml
+++ b/test-suite/tests/ab-with-input-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0065">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0065">
    <t:info>
       <t:title>with-input-002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with missing @port on atomic step: XS0065 is raised because there is no primary input port.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-003.xml
+++ b/test-suite/tests/ab-with-input-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0010">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0010">
    <t:info>
       <t:title>with-input-003</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with undeclared port: XS0010 to be raised.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-004.xml
+++ b/test-suite/tests/ab-with-input-004.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-004</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with select.</p>
    </t:description>
    <t:pipeline>
@@ -25,7 +23,7 @@
          <p:identity>
             <p:with-input select="root/doc">
                <p:inline>
-                  <root xmlns="">
+                  <root>
                      <doc/>
                   </root>
                </p:inline>

--- a/test-suite/tests/ab-with-input-005.xml
+++ b/test-suite/tests/ab-with-input-005.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-005</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-006.xml
+++ b/test-suite/tests/ab-with-input-006.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0085">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0085">
    <t:info>
       <t:title>with-input-006</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href and @pipe: XS0085 to be raised</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-007.xml
+++ b/test-suite/tests/ab-with-input-007.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>with-input-007</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href and p:inline: XS0081 to be raised</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
          <p:identity>
             <p:with-input href="../documents/ab-doc.xml">
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-008.xml
+++ b/test-suite/tests/ab-with-input-008.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>with-input-008</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href and p:empty: XS0081 to be raised</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-009.xml
+++ b/test-suite/tests/ab-with-input-009.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>with-input-009</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href and p:document: XS0081 to be raised</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-010.xml
+++ b/test-suite/tests/ab-with-input-010.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>with-input-010</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href and p:pipe: XS0081 to be raised</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-011.xml
+++ b/test-suite/tests/ab-with-input-011.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0081">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0081">
    <t:info>
       <t:title>with-input-011</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href and implicit inline content: XS0081 to be raised</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
       
          <p:identity>
             <p:with-input href="../documents/ab-doc.xml">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-012.xml
+++ b/test-suite/tests/ab-with-input-012.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-012</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @href. Checks p:documentation and p:pipeinfo are allowed as children of p:with-input.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-013.xml
+++ b/test-suite/tests/ab-with-input-013.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-013</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe (step and port)</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-014.xml
+++ b/test-suite/tests/ab-with-input-014.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-014</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe (just step)</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-015.xml
+++ b/test-suite/tests/ab-with-input-015.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-015</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe (just port)</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-016.xml
+++ b/test-suite/tests/ab-with-input-016.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-016</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe (neither step nor port)</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-017.xml
+++ b/test-suite/tests/ab-with-input-017.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>with-input-017</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe and p:empty: XS0082 to be raised</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-018.xml
+++ b/test-suite/tests/ab-with-input-018.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>with-input-018</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe and p:document: XS0082 to be raised</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-019.xml
+++ b/test-suite/tests/ab-with-input-019.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>with-input-019</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe and p:pipe: XS0082 to be raised</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-020.xml
+++ b/test-suite/tests/ab-with-input-020.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>with-input-020</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe and p:inline: XS0082 to be raised</p>
    </t:description>
    <t:pipeline>
@@ -35,14 +31,14 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       
          <p:identity>
             <p:with-input pipe="one@result">
                <p:inline>&gt;
-              <doc xmlns=""/>
+              <doc/>
                </p:inline>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-021.xml
+++ b/test-suite/tests/ab-with-input-021.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>with-input-021</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe and implicit inline content: XS0082 to be raised</p>
    </t:description>
    <t:pipeline>
@@ -35,13 +31,13 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       
          <p:identity>
             <p:with-input pipe="one@result">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-022.xml
+++ b/test-suite/tests/ab-with-input-022.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-022</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with @pipe. Checks p:documentation and p:pipeinfo are allowed as children of p:with-input.</p>
    </t:description>
    <t:pipeline>
@@ -33,7 +31,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-023.xml
+++ b/test-suite/tests/ab-with-input-023.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-023</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with p:pipe (step and port).</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-024.xml
+++ b/test-suite/tests/ab-with-input-024.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-024</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with p:pipe (just step).</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-025.xml
+++ b/test-suite/tests/ab-with-input-025.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-025</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with p:pipe (just port).</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-026.xml
+++ b/test-suite/tests/ab-with-input-026.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-026</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with p:pipe neither @step nor @port.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-028.xml
+++ b/test-suite/tests/ab-with-input-028.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0022">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0022">
    <t:info>
       <t:title>with-input-028</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with p:pipe with an unknown port.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-029.xml
+++ b/test-suite/tests/ab-with-input-029.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0067">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0067">
    <t:info>
       <t:title>with-input-029</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with p:pipe (no port and no step) and no default readable port</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-030.xml
+++ b/test-suite/tests/ab-with-input-030.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0022">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0022">
    <t:info>
       <t:title>with-input-030</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with p:pipe (no @step) with an unknown port.</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-031.xml
+++ b/test-suite/tests/ab-with-input-031.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0067">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0067">
    <t:info>
       <t:title>with-input-031</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with empty @pipe and no default readable port</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-032.xml
+++ b/test-suite/tests/ab-with-input-032.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0090">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0090">
    <t:info>
       <t:title>with-input-032</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Changed error code to newly introduced XS0090: Defective @pipe</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with defective @pipe: step@</p>
    </t:description>
    <t:pipeline>
@@ -44,7 +40,7 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-033.xml
+++ b/test-suite/tests/ab-with-input-033.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-033</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with space separated explicit targets on @pipe </p>
    </t:description>
    <t:pipeline>
@@ -42,13 +40,13 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       
          <p:identity name="two">
             <p:with-input>
-               <doc2 xmlns=""/>
+               <doc2/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-034.xml
+++ b/test-suite/tests/ab-with-input-034.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-034</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with space separated targets (just step names) on @pipe </p>
    </t:description>
    <t:pipeline>
@@ -33,13 +31,13 @@
       
          <p:identity name="one">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       
          <p:identity name="two">
             <p:with-input>
-               <doc2 xmlns=""/>
+               <doc2/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-035.xml
+++ b/test-suite/tests/ab-with-input-035.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0089">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0089">
    <t:info>
       <t:title>with-input-035</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Checks only one p:empty is allowed as connection.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-036.xml
+++ b/test-suite/tests/ab-with-input-036.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0089">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0089">
    <t:info>
       <t:title>with-input-036</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Checks p:empty and p:inline are not allowed as connection.</p>
    </t:description>
    <t:pipeline>
@@ -46,7 +42,7 @@
             <p:with-input>
                <p:empty/>
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-037.xml
+++ b/test-suite/tests/ab-with-input-037.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0089">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0089">
    <t:info>
       <t:title>with-input-037</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Checks p:empty and p:pipe are not allowed as connection.</p>
    </t:description>
    <t:pipeline>
@@ -44,7 +40,7 @@
       
          <p:identity name="identity">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-038.xml
+++ b/test-suite/tests/ab-with-input-038.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0089">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0089">
    <t:info>
       <t:title>with-input-038</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Checks p:empty and p:document are not allowed as connection.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-039.xml
+++ b/test-suite/tests/ab-with-input-039.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0044">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0044">
    <t:info>
       <t:title>with-input-039</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Checks p:namespaces is not allowed.</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
          <p:identity>
             <p:with-input>
               <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
               </p:inline>
               <p:namespaces/>
             </p:with-input>

--- a/test-suite/tests/ab-with-input-040.xml
+++ b/test-suite/tests/ab-with-input-040.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-040</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Combinations of p:documentation and implicit inline are allowed.</p>
    </t:description>
    <t:pipeline>
@@ -43,7 +41,7 @@
          <p:identity>
             <p:with-input> 
                <p:documentation>Some documentation.</p:documentation>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-041.xml
+++ b/test-suite/tests/ab-with-input-041.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-041</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Combinations of p:pipeinfo and implicit inline are allowed.</p>
    </t:description>
    <t:pipeline>
@@ -43,7 +41,7 @@
          <p:identity>
             <p:with-input> 
                <p:pipeinfo>Some documentation.</p:pipeinfo>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-042.xml
+++ b/test-suite/tests/ab-with-input-042.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0044">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0044">
    <t:info>
       <t:title>with-input-042</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: p:inline and implicit inline not allowed</p>
    </t:description>
    <t:pipeline>
@@ -36,9 +32,9 @@
          <p:identity>
             <p:with-input> 
                <p:inline>
-                  <some-doc xmlns=""/>
+                  <some-doc/>
                </p:inline>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-043.xml
+++ b/test-suite/tests/ab-with-input-043.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0044">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0044">
    <t:info>
       <t:title>with-input-043</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: p:document and implicit inline not allowed</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
          <p:identity>
             <p:with-input> 
                <p:document href="some-uri"/>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-044.xml
+++ b/test-suite/tests/ab-with-input-044.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0044">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0044">
    <t:info>
       <t:title>with-input-044</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: p:pipe and implicit inline not allowed</p>
    </t:description>
    <t:pipeline>
@@ -35,14 +31,14 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       
          <p:identity>
             <p:with-input>
                <p:pipe/>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-045.xml
+++ b/test-suite/tests/ab-with-input-045.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-045</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Combinations of implicit inline and p:documentation are allowed</p>
    </t:description>
    <t:pipeline>
@@ -42,7 +40,7 @@
            
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
                <p:documentation>Some documentation.</p:documentation>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-046.xml
+++ b/test-suite/tests/ab-with-input-046.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-046</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -27,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Combinations of implicit inline and p:pipeinfo are allowed</p>
    </t:description>
    <t:pipeline>
@@ -42,7 +40,7 @@
            
          <p:identity>
             <p:with-input> 
-               <doc xmlns=""/>
+               <doc/>
                <p:pipeinfo>Some documentation.</p:pipeinfo>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-047.xml
+++ b/test-suite/tests/ab-with-input-047.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0044">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0044">
    <t:info>
       <t:title>with-input-047</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: implicit inline and p:inline not allowed </p>
    </t:description>
    <t:pipeline>
@@ -35,9 +31,9 @@
            
          <p:identity>
             <p:with-input> 
-               <doc xmlns=""/>
+               <doc/>
                <p:inline>
-                  <some-doc xmlns=""/>
+                  <some-doc/>
                </p:inline>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-048.xml
+++ b/test-suite/tests/ab-with-input-048.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0044">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0044">
    <t:info>
       <t:title>with-input-048</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: implicit inline and p:document not allowed</p>
    </t:description>
    <t:pipeline>
@@ -35,7 +31,7 @@
            
          <p:identity>
             <p:with-input> 
-               <doc xmlns=""/>
+               <doc/>
                <p:document href="some-uri"/>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-049.xml
+++ b/test-suite/tests/ab-with-input-049.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0044">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0044">
    <t:info>
       <t:title>with-input-049</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: implicit inline and p:pipe not allowed</p>
    </t:description>
    <t:pipeline>
@@ -35,13 +31,13 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
                <p:pipe/>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-050.xml
+++ b/test-suite/tests/ab-with-input-050.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0089">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0089">
    <t:info>
       <t:title>with-input-050</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Changed two tests.</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: implicit inline and p:empty not allowed</p>
    </t:description>
    <t:pipeline>
@@ -44,7 +40,7 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
                <p:empty/>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-051.xml
+++ b/test-suite/tests/ab-with-input-051.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0089">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0089">
    <t:info>
       <t:title>with-input-051</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Corrected tests and adapt to changes in the spec</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: p:empty and implicit inline not allowed</p>
    </t:description>
    <t:pipeline>
@@ -45,7 +41,7 @@
          <p:identity>
             <p:with-input>
                <p:empty/>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-052.xml
+++ b/test-suite/tests/ab-with-input-052.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-052</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -18,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: implicit inline with two documents </p>
    </t:description>
    <t:pipeline>
@@ -33,8 +31,8 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
-               <doc2 xmlns=""/>
+               <doc/>
+               <doc2/>
             </p:with-input>
          </p:identity>
       

--- a/test-suite/tests/ab-with-input-053.xml
+++ b/test-suite/tests/ab-with-input-053.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-053</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests for XS0079: Splitting ab-with-input-053 is several tests to have a better diagnostic.</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No comments, non-whitespace text nodes, and processing instructions allowed as siblings with implicit inlines.</p>
    </t:description>
    <t:pipeline>
@@ -45,7 +41,7 @@
          <p:identity>
             <p:with-input>
             <!-- comment -->
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-053a.xml
+++ b/test-suite/tests/ab-with-input-053a.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-053a</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests for XS0079: Splitting ab-with-input-053 is several tests to have a better diagnostic.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No comments, non-whitespace text nodes, and processing instructions allowed as siblings with implicit inlines.</p>
    </t:description>
    <t:pipeline>
@@ -26,7 +22,7 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
                <!-- comment -->
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-053b.xml
+++ b/test-suite/tests/ab-with-input-053b.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-053b</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests for XS0079: Splitting ab-with-input-053 is several tests to have a better diagnostic.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No comments, non-whitespace text nodes, and processing instructions allowed as siblings with implicit inlines.</p>
    </t:description>
    <t:pipeline>
@@ -26,9 +22,9 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
                <!-- comment -->
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-053c.xml
+++ b/test-suite/tests/ab-with-input-053c.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-053c</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests for XS0079: Splitting ab-with-input-053 is several tests to have a better diagnostic.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No comments, non-whitespace text nodes, and processing instructions allowed as siblings with implicit inlines.</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
          <p:identity>
             <p:with-input>
             <?pi target?>            
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-053d.xml
+++ b/test-suite/tests/ab-with-input-053d.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-053d</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests for XS0079: Splitting ab-with-input-053 is several tests to have a better diagnostic.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No comments, non-whitespace text nodes, and processing instructions allowed as siblings with implicit inlines.</p>
    </t:description>
    <t:pipeline>
@@ -26,7 +22,7 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
                <?pi target?>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-053e.xml
+++ b/test-suite/tests/ab-with-input-053e.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-053e</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests for XS0079: Splitting ab-with-input-053 is several tests to have a better diagnostic.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No comments, non-whitespace text nodes, and processing instructions allowed as siblings with implicit inlines.</p>
    </t:description>
    <t:pipeline>
@@ -26,9 +22,9 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
                <?pi target?>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-053f.xml
+++ b/test-suite/tests/ab-with-input-053f.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-053f</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests for XS0079: Splitting ab-with-input-053 is several tests to have a better diagnostic.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No comments, non-whitespace text nodes, and processing instructions allowed as siblings with implicit inlines.</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
          <p:identity>
             <p:with-input>
             text
-            <doc xmlns=""/>
+            <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-053g.xml
+++ b/test-suite/tests/ab-with-input-053g.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-053g</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests for XS0079: Splitting ab-with-input-053 is several tests to have a better diagnostic.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No comments, non-whitespace text nodes, and processing instructions allowed as siblings with implicit inlines.</p>
    </t:description>
    <t:pipeline>
@@ -26,7 +22,7 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             text
           </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-053h.xml
+++ b/test-suite/tests/ab-with-input-053h.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-053h</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests for XS0079: Splitting ab-with-input-053 is several tests to have a better diagnostic.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No comments, non-whitespace text nodes, and processing instructions allowed as siblings with implicit inlines.</p>
    </t:description>
    <t:pipeline>
@@ -26,9 +22,9 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             text
-            <doc xmlns=""/>
+            <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-054.xml
+++ b/test-suite/tests/ab-with-input-054.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
    <t:info>
       <t:title>with-input-054</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: No non empty text nodes allowed as siblings with implicit inlines</p>
    </t:description>
    <t:pipeline>
@@ -36,7 +32,7 @@
          <p:identity>
             <p:with-input>
             text
-            <doc xmlns=""/>
+            <doc/>
             more-text
           </p:with-input>
          </p:identity>

--- a/test-suite/tests/ab-with-input-055.xml
+++ b/test-suite/tests/ab-with-input-055.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0032">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0032">
    <t:info>
       <t:title>with-input-055</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests primary input port is connected.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-056.xml
+++ b/test-suite/tests/ab-with-input-056.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0032">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0032">
    <t:info>
       <t:title>with-input-056</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests primary input port is connected.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-057.xml
+++ b/test-suite/tests/ab-with-input-057.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0032">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0032">
    <t:info>
       <t:title>with-input-057</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests primary input port is connected. (p:documentation and p:pipeinfo are no connections)</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/ab-with-input-058.xml
+++ b/test-suite/tests/ab-with-input-058.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0003">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0003">
    <t:info>
       <t:title>with-input-058</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests error XS0003 is raised if non-primary input port is not connected.</p>
    </t:description>
    <t:pipeline>
@@ -44,7 +40,7 @@
       
          <p:insert match="/doc" position="first-child">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:insert>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-059.xml
+++ b/test-suite/tests/ab-with-input-059.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0003">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0003">
    <t:info>
       <t:title>with-input-059</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests error XS0003 is raised if non-primary input port is not connected.</p>
    </t:description>
    <t:pipeline>
@@ -44,7 +40,7 @@
       
          <p:insert match="/doc" position="first-child">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             <p:with-input port="insertion"/>
          </p:insert>

--- a/test-suite/tests/ab-with-input-060.xml
+++ b/test-suite/tests/ab-with-input-060.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0003">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0003">
    <t:info>
       <t:title>with-input-060</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -29,13 +25,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests p:with-input: Tests error XS0003 is raised if non-primary input port is not connected.</p>
    </t:description>
    <t:pipeline>
@@ -44,7 +40,7 @@
       
          <p:insert match="/doc" position="first-child">
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             <p:with-input port="insertion">
                <p:documentation/>

--- a/test-suite/tests/ab-with-input-061.xml
+++ b/test-suite/tests/ab-with-input-061.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0086">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0086">
    <t:info>
       <t:title>with-input-061</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests port is not bound twice.</p>
    </t:description>
    <t:pipeline>
@@ -35,10 +31,10 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-062.xml
+++ b/test-suite/tests/ab-with-input-062.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0086">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0086">
    <t:info>
       <t:title>with-input-062</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests port is not bound twice.</p>
    </t:description>
    <t:pipeline>
@@ -35,10 +31,10 @@
       
          <p:identity>
             <p:with-input port="source">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             <p:with-input port="source">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-063.xml
+++ b/test-suite/tests/ab-with-input-063.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0086">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0086">
    <t:info>
       <t:title>with-input-063</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests port is not bound twice.</p>
    </t:description>
    <t:pipeline>
@@ -35,10 +31,10 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             <p:with-input port="source">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-064.xml
+++ b/test-suite/tests/ab-with-input-064.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0086">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0086">
    <t:info>
       <t:title>with-input-064</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: Tests port is not bound twice.</p>
    </t:description>
    <t:pipeline>
@@ -35,10 +31,10 @@
       
          <p:identity>
             <p:with-input port="source">
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-065.xml
+++ b/test-suite/tests/ab-with-input-065.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-065</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with select from drp</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
       
          <p:identity>
             <p:with-input>
-               <doc xmlns="">
+               <doc>
                   <element/>
                </doc>
             </p:with-input>
@@ -36,7 +34,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="element">The document root is not element.</s:assert>

--- a/test-suite/tests/ab-with-input-066.xml
+++ b/test-suite/tests/ab-with-input-066.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-066</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests and some previous texts adapted to recent development</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input with select and pipe</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
       
          <p:identity name="source">
             <p:with-input>
-               <doc xmlns="">
+               <doc>
                   <element/>
                </doc>
             </p:with-input>
@@ -38,7 +36,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="element">The document root is not element.</s:assert>

--- a/test-suite/tests/ab-with-input-select-001.xml
+++ b/test-suite/tests/ab-with-input-select-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-select-001</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test select on p:with-input select="."</p>
    </t:description>
    <t:pipeline>
@@ -23,7 +21,7 @@
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select=".">
-                    <doc xmlns=""><!-- A comment -->
+                    <doc><!-- A comment -->
                   <element1 att="att"/>
                   <?target pi?>
                         A text node
@@ -34,7 +32,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="count(*) = 1">Document does not have exactly one child element.</s:assert>

--- a/test-suite/tests/ab-with-input-select-002.xml
+++ b/test-suite/tests/ab-with-input-select-002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-select-002</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,22 +16,21 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test select on p:with-input select="comment()"</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-         xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0">
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="*/comment()">
-                    <doc xmlns=""><!-- A comment -->
+                    <doc><!-- A comment -->
                   <element1 att="att"/>
                   <?target pi?>
                         A text node
@@ -46,7 +43,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-with-input-select-003.xml
+++ b/test-suite/tests/ab-with-input-select-003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-select-003</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,22 +16,21 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test select on p:with-input select="processing-instruction()"</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
-         xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0">
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="*/processing-instruction()">
-                    <doc xmlns=""><!-- A comment -->
+                    <doc><!-- A comment -->
                   <element1 att="att"/>
                   <?pi target?>
                         A text node
@@ -46,7 +43,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-with-input-select-004.xml
+++ b/test-suite/tests/ab-with-input-select-004.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-select-004</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,22 +16,21 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test select on p:with-input select="text()"</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
-         xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" version="3.0">
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="*/text()">
-                    <doc xmlns=""><!-- A comment -->
+                    <doc><!-- A comment -->
                   <element1 att="att"/>
                   <?pi target?>
                         A text node
@@ -46,7 +43,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-with-input-select-005.xml
+++ b/test-suite/tests/ab-with-input-select-005.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-select-005</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that an all text selection on p:with-input results in content-type "text/plain"</p>
    </t:description>
    <t:pipeline>
@@ -23,7 +21,7 @@
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="*/text()[1]">
-                    <doc xmlns=""><!-- A comment -->
+                    <doc><!-- A comment -->
                   <element1 att="att"/>
                   <?pi target?>
                         A text node
@@ -38,7 +36,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-with-input-select-006.xml
+++ b/test-suite/tests/ab-with-input-select-006.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-select-006</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -36,7 +34,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
@@ -45,23 +43,22 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that content-type is changed to application/xml when selecting from XLST document.</p>
    </t:description>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
-            xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="/xsl:stylesheet/xsl:template[1]">
                     <p:inline content-type="application/xslt+xml">
-                        <xsl:stylesheet  version="2.0">
+                        <xsl:stylesheet version="2.0">
                      <xsl:template match="/">
                         <xsl:text>result</xsl:text>
                      </xsl:template>
@@ -76,7 +73,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-with-input-select-007.xml
+++ b/test-suite/tests/ab-with-input-select-007.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0016">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0016">
    <t:info>
       <t:title>with-input-select-007</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>More tests.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD0016 is raised, when @select returns value that is not a node.</p>
    </t:description>
    <t:pipeline>
@@ -34,7 +30,7 @@
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="count(/doc/@*)">
-                    <doc xmlns="" att1="1" att2="3"/>
+                    <doc att1="1" att2="3"/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-with-input-select-008.xml
+++ b/test-suite/tests/ab-with-input-select-008.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0016">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0016">
    <t:info>
       <t:title>with-input-select-008</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix namespace declarations</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>reached 300</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests that XD0016 is raised, when @select returns an attribute.</p>
    </t:description>
    <t:pipeline>
@@ -34,7 +30,7 @@
             <p:output port="result"/>
             <p:identity>
                 <p:with-input select="/doc/@*">
-                    <doc xmlns="" att1="1" att2="3"/>
+                    <doc att1="1" att2="3"/>
                 </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-with-input-select-009.xml
+++ b/test-suite/tests/ab-with-input-select-009.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>with-input-select-009</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests select on p:with-input and no explicit connection is connected to the default readable port.</p>
    </t:description>
    <t:pipeline>
@@ -24,7 +22,7 @@
             
             <p:identity>
                 <p:with-input>
-               <doc xmlns="">
+               <doc>
                   <element/>
                </doc>
             </p:with-input>
@@ -37,7 +35,7 @@
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/">

--- a/test-suite/tests/ab-with-option-001.xml
+++ b/test-suite/tests/ab-with-option-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0031">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0031">
    <t:info>
       <t:title>With-option 001</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0031 is raised, when step is called with an undeclared option in short-cut</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:identity option="not-declared">
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-with-option-002.xml
+++ b/test-suite/tests/ab-with-option-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0031">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0031">
    <t:info>
       <t:title>With-option 002</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0031 is raised, when p:with-option uses an undeclared option name.</p>
    </t:description>
    <t:pipeline>
@@ -28,7 +24,7 @@
             <p:identity>
                 <p:with-option name="undeclared" select="option"/>
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:identity>
         </p:declare-step>

--- a/test-suite/tests/ab-with-option-003.xml
+++ b/test-suite/tests/ab-with-option-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0080">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0080">
    <t:info>
       <t:title>With-option 003</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0080 is raised, when p:with-option binds an option twice.</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:count>
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
                 <p:with-option name="limit" select="1"/>
                 <p:with-option name="limit" select="2"/>

--- a/test-suite/tests/ab-with-option-004.xml
+++ b/test-suite/tests/ab-with-option-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0080">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0080">
    <t:info>
       <t:title>With-option 004</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0080 is raised, when option short cut and p:with-option is used for the same option.</p>
    </t:description>
    <t:pipeline>
@@ -27,7 +23,7 @@
             
             <p:count limit="2">
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
                 <p:with-option name="limit" select="1"/>
             </p:count>

--- a/test-suite/tests/ab-with-option-005.xml
+++ b/test-suite/tests/ab-with-option-005.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0018">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0018">
    <t:info>
       <t:title>With-option 005</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix typo in description</p>
             </t:description>
          </t:revision>
@@ -20,13 +16,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new and some changed tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests XS0018 is raised, if a step is invoke without a required option.</p>
    </t:description>
    <t:pipeline>
@@ -36,10 +32,10 @@
             
             <p:insert>
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
                 <p:with-input port="insertion">
-               <insert xmlns=""/>
+               <insert/>
             </p:with-input>
             </p:insert>
         </p:declare-step>

--- a/test-suite/tests/ab-with-option-006.xml
+++ b/test-suite/tests/ab-with-option-006.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>With-option 006</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests variable reference in an option short-cut</p>
    </t:description>
    <t:pipeline>
@@ -25,13 +23,13 @@
             
             <p:add-attribute attribute-name="att" attribute-value="{$att-value}">
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:add-attribute>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-with-option-007.xml
+++ b/test-suite/tests/ab-with-option-007.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>With-option 007</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests variable reference in p:with-option</p>
    </t:description>
    <t:pipeline>
@@ -26,13 +24,13 @@
             <p:add-attribute attribute-name="att">
                 <p:with-option name="attribute-value" select="$att-value"/>
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:add-attribute>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-with-option-008.xml
+++ b/test-suite/tests/ab-with-option-008.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>With-option 006</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests reference to default readable port in an option short-cut</p>
    </t:description>
    <t:pipeline>
@@ -24,19 +22,19 @@
             
             <p:identity>
                 <p:with-input>
-               <doc xmlns="">5</doc>
+               <doc>5</doc>
             </p:with-input>
             </p:identity>
             
             <p:add-attribute attribute-name="att" attribute-value="{/doc/text()}">
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:add-attribute>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/ab-with-option-009.xml
+++ b/test-suite/tests/ab-with-option-009.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>With-option 009</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some tests changed and new tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests reference to default readable port in p:with-option</p>
    </t:description>
    <t:pipeline>
@@ -24,20 +22,20 @@
            
             <p:identity>
                 <p:with-input>
-               <doc xmlns="">5</doc>
+               <doc>5</doc>
             </p:with-input>
             </p:identity>
             
             <p:add-attribute attribute-name="att">
                 <p:with-option name="attribute-value" select="/doc/text()"/>
                 <p:with-input>
-               <doc xmlns=""/>
+               <doc/>
             </p:with-input>
             </p:add-attribute>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>

--- a/test-suite/tests/choose-001.xml
+++ b/test-suite/tests/choose-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Choose 001</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/choose-002.xml
+++ b/test-suite/tests/choose-002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Choose 002</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/choose-003.xml
+++ b/test-suite/tests/choose-003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Choose 003</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/choose-004.xml
+++ b/test-suite/tests/choose-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0004">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0004">
    <t:info>
       <t:title>Choose 004</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixed namespace</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixed namespace</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/default-p-input.xml
+++ b/test-suite/tests/default-p-input.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Defaulted p:inline</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -30,13 +28,13 @@
 
          <p:identity name="two">
             <p:with-input port="source">
-               <doc xmlns="">The p:inline element can be defaulted.</doc>
+               <doc>The p:inline element can be defaulted.</doc>
             </p:with-input>
          </p:identity>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/doc-prop-001.xml
+++ b/test-suite/tests/doc-prop-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Document properties 001</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/doc-prop-002.xml
+++ b/test-suite/tests/doc-prop-002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Document properties 002</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/doc-prop-003.xml
+++ b/test-suite/tests/doc-prop-003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Document properties 003</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/doc-prop-004.xml
+++ b/test-suite/tests/doc-prop-004.xml
@@ -1,7 +1,4 @@
-<!-- I don't know if this test should pass or not --><t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass"
-        when="false()">
+<!-- I don't know if this test should pass or not --><t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" when="false()">
    <t:info>
       <t:title>Document properties 004</t:title>
       <t:revision-history>
@@ -10,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/doc-prop-005.xml
+++ b/test-suite/tests/doc-prop-005.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="xqterr:XPTY0004">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="xqterr:XPTY0004">
    <t:info>
       <t:title>Document properties 005</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/err-xd0036-001.xml
+++ b/test-suite/tests/err-xd0036-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0036">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0036">
    <t:info>
       <t:title>Error XD0036</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Added tests for invalid sequence type and unmatched sequence type</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/err-xs0096-001.xml
+++ b/test-suite/tests/err-xs0096-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0096">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0096">
    <t:info>
      <t:title>Invalid sequence type</t:title>
      <t:revision-history>
@@ -11,14 +7,14 @@
          <t:author>
            <t:name>Norman Walsh</t:name>
          </t:author>
-         <t:description>
+         <t:description xmlns="http://www.w3.org/1999/xhtml">
            <p>Updated to correct error code; renamed test file.</p>
          </t:description>
        </t:revision>
      </t:revision-history>
      <t:specref linkend="err.inline.S0096"/>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Error <code>err:XS0096</code> is raised for an invalid sequence type.</p>
    </t:description>
    <t:pipeline>

--- a/test-suite/tests/inline-avt.xml
+++ b/test-suite/tests/inline-avt.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Inline AVTs</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/inline-tvt.xml
+++ b/test-suite/tests/inline-tvt.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Inline TVTs</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -17,7 +15,7 @@
    </t:info>
    <t:pipeline src="../pipelines/inline-avt.xpl"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/nw-dup-input-port-001.xml
+++ b/test-suite/tests/nw-dup-input-port-001.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0086">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0086">
    <t:info>
       <t:title>nw-dup-input-port-001</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Test that port names are optional</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: input port names may not be explicitly repeated.</p>
    </t:description>
    <t:pipeline>
@@ -27,12 +23,12 @@
          <p:identity>
             <p:with-input port="source">
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
             <p:with-input port="source">
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/nw-dup-input-port-002.xml
+++ b/test-suite/tests/nw-dup-input-port-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0086">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0086">
    <t:info>
       <t:title>nw-dup-input-port-001</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Test that port names are optional</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: input port names may not be implicitly repeated.</p>
    </t:description>
    <t:pipeline>
@@ -27,12 +23,12 @@
          <p:identity>
             <p:with-input>
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
             <p:with-input>
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/nw-dup-input-port-003.xml
+++ b/test-suite/tests/nw-dup-input-port-003.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0086">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0086">
    <t:info>
       <t:title>nw-dup-input-port-001</t:title>
       <t:revision-history>
@@ -11,13 +7,13 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Test that port names are optional</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:with-input: input port names may not be implicitly and explicitly repeated.</p>
    </t:description>
    <t:pipeline>
@@ -27,12 +23,12 @@
          <p:identity>
             <p:with-input>
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
             <p:with-input port="source">
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
          </p:identity>

--- a/test-suite/tests/nw-optional-port-001.xml
+++ b/test-suite/tests/nw-optional-port-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>optoinal-port-001</t:title>
       <t:revision-history>
@@ -9,13 +7,13 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Test that port names are optional on p:with-input</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
-   <t:description>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Test that port is optional on p:with-input</p>
    </t:description>
    <t:pipeline>
@@ -24,14 +22,14 @@
          <p:identity>
             <p:with-input>
                <p:inline>
-                  <doc xmlns=""/>
+                  <doc/>
                </p:inline>
             </p:with-input>
          </p:identity>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/opt-drp.xml
+++ b/test-suite/tests/opt-drp.xml
@@ -1,12 +1,10 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Optional p:inline wrapper</t:title>
       <t:revision-history>
          <t:revision initials="nw">
             <t:date>2018-10-11</t:date>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixed syntax of @parameters; maps are always expressions.</p>
             </t:description>
          </t:revision>
@@ -15,7 +13,7 @@
             <t:author initials="nw">
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -23,7 +21,7 @@
    </t:info>
    <t:pipeline src="../pipelines/opt-drp.xpl"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/p-count-001.xml
+++ b/test-suite/tests/p-count-001.xml
@@ -1,7 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass"
-        features="p-count">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" features="p-count">
    <t:info>
       <t:title>p:count 001</t:title>
       <t:revision-history>
@@ -10,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add features</p>
             </t:description>
          </t:revision>
@@ -19,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add tests for p:count</p>
             </t:description>
          </t:revision>
@@ -28,7 +25,7 @@
    <t:pipeline src="../pipelines/p-count-001.xpl"/>
    <t:option name="limit" select="'0'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/p-count-002.xml
+++ b/test-suite/tests/p-count-002.xml
@@ -1,7 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass"
-        features="p-count p-count-limit">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" features="p-count p-count-limit">
    <t:info>
       <t:title>p:count 002</t:title>
       <t:revision-history>
@@ -10,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests. Some tests changed to new order in p:pipe</p>
             </t:description>
          </t:revision>
@@ -19,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add features</p>
             </t:description>
          </t:revision>
@@ -28,7 +25,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add tests for p:count</p>
             </t:description>
          </t:revision>
@@ -37,7 +34,7 @@
    <t:pipeline src="../pipelines/p-count-001.xpl"/>
    <t:option name="limit" select="'1'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/p-count-003.xml
+++ b/test-suite/tests/p-count-003.xml
@@ -1,7 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass"
-        features="p-count p-count-limit">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" features="p-count p-count-limit">
    <t:info>
       <t:title>p:count 003</t:title>
       <t:revision-history>
@@ -10,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add features</p>
             </t:description>
          </t:revision>
@@ -19,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add tests for p:count</p>
             </t:description>
          </t:revision>
@@ -28,7 +25,7 @@
    <t:pipeline src="../pipelines/p-count-001.xpl"/>
    <t:option name="limit" select="'5'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/p-inline-001.xml
+++ b/test-suite/tests/p-inline-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:inline 001</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -27,15 +25,14 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests for p:inline</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
-         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">
@@ -68,7 +65,7 @@
 </c:result>
 -->
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/p-inline-002.xml
+++ b/test-suite/tests/p-inline-002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:inline 002</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -36,7 +34,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
@@ -45,7 +43,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -54,7 +52,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -63,15 +61,14 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests for p:inline</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
-         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">
@@ -91,7 +88,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/p-inline-003.xml
+++ b/test-suite/tests/p-inline-003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:inline 003</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -36,7 +34,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
@@ -45,7 +43,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -54,7 +52,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -63,15 +61,14 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New p:inline tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">
@@ -161,7 +158,7 @@ YII=
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/p-inline-004.xml
+++ b/test-suite/tests/p-inline-004.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0069">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0069">
    <t:info>
       <t:title>p:inline 004</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
@@ -38,7 +34,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -47,7 +43,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New p:inline tests</p>
             </t:description>
          </t:revision>
@@ -56,15 +52,14 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New p:inline tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
-         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">

--- a/test-suite/tests/p-inline-005.xml
+++ b/test-suite/tests/p-inline-005.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0054">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0054">
    <t:info>
       <t:title>p:inline 005</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New p:inline tests</p>
             </t:description>
          </t:revision>
@@ -38,15 +34,14 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New p:inline tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
-         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">

--- a/test-suite/tests/p-inline-006.xml
+++ b/test-suite/tests/p-inline-006.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XD0056">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0056">
    <t:info>
       <t:title>p:inline 006</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixing broken test (namespace removed)</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>=Adapted tests to PR #422</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Change test with document-properties to map{xs:QName, item()}</p>
             </t:description>
          </t:revision>
@@ -38,7 +34,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Some new tests.</p>
             </t:description>
          </t:revision>
@@ -47,7 +43,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>added new tests</p>
             </t:description>
          </t:revision>
@@ -56,7 +52,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New p:inline tests</p>
             </t:description>
          </t:revision>
@@ -65,15 +61,14 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New p:inline tests</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
    <t:pipeline>
-      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" 
-         xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" name="main" version="3.0">
          <p:output port="result" sequence="true"/>
 
          <p:identity name="inline">

--- a/test-suite/tests/p-inline-007.xml
+++ b/test-suite/tests/p-inline-007.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:inline 007</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests</p>
             </t:description>
          </t:revision>
@@ -32,7 +30,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/p-inline-008.xml
+++ b/test-suite/tests/p-inline-008.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:inline 008</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>New tests</p>
             </t:description>
          </t:revision>
@@ -32,7 +30,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/parameters-001.xml
+++ b/test-suite/tests/parameters-001.xml
@@ -1,12 +1,10 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Parameters 001</t:title>
       <t:revision-history>
          <t:revision initials="nw">
             <t:date>2018-10-11</t:date>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fixed syntax of @parameters; maps are always expressions.</p>
             </t:description>
          </t:revision>
@@ -15,7 +13,7 @@
             <t:author initials="nw">
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -23,7 +21,7 @@
    </t:info>
    <t:pipeline src="../pipelines/parameters-001.xpl"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/parameters-002.xml
+++ b/test-suite/tests/parameters-002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Parameters 002</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -17,7 +15,7 @@
    </t:info>
    <t:pipeline src="../pipelines/parameters-002.xpl"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/parameters-003.xml
+++ b/test-suite/tests/parameters-003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Parameters 003</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -17,7 +15,7 @@
    </t:info>
    <t:pipeline src="../pipelines/parameters-003.xpl"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/pipe-attr-001.xml
+++ b/test-suite/tests/pipe-attr-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Pipe attributes 001</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Reversed @pipe-substructure. (-&gt;Prague 2018)</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
@@ -27,7 +25,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -63,7 +61,7 @@
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/pipe-attr-002.xml
+++ b/test-suite/tests/pipe-attr-002.xml
@@ -1,8 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail"
-        code="err:XS0082">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0082">
    <t:info>
       <t:title>Pipe attributes 002</t:title>
       <t:revision-history>
@@ -11,7 +7,7 @@
             <t:author>
                <t:name>Achim Berndzen</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
@@ -20,7 +16,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Fix error code</p>
             </t:description>
          </t:revision>
@@ -29,7 +25,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>

--- a/test-suite/tests/simple.xml
+++ b/test-suite/tests/simple.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>The simplest pipeline</t:title>
       <t:revision-history>
@@ -9,18 +7,18 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
    <t:input port="source">
-      <doc xmlns=""/>
+      <doc/>
    </t:input>
    <t:pipeline src="../pipelines/simple.xpl"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>

--- a/test-suite/tests/try-catch-001.xml
+++ b/test-suite/tests/try-catch-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Try/catch 001</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/try-catch-001.xpl"/>
    <t:option name="error" select="0"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/try-catch-002.xml
+++ b/test-suite/tests/try-catch-002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Try/catch 002</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/try-catch-001.xpl"/>
    <t:option name="error" select="1"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/try-catch-003.xml
+++ b/test-suite/tests/try-catch-003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Try/catch 003</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/try-catch-001.xpl"/>
    <t:option name="error" select="2"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/try-catch-004.xml
+++ b/test-suite/tests/try-catch-004.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Try/catch 004</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/try-catch-002.xpl"/>
    <t:option name="error" select="0"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/try-catch-005.xml
+++ b/test-suite/tests/try-catch-005.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Try/catch 005</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/try-catch-002.xpl"/>
    <t:option name="error" select="1"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/try-catch-006.xml
+++ b/test-suite/tests/try-catch-006.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Try/catch 006</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/try-catch-002.xpl"/>
    <t:option name="error" select="2"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/try-catch-007.xml
+++ b/test-suite/tests/try-catch-007.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Try/catch 007</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/try-catch-003.xpl"/>
    <t:option name="error" select="1"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/try-catch-008.xml
+++ b/test-suite/tests/try-catch-008.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Try/catch 008</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Port my test suite; add documentation and schemas</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/try-catch-003.xpl"/>
    <t:option name="error" select="2"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/with-input-select-001.xml
+++ b/test-suite/tests/with-input-select-001.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>With-input-select 001</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add tests for @select on p:with-input</p>
             </t:description>
          </t:revision>
@@ -17,7 +15,7 @@
    </t:info>
    <t:pipeline src="../pipelines/with-input-select-001.xpl"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/with-input-select-002.xml
+++ b/test-suite/tests/with-input-select-002.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>With-input-select 002</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add tests for @select on p:with-input</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/with-input-select-001.xpl"/>
    <t:option name="class" select="'a'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/with-input-select-003.xml
+++ b/test-suite/tests/with-input-select-003.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>With input-select 003</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add tests for @select on p:with-input</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/with-input-select-001.xpl"/>
    <t:option name="class" select="'b'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/test-suite/tests/with-input-select-004.xml
+++ b/test-suite/tests/with-input-select-004.xml
@@ -1,6 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>With input-select 004</t:title>
       <t:revision-history>
@@ -9,7 +7,7 @@
             <t:author>
                <t:name>Norman Walsh</t:name>
             </t:author>
-            <t:description>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Add tests for @select on p:with-input</p>
             </t:description>
          </t:revision>
@@ -18,7 +16,7 @@
    <t:pipeline src="../pipelines/with-input-select-001.xpl"/>
    <t:option name="blank" select="'x'"/>
    <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/*">

--- a/tools/xsl/test-indexes.xsl
+++ b/tools/xsl/test-indexes.xsl
@@ -384,7 +384,8 @@
                     <xsl:sequence select="t:test-link($href)"/>
 
                     <!-- there was a massive refactor on 2018-10-09 and 2018-10-10 -->
-                    <xsl:variable name="cutoff" select="xs:date('2018-10-10')"/>
+                    <!-- there was another massive refactor on 2018-10-14 -->
+                    <xsl:variable name="cutoff" select="xs:date('2018-10-14')"/>
                     <xsl:variable name="fuzz" select="xs:dayTimeDuration('P1D')"/>
                     <xsl:variable name="log-date" select="xs:date(current-grouping-key())"/>
                     <xsl:variable name="rev-date"

--- a/tools/xsl/update-test-ns.xsl
+++ b/tools/xsl/update-test-ns.xsl
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:t="http://xproc.org/ns/testsuite/3.0"
+                xmlns:h="http://www.w3.org/1999/xhtml"
+		exclude-result-prefixes="h xs"
+                version="2.0">
+
+<xsl:output method="xml" encoding="utf-8" indent="no"
+	    omit-xml-declaration="yes"/>
+
+<xsl:template match="t:*">
+  <xsl:element name="{node-name(.)}" namespace="{namespace-uri(.)}">
+    <xsl:for-each select="namespace::*">
+      <xsl:if test="string(.) != 'http://www.w3.org/1999/xhtml'">
+        <xsl:sequence select="."/>
+      </xsl:if>
+    </xsl:for-each>
+    <xsl:apply-templates select="@*,node()"/>
+  </xsl:element>
+</xsl:template>
+
+<xsl:template match="t:pipeline">
+  <xsl:choose>
+    <xsl:when test="@src">
+      <xsl:next-match/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:element name="{node-name(.)}" namespace="{namespace-uri(.)}">
+        <xsl:for-each select="namespace::*">
+          <xsl:if test="string(.) != 'http://www.w3.org/1999/xhtml'">
+            <xsl:sequence select="."/>
+          </xsl:if>
+        </xsl:for-each>
+        <xsl:apply-templates select="@*"/>
+        <xsl:apply-templates select="node()" mode="strip-html"/>
+      </xsl:element>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template match="t:description">
+  <xsl:copy>
+    <xsl:apply-templates select="@*,node()"/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="element()">
+  <xsl:copy>
+    <xsl:apply-templates select="@*,node()"/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="attribute()">
+  <xsl:variable name="tokens" select="tokenize(., '\s+')"/>
+  <xsl:for-each select="$tokens">
+    <xsl:if test="contains(., ':')">
+      <xsl:message>Earning attribute value: <xsl:value-of select="."/></xsl:message>
+    </xsl:if>
+  </xsl:for-each>
+
+  <xsl:copy/>
+</xsl:template>
+
+<xsl:template match="t:test/@code|s:ns/@uri"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+  <xsl:copy/>
+</xsl:template>
+
+<xsl:template match="text()|comment()|processing-instruction()">
+  <xsl:copy/>
+</xsl:template>
+
+<!-- ============================================================ -->
+
+<xsl:template match="element()" mode="strip-html">
+  <xsl:element name="{node-name(.)}" namespace="{namespace-uri(.)}">
+    <xsl:for-each select="namespace::*">
+      <xsl:if test="string(.) != 'http://www.w3.org/1999/xhtml'">
+        <xsl:sequence select="."/>
+      </xsl:if>
+    </xsl:for-each>
+    <xsl:apply-templates select="@*,node()" mode="strip-html"/>
+  </xsl:element>
+</xsl:template>
+
+<xsl:template match="attribute()|text()|comment()|processing-instruction()"
+              mode="strip-html">
+  <xsl:copy/>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Fix #83 