### PR TITLE
Proposed changes to unwrap tests

### DIFF
--- a/test-suite/tests/ab-escape-markup-004.xml
+++ b/test-suite/tests/ab-escape-markup-004.xml
@@ -49,12 +49,12 @@
          <s:pattern>
              <s:rule context="/">
                 <s:assert test="wrapper">Document element is not wrapper.</s:assert>
-                <s:assert test="count(wrapper/node())=11">Document element should have 11 children.</s:assert>
-                <s:assert test="wrapper/node()[2] instance of comment()">First child should be comment.</s:assert>
-                <s:assert test="wrapper/node()[4] instance of processing-instruction()">Second child should be pi.</s:assert>
-                <s:assert test="wrapper/node()[6] instance of element()">Third child should be element.</s:assert>
-                <s:assert test="wrapper/node()[8] instance of comment()">Fourth child should be comment.</s:assert>
-                <s:assert test="wrapper/node()[10] instance of processing-instruction()">Fifth child should be pi.</s:assert>
+                <s:assert test="count(wrapper/node())=9">Document element should have 11 children.</s:assert>
+                <s:assert test="wrapper/node()[1] instance of comment()">First child should be comment.</s:assert>
+                <s:assert test="wrapper/node()[3] instance of processing-instruction()">Second child should be pi.</s:assert>
+                <s:assert test="wrapper/node()[5] instance of element()">Third child should be element.</s:assert>
+                <s:assert test="wrapper/node()[7] instance of comment()">Fourth child should be comment.</s:assert>
+                <s:assert test="wrapper/node()[9] instance of processing-instruction()">Fifth child should be pi.</s:assert>
                </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-unwrap-003.xml
+++ b/test-suite/tests/ab-unwrap-003.xml
@@ -16,12 +16,10 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:unwrap</p>
    </t:description>
-   <t:input port='source'>
-      <doc><?pi target ?>
+   <t:input port='source'><doc><?pi target ?>
          <para>a</para>
          <!-- comment -->
-      </doc>
-   </t:input>
+      </doc></t:input>
    
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
@@ -36,11 +34,10 @@
       <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
              <s:rule context="/">
-                <s:assert test="count(/node())=3">Document should have five children.</s:assert>
+                <s:assert test="count(/node())=6">Document should have six children.</s:assert>
                 <s:assert test="/node()[1] instance of processing-instruction()">First child node should be a processing instruction.</s:assert>
-                <s:assert test="/node()[2] instance of element()">First child node should be an element.</s:assert>
-                <s:assert test="/node()[3] instance of comment()">First child node should be a comment.</s:assert>
-                
+                <s:assert test="/node()[3] instance of element()">First child node should be an element.</s:assert>
+                <s:assert test="/node()[5] instance of comment()">First child node should be a comment.</s:assert>
                 <s:assert test="para">Root element should be 'para'.</s:assert>
                 <s:assert test="para/text()='a'">Element 'para' should have text a.</s:assert>
              </s:rule>

--- a/test-suite/tests/ab-unwrap-005.xml
+++ b/test-suite/tests/ab-unwrap-005.xml
@@ -16,9 +16,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:unwrap</p>
    </t:description>
-   <t:input port='source'>
-      <doc>Some <doc>text.</doc></doc>
-   </t:input>
+   <t:input port='source'><doc>Some <doc>text.</doc></doc></t:input>
    
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">


### PR DESCRIPTION
Some of the unwrap tests seem to assume that whitespace is being removed from the test inputs. I don't think that's the expected behavior. Here are a couple of proposed fixes.

Or am I mistaken about something?
