### PR TITLE
Remove reference to 't:' namespace

### DIFF
--- a/test-suite/tests/p-inline-006.xml
+++ b/test-suite/tests/p-inline-006.xml
@@ -75,7 +75,7 @@
             <p:with-input port="source">
                <p:inline encoding="base64" content-type="image/png">
 iVBORw0KGgoAAAANSUhEUgAAAIAAAAAdCAYAAABixmRWAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
-<t:no-markup-please/>
+<c:no-markup-please/>
                </p:inline>
             </p:with-input>
          </p:identity>


### PR DESCRIPTION
Hi Achim,

Not sure how your test runner works, but in mine, I recently had to remove the "t:" namespace from the in-scope namespaces of the pipeline. Failing to do so was producing erroneous results in some tests that examined the serialized output.

This test relies on it being in-scope. I fixed it by changing t: to c: which is already declared.
