### PR TITLE
Small fixes, before I lose track of them

### DIFF
--- a/test-suite/tests/ab-with-input-002.xml
+++ b/test-suite/tests/ab-with-input-002.xml
@@ -20,6 +20,15 @@
                <p>Creating new tests, extending rng and corrected xproc's test</p>
             </t:description>
          </t:revision>
+         <t:revision>
+            <t:date>2019-06-30T14:36:00Z</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added href attribute so that err:XS0018 is not an equally valid error.</p>
+            </t:description>
+         </t:revision>
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
@@ -28,8 +37,8 @@
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
          <p:output port="result"/>
-      
-         <p:load>
+
+         <p:load href="irrelevant">
             <p:with-input/>
          </p:load>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-027.xml
+++ b/test-suite/tests/ab-with-input-027.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0' expected="fail" code="err:XS0022">
+<t:test xmlns:t='http://xproc.org/ns/testsuite/3.0'
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0022">
   <t:info>
     <t:title>with-input-027</t:title>
     <t:revision-history>
@@ -9,6 +11,16 @@
         </t:author>
         <t:description xmlns="http://www.w3.org/1999/xhtml">
           <p>Completing tests for p:with-input</p>
+        </t:description>
+      </t:revision>
+      <t:revision>
+        <t:date>2019-06-30T14:56:00Z</t:date>
+        <t:author>
+          <t:name>Norman Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Added missing namespace declaration for err: namespace; no
+          significant test changes.</p>
         </t:description>
       </t:revision>
     </t:revision-history>

--- a/test-suite/tests/ab-with-input-051.xml
+++ b/test-suite/tests/ab-with-input-051.xml
@@ -1,4 +1,6 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0089">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XS0100 err:XS0089">
    <t:info>
       <t:title>with-input-051</t:title>
       <t:revision-history>
@@ -27,6 +29,15 @@
             </t:author>
             <t:description xmlns="http://www.w3.org/1999/xhtml">
                <p>Creating new tests, extending rng and corrected xproc's test</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
+            <t:date>2019-06-30T17:55:00Z</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added err:xs0100 as a passing error code.</p>
             </t:description>
          </t:revision>
       </t:revision-history>


### PR DESCRIPTION
Two of these changes should be non-controversial.

I think err:XS0100 is equally valid for ab-with-input-051.