### PR TITLE
Fixed another test: Preceding/trailing whitespace

### DIFF
--- a/test-suite/tests/ab-pack-007.xml
+++ b/test-suite/tests/ab-pack-007.xml
@@ -3,6 +3,15 @@
       <t:title>pack 007 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-07-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Fixed test: Preceding/trailing whitespace is removed.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-06-30</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -55,16 +64,18 @@
           <s:pattern>
             <s:rule context="/">
                <s:assert test="doc">The document root is not doc.</s:assert>
-               <s:assert test="doc/wrap/child::node()[1] instance of text()">First child of wrap should be a text.</s:assert>               
-               <s:assert test="doc/wrap/child::node()[2] instance of comment()">Second child of wrap should be a comment.</s:assert>
-               <s:assert test="doc/wrap/child::node()[3] instance of text()">Third child of wrap should be a text.</s:assert>               
-               <s:assert test="doc/wrap/child::node()[4] instance of element()">Forth child of wrap should be an element.</s:assert>
-               <s:assert test="doc/wrap/child::node()[6] instance of processing-instruction()">Sixth child of wrap should be a pi.</s:assert>
-               <s:assert test="doc/wrap/child::node()[8] instance of processing-instruction()">Eight child of wrap should be an pi.</s:assert>
-               <s:assert test="doc/wrap/child::node()[10] instance of element()">Tenth child of wrap should be an element.</s:assert>
-               <s:assert test="doc/wrap/child::node()[12] instance of comment()">Twelfth child of wrap should be a comment.</s:assert>
-               
-               <s:assert test="count(doc/wrap/child::node())=13">Element 'wrap' should have 13 children.</s:assert>              
+               <s:assert test="doc/wrap/child::node()[1] instance of comment()">First child of wrap should be a comment.</s:assert>
+               <s:assert test="doc/wrap/child::node()[2] instance of text()">Second child of wrap should be a text.</s:assert>
+               <s:assert test="doc/wrap/child::node()[3] instance of element()">Third child of wrap should be an element.</s:assert>
+               <s:assert test="doc/wrap/child::node()[4] instance of text()">Forth child of wrap should be a text.</s:assert>
+               <s:assert test="doc/wrap/child::node()[5] instance of processing-instruction()">Fifth child of wrap should be a pi.</s:assert>
+               <s:assert test="doc/wrap/child::node()[6] instance of processing-instruction()">Sixth child of wrap should be an pi.</s:assert>
+               <s:assert test="doc/wrap/child::node()[7] instance of text()">Seventh child of wrap should be a text.</s:assert>
+               <s:assert test="doc/wrap/child::node()[8] instance of element()">Eighth child of wrap should be an element.</s:assert>
+               <s:assert test="doc/wrap/child::node()[9] instance of text()">Ninth child of wrap should be an element.</s:assert>
+               <s:assert test="doc/wrap/child::node()[10] instance of comment()">Tenth child of wrap should be a comment.</s:assert>
+          
+               <s:assert test="count(doc/wrap/child::node())=10">Element 'wrap' should have 10 children.</s:assert>              
             </s:rule>
          </s:pattern>
       </s:schema>


### PR DESCRIPTION
There was another test (for p:pack) having false node counting because of my bug in / error about handling preceding/trailing whitespaces in p:inline correctly.