### PR TITLE
Fix choose-004: No error XD0004 anymore

### DIFF
--- a/test-suite/pipelines/choose-004.xpl
+++ b/test-suite/pipelines/choose-004.xpl
@@ -29,5 +29,6 @@
       </p:identity>
     </p:when>
   </p:choose>
-
+  
+  <p:wrap-sequence wrapper="result" />
 </p:declare-step>

--- a/test-suite/tests/choose-004.xml
+++ b/test-suite/tests/choose-004.xml
@@ -1,7 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XD0004">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Choose 004</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2018-12-02</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Changed test, because it not an error anymore, if no p:when is selected and no p:otherwise is present.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2017-10-09T21:11:50-07:00</t:date>
             <t:author>
@@ -33,4 +42,16 @@
    </t:info>
    <t:pipeline src="../pipelines/choose-004.xpl"/>
    <t:option name="match" select="'3'"/>
+   <t:schematron>
+     <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
+      
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::result">The pipeline root is not result.</s:assert>
+               <s:assert test="count(self::result/*)=0">The result document should not have children.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
 </t:test>


### PR DESCRIPTION
Fixed test choose-004. We removed XD0004 because it is not an error anymore, if no p:when in a p:choose is selected and no p:otherwise is present.

The result is now expected to be an empty sequence on the default output port of p:choose. This is wrapped into a wrapper to test it.