### PR TITLE
Update error codes for XS0096 tests

### DIFF
--- a/test-suite/tests/ab-err-s0096-1.xml
+++ b/test-suite/tests/ab-err-s0096-1.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0096">
+        expected="fail" code="err:XS0096 err:XD0015">
 <t:info>
   <t:title>Test ab-err-s0096-1</t:title>
   <t:revision-history>

--- a/test-suite/tests/ab-err-s0096-2.xml
+++ b/test-suite/tests/ab-err-s0096-2.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0096">
+        expected="fail" code="err:XS0096 err:XD0015">
 <t:info>
   <t:title>Test ab-err-s0096-2</t:title>
   <t:revision-history>

--- a/test-suite/tests/ab-err-s0096-3.xml
+++ b/test-suite/tests/ab-err-s0096-3.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XS0096">
+        expected="fail" code="err:XS0096 err:XD0015">
 <t:info>
   <t:title>Test ab-err-s0096-3</t:title>
   <t:revision-history>


### PR DESCRIPTION
I think `err:XD0015` is an equally valid error code for these tests.
