### PR TITLE
Fix errors in try/catch pipelines

### DIFF
--- a/test-suite/pipelines/try-catch-001.xpl
+++ b/test-suite/pipelines/try-catch-001.xpl
@@ -18,10 +18,18 @@
           </p:identity>
         </p:when>
         <p:when test="$error = 1">
-          <p:error code="cx:error"/>
+          <p:error code="cx:error">
+            <p:with-input port="source">
+              <p:empty/>
+            </p:with-input>
+          </p:error>
         </p:when>
         <p:otherwise>
-          <p:error code="cx:error2"/>
+          <p:error code="cx:error2">
+            <p:with-input port="source">
+              <p:empty/>
+            </p:with-input>
+          </p:error>
         </p:otherwise>
       </p:choose>
     </p:group>

--- a/test-suite/pipelines/try-catch-002.xpl
+++ b/test-suite/pipelines/try-catch-002.xpl
@@ -20,10 +20,18 @@
           </p:identity>
         </p:when>
         <p:when test="$error = 1">
-          <p:error code="cx:error"/>
+          <p:error code="cx:error">
+            <p:with-input port="source">
+              <p:empty/>
+            </p:with-input>
+          </p:error>
         </p:when>
         <p:otherwise>
-          <p:error code="cx:error2"/>
+          <p:error code="cx:error2">
+            <p:with-input port="source">
+              <p:empty/>
+            </p:with-input>
+          </p:error>
         </p:otherwise>
       </p:choose>
     </p:group>

--- a/test-suite/pipelines/try-catch-003.xpl
+++ b/test-suite/pipelines/try-catch-003.xpl
@@ -18,10 +18,18 @@
           </p:identity>
         </p:when>
         <p:when test="$error = 1">
-          <p:error code="cx:error"/>
+          <p:error code="cx:error">
+            <p:with-input port="source">
+              <p:empty/>
+            </p:with-input>
+          </p:error>
         </p:when>
         <p:otherwise>
-          <p:error code="cx:error2"/>
+          <p:error code="cx:error2">
+            <p:with-input port="source">
+              <p:empty/>
+            </p:with-input>
+          </p:error>
         </p:otherwise>
       </p:choose>
     </p:group>


### PR DESCRIPTION
I had accidentally configured my `p:error` step so that it had no inputs or outputs. When I fixed that I discovered that I'd left their inputs unbound.
