### PR TITLE
New and changed tests

### DIFF
--- a/test-suite/tests/ab-input-028.xml
+++ b/test-suite/tests/ab-input-028.xml
@@ -3,6 +3,15 @@
       <t:title>Input 028</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-01-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Changed test because an atomic result of select is not an error anymore, but an attribute is.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-06-02T17:53:51-05:00</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -23,11 +32,11 @@
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Tests XD0016 is raised, when @select return something, that is not a node.</p>
+      <p>Tests XD0016 is raised, when @select returns an attribute.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
-            <p:input port="source" select="count(/doc/@*)">
+            <p:input port="source" select="/doc/@att1">
                 <doc att1="1" att2="2"/>
             </p:input>
             <p:output port="result"/>

--- a/test-suite/tests/ab-subpipeline-001.xml
+++ b/test-suite/tests/ab-subpipeline-001.xml
@@ -1,0 +1,46 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>Subpipeline-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-01-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added test.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests a subpipeline that ends with a p:variable.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input><doc /></p:with-input>
+         </p:identity>
+         
+         <p:group>
+            <p:identity />
+            
+            <p:variable name="irrelevant" select="count(//*)"/>
+         </p:group>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="doc">Document root is not 'doc'.</s:assert>
+               <s:assert test="count(/doc/*)=0">doc should not have any children.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-with-input-select-007.xml
+++ b/test-suite/tests/ab-with-input-select-007.xml
@@ -3,6 +3,15 @@
       <t:title>with-input-select-007</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-01-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Changed test because selecting an atomic value is not an error anymore. But selection an attribute is.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2018-06-02T17:53:51-05:00</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -29,7 +38,7 @@
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:identity>
-                <p:with-input select="count(/doc/@*)">
+                <p:with-input select="/doc/@att1">
                     <doc att1="1" att2="3"/>
                 </p:with-input>
             </p:identity>

--- a/test-suite/tests/ab-with-input-select-010.xml
+++ b/test-suite/tests/ab-with-input-select-010.xml
@@ -1,0 +1,42 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>with-input-select-010</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-01-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added test</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests select on p:with-input/@select resulting in an atomic value.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+            <p:output port="result"/>
+            
+            <p:wrap-sequence wrapper="result">
+               <p:with-input select="4" >
+                  <p:empty />
+               </p:with-input>
+            </p:wrap-sequence>
+            
+        </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Document root is not 'result'.</s:assert>
+               <s:assert test="result/text()='4'">'result' does not a text child with value '4'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-with-input-select-011.xml
+++ b/test-suite/tests/ab-with-input-select-011.xml
@@ -1,0 +1,45 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>with-input-select-011</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-01-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added test</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests select on p:with-input/@select resulting in an atomic value is "text/plain"</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+            <p:output port="result"/>
+            
+            <p:identity>
+               <p:with-input select="4" >
+                  <p:empty />
+               </p:with-input>
+            </p:identity>
+            
+            <p:wrap-sequence wrapper="result">
+               <p:with-input select="p:document-property(., 'content-type')" />
+            </p:wrap-sequence>
+        </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Document root is not 'result'.</s:assert>
+               <s:assert test="result/text()='text/plain'">'result' does not a text child with value 'text/plain'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-with-input-select-012.xml
+++ b/test-suite/tests/ab-with-input-select-012.xml
@@ -1,0 +1,45 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>with-input-select-012</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-01-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added test</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests select on p:with-input/@select resulting in a map is "application/json"</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+            <p:output port="result"/>
+            
+            <p:identity>
+               <p:with-input select="map{'key' : 'value'}" >
+                  <p:empty />
+               </p:with-input>
+            </p:identity>
+            
+            <p:wrap-sequence wrapper="result">
+               <p:with-input select="p:document-property(., 'content-type')" />
+            </p:wrap-sequence>
+        </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Document root is not 'result'.</s:assert>
+               <s:assert test="result/text()='application/json'">'result' does not a text child with value 'application/json'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-with-input-select-013.xml
+++ b/test-suite/tests/ab-with-input-select-013.xml
@@ -1,0 +1,45 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>with-input-select-013</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-01-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added test</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests select on p:with-input/@select resulting in an array is "application/json"</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+            <p:output port="result"/>
+            
+            <p:identity>
+               <p:with-input select="array{'value'}" >
+                  <p:empty />
+               </p:with-input>
+            </p:identity>
+            
+            <p:wrap-sequence wrapper="result">
+               <p:with-input select="p:document-property(., 'content-type')" />
+            </p:wrap-sequence>
+        </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p" uri="http://www.w3.org/ns/xproc"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Document root is not 'result'.</s:assert>
+               <s:assert test="result/text()='application/json'">'result' does not a text child with value 'application/json'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
1. New and changed tests for changes in p:with-input/@select: Maps and arrays are now allowed.
2. Test to address #120 (p:variable at end of subpipeline)