### PR TITLE
Additional test for p:import

### DIFF
--- a/test-suite/tests/ab-library-035.xml
+++ b/test-suite/tests/ab-library-035.xml
@@ -1,0 +1,51 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>Library import 035 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-03-07</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added new tests for p:declare-step and p:import.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that a private step in a library and a same named steps are kept separate.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:x="http://test">
+         <p:import href="../pipelines/ab-library-009.xpl" />
+         <p:output port="result" />
+         
+         <p:declare-step type="x:step1">
+            <p:output port="source" />
+            <p:identity>
+               <p:with-input><doc2 /></p:with-input>
+            </p:identity>
+         </p:declare-step>
+         
+         <x:step name="imported" />
+         <x:step1 name="local"/>
+         
+         <p:wrap-sequence wrapper="result">
+            <p:with-input pipe="@imported @local" />
+         </p:wrap-sequence>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not doc.</s:assert>
+               <s:assert test="result/*[1]/name()='doc'">First child is not named 'doc'.</s:assert>
+               <s:assert test="result/*[2]/name()='doc2'">Second child is not named 'doc2'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+ </t:test>


### PR DESCRIPTION
Added a test to check private step in imported library and importing library with same name are kept apart.