### PR TITLE
Fixed test to changed specs

### DIFF
--- a/test-suite/tests/ab-option-032.xml
+++ b/test-suite/tests/ab-option-032.xml
@@ -1,7 +1,17 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0093">
    <t:info>
       <t:title>Option declaration 032</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2019-02-19</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Fixed test because XS0093 needs to be raised.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2018-08-10T18:12:26+02:00</t:date>
             <t:author>
@@ -14,13 +24,12 @@
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Checks option can be declared with @visibility (public|private).</p>
+      <p>Checks error is raised if p:option (parent not p:library) uses @visibility.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
             <p:output port="result"/>
             <p:option name="option" select="5" visibility="public"/>
-            <p:option name="option1" select="4" visibility="private"/>
             
             <p:identity>
                 <p:with-input>
@@ -29,14 +38,4 @@
             </p:identity>
         </p:declare-step>
    </t:pipeline>
-   <t:schematron>
-      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
-         <s:pattern>
-            <s:rule context="/">
-               <s:assert test="doc">The pipeline root is not doc.</s:assert>
-               <s:assert test="count(doc/node())=0">The root element should not have any children.</s:assert>
-            </s:rule>
-         </s:pattern>
-      </s:schema>
-   </t:schematron>
 </t:test>


### PR DESCRIPTION
Fixed test because according to the recent changes in the specs @visibility is only allowed on p:option which is a child of a p:library.