### PR TITLE
Fix doc-prop-005

### DIFF
--- a/test-suite/pipelines/doc-prop-005.xpl
+++ b/test-suite/pipelines/doc-prop-005.xpl
@@ -7,9 +7,8 @@
 
   <p:variable name="a" select="3 + 4"/>
 
-  <!-- this should fail, $a isn't a document -->
   <p:identity>
-    <p:with-input port="source" select="p:document-properties-document($a)/c:document-properties/a">
+    <p:with-input port="source" select="p:document-properties-document($a)">
       <p:empty/>
     </p:with-input>
   </p:identity>

--- a/test-suite/tests/doc-prop-005.xml
+++ b/test-suite/tests/doc-prop-005.xml
@@ -1,7 +1,18 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="xqterr:XPTY0004">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>Document properties 005</t:title>
       <t:revision-history>
+      	 <t:revision>
+      	 	<t:date>2018-12-03</t:date>
+      	 	<t:author>
+      	 		<t:name>Achim Berndzen</t:name>
+      	 	</t:author>
+      	 	<t:description xmlns="http://www.w3.org/1999/xhtml">
+      	 		<p>Changed test, because it not an error anymore, if 
+      	 		parameter of p:document-properties-document() is not a
+      	 		document.</p>
+      	 	</t:description>
+      	 </t:revision>
          <t:revision>
             <t:date>2017-09-24T17:47:42+01:00</t:date>
             <t:author>
@@ -14,4 +25,15 @@
       </t:revision-history>
    </t:info>
    <t:pipeline src="../pipelines/doc-prop-005.xpl"/>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::c:document-properties">The pipeline root is not c:document-properties.</s:assert>
+               <s:assert test="count(/self::c:document-properties/*)=0">Root c:document-properties shouldnt have child elements.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
 </t:test>


### PR DESCRIPTION
Fixing test "doc-prop-005": It not an error anymore, if `p:document-properties-document()` is called with something, that is not a document. 