### PR TITLE
Test fixes

### DIFF
--- a/test-suite/tests/ab-variable-021.xml
+++ b/test-suite/tests/ab-variable-021.xml
@@ -2,9 +2,15 @@
    <t:info>
       <t:title>Variable declaration 021</t:title>
       <t:revision-history>
+         <t:revision initials="nw">
+            <t:date>2018-10-16</t:date>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Fixed test; the error is only raised if the context item is referenced.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2018-06-02T17:53:51-05:00</t:date>
-            <t:author>
+            <t:author initials="nw">
                <t:name>Norman Walsh</t:name>
             </t:author>
             <t:description xmlns="http://www.w3.org/1999/xhtml">
@@ -32,12 +38,14 @@
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Checks XD0008 is raised if more than one document appears as connection of p:variable and @connection is missing.</p>
+      <p>Checks that <code>err:XD0008</code> is raised if more than one document
+      appears as connection on <code>p:variable</code> and <code>@connection</code>
+      is missing. (This error is only raised if the context item is referenced.)</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
-            <p:variable name="var" select="5">
+            <p:variable name="var" select="count(.)">
                 <doc/>
                 <doc/>
             </p:variable>

--- a/test-suite/tests/ab-variable-021a.xml
+++ b/test-suite/tests/ab-variable-021a.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="lazy-eval"
+        expected="pass">
    <t:info>
       <t:title>Variable declaration 021a</t:title>
       <t:revision-history>
@@ -19,7 +21,7 @@
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
-            <p:variable name="var" select="5">
+            <p:variable name="var" select="count(.)">
                 <doc/>
                 <doc/>
             </p:variable>

--- a/test-suite/tests/ab-variable-021b.xml
+++ b/test-suite/tests/ab-variable-021b.xml
@@ -1,0 +1,48 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>Variable declaration 021b</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2018-10-16</t:date>
+            <t:author>
+              <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Checks <em>no</em> error is raised if more than one document
+      appears as connection on <code>p:variable</code> if there’s no reference
+      to the context item.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+            <p:output port="result"/>
+            <p:variable name="var" select="5">
+                <doc/>
+                <doc/>
+            </p:variable>
+
+            <p:identity>
+                <p:with-input>
+                    <doc>{$var}</doc>
+                </p:with-input>
+            </p:identity>
+        </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="doc">The pipeline root is not doc.</s:assert>
+               <s:assert test="doc=5">The root element does not have the correct value</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-variable-022.xml
+++ b/test-suite/tests/ab-variable-022.xml
@@ -37,7 +37,7 @@
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
-            <p:variable name="var" select="5" collection="false">
+            <p:variable name="var" select="count(.)" collection="false">
                 <doc/>
                 <doc/>
             </p:variable>

--- a/test-suite/tests/nw-collection-002.xml
+++ b/test-suite/tests/nw-collection-002.xml
@@ -43,7 +43,7 @@
           <p:with-input port="source" pipe="@id1 @id2"/>
         </p:identity>
 
-        <p:variable name="a" select="count(collection())"/>
+        <p:variable name="a" select="count(.)"/>
 
         <p:identity>
           <p:with-input>


### PR DESCRIPTION
These tests needed to be updated to reflect our position that it's only an error to have multiple documents if the context item is referenced.
