### PR TITLE
Changes as consequence of fix-172

### DIFF
--- a/test-suite/tests/ab-hash-014.xml
+++ b/test-suite/tests/ab-hash-014.xml
@@ -1,8 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-   xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XC0023">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>hash 014 (AB)</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2019-07-26</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Matching / is not an error anymore.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2019-06-16</t:date>
             <t:author>
@@ -33,7 +41,7 @@
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Testing p:hash raises XC0023 if document-node is selected.</p>
+      <p>Testing p:hash matching / is a text result.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
@@ -41,11 +49,23 @@
          
          <p:hash value="XML Processing Model Working Group" algorithm="crc" match="/">
             <p:with-input>
-               <doc att="wrong" />
+               <doc  />
             </p:with-input>
          </p:hash>
-        
+         
+         <p:wrap-sequence wrapper="result" />
+         
       </p:declare-step>
    </t:pipeline>
-   
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="/result">Root element is not wrapper.</s:assert>
+               <s:assert test="count(/result/node())=1">Wrapper should have exactly one child.</s:assert>
+               <s:assert test="/result/text()='852b1f51'"></s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
 </t:test>

--- a/test-suite/tests/ab-hash-014a.xml
+++ b/test-suite/tests/ab-hash-014a.xml
@@ -1,0 +1,51 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>hash 014a (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-07-26</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>New test.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Testing p:hash matching / is a text result.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result" />
+         
+         <p:hash value="XML Processing Model Working Group" algorithm="crc" match="/">
+            <p:with-input>
+               <p:inline document-properties="map{'serialization':map{'indent': true()}, 'bogus-prop':'bogus'}">
+               <doc  />
+               </p:inline>
+            </p:with-input>
+         </p:hash>
+         
+         <p:identity>
+            <p:with-input select="p:document-properties-document(.)" />
+         </p:identity>
+         
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="/c:document-properties">Root element is not 'c:document-properties'.</s:assert>
+               <s:assert test="/c:document-properties/bogus-prop">There is no property 'bogus-prop'.</s:assert>
+               <s:assert test="/c:document-properties/bogus-prop/text()='bogus'">Value of property is not 'bogus'.</s:assert>
+               <s:assert test="not(c:document-properties/serialization)">There should be no property 'serialization'</s:assert>
+               <s:assert test="/c:document-properties/content-type='text/plain'">Property 'content-type' is not 'text/plain'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-replace-007.xml
+++ b/test-suite/tests/ab-replace-007.xml
@@ -1,9 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
-   xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XC0023"
-   >
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:replace-007 (AB)</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2019-07-26</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Matching / is not an error anymore.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2019-05-18</t:date>
             <t:author>
@@ -16,9 +23,8 @@
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Tests p:replace</p>
-   </t:description>
-   
+      <p>Tests p:replace matching /</p>
+   </t:description> 
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
          <p:output port="result"/>
@@ -33,5 +39,14 @@
          </p:replace>         
       </p:declare-step>
    </t:pipeline>
-   
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="/new-element">Root element is not "new-element".</s:assert>
+               <s:assert test="/new-element/element">Element "new-element" should have a child "element".</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
 </t:test>

--- a/test-suite/tests/ab-replace-007a.xml
+++ b/test-suite/tests/ab-replace-007a.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
-      <t:title>uuid 008 (AB)</t:title>
+      <t:title>p:replace-007a (AB)</t:title>
       <t:revision-history>
          <t:revision>
             <t:date>2019-07-26</t:date>
@@ -8,32 +8,27 @@
                <t:name>Achim Berndzen</t:name>
             </t:author>
             <t:description xmlns="http://www.w3.org/1999/xhtml">
-               <p>Changed test: matching / is not an error anymore.</p>
+               <p>New test.</p>
             </t:description>
          </t:revision>
-         <t:revision>
-            <t:date>2019-06-16</t:date>
-            <t:author>
-               <t:name>Achim Berndzen</t:name>
-            </t:author>
-            <t:description xmlns="http://www.w3.org/1999/xhtml">
-               <p>Tests for p:uuid</p>
-            </t:description>
-         </t:revision>
+         
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Testing p:uuid matching document root.</p>
-   </t:description>
+      <p>Tests p:replace matching / with text document</p>
+   </t:description> 
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
          <p:output port="result"/>
-         
-         <p:uuid match="/">
-            <p:with-input>
-               <doc>text</doc>
+            
+         <p:replace match="/">
+            <p:with-input port="source">
+               <doc/>
             </p:with-input>
-         </p:uuid>
+            <p:with-input port="replacement">
+               <p:inline content-type="text/plain">Some text.</p:inline>
+            </p:with-input>
+         </p:replace>
          <p:wrap-sequence wrapper="result" />
       </p:declare-step>
    </t:pipeline>
@@ -41,8 +36,8 @@
       <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
-               <s:assert test="/result">Root element is not 'result'.</s:assert>
-               <s:assert test="string-length(normalize-space(/result/text()))!=0">Text child a element 'result' should not be an empty string.</s:assert>
+               <s:assert test="/result">Root element is not "result".</s:assert>
+               <s:assert test="/result/text()='Some text.'">Text in "result" is not "Some text."</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-replace-007b.xml
+++ b/test-suite/tests/ab-replace-007b.xml
@@ -1,0 +1,53 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>p:replace-007b (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-07-26</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>New test.</p>
+            </t:description>
+         </t:revision>
+         
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:replace matching / with text document</p>
+   </t:description> 
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+            
+         <p:replace match="/">
+            <p:with-input port="source">
+               <p:inline document-properties="map{'serialization':map{'indent': true()}, 'bogus-prop':'bogus'}">
+                  <doc/>
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="replacement">
+               <p:inline content-type="text/plain">Some text.</p:inline>
+            </p:with-input>
+         </p:replace>
+         <p:identity>
+            <p:with-input select="p:document-properties-document(.)" />
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="/c:document-properties">Root element is not 'c:document-properties'.</s:assert>
+               <s:assert test="/c:document-properties/bogus-prop">There is no property 'bogus-prop'.</s:assert>
+               <s:assert test="/c:document-properties/bogus-prop/text()='bogus'">Value of property is not 'bogus'.</s:assert>
+               <s:assert test="not(c:document-properties/serialization)">There should be no property 'serialization'</s:assert>
+               <s:assert test="/c:document-properties/content-type='text/plain'">Property 'content-type' is not 'text/plain'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-string-replace-008.xml
+++ b/test-suite/tests/ab-string-replace-008.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
-      <t:title>uuid 008 (AB)</t:title>
+      <t:title>p:string-replace 008 (AB)</t:title>
       <t:revision-history>
          <t:revision>
             <t:date>2019-07-26</t:date>
@@ -8,32 +8,24 @@
                <t:name>Achim Berndzen</t:name>
             </t:author>
             <t:description xmlns="http://www.w3.org/1999/xhtml">
-               <p>Changed test: matching / is not an error anymore.</p>
-            </t:description>
-         </t:revision>
-         <t:revision>
-            <t:date>2019-06-16</t:date>
-            <t:author>
-               <t:name>Achim Berndzen</t:name>
-            </t:author>
-            <t:description xmlns="http://www.w3.org/1999/xhtml">
-               <p>Tests for p:uuid</p>
+               <p>New test matching /.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Testing p:uuid matching document root.</p>
+      <p>Tests p:string-replace</p>
    </t:description>
+   
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
          <p:output port="result"/>
-         
-         <p:uuid match="/">
+            
+         <p:string-replace match="/" replace="'text'">
             <p:with-input>
-               <doc>text</doc>
+               <doc />
             </p:with-input>
-         </p:uuid>
+         </p:string-replace>
          <p:wrap-sequence wrapper="result" />
       </p:declare-step>
    </t:pipeline>
@@ -41,8 +33,8 @@
       <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
-               <s:assert test="/result">Root element is not 'result'.</s:assert>
-               <s:assert test="string-length(normalize-space(/result/text()))!=0">Text child a element 'result' should not be an empty string.</s:assert>
+               <s:assert test="result">The document root is not 'result'.</s:assert>
+               <s:assert test="result/text()='text'">Result is not 'text'.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-string-replace-009.xml
+++ b/test-suite/tests/ab-string-replace-009.xml
@@ -1,0 +1,50 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>p:string-replace 009 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-07-26</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added test for matching /.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:string-replace</p>
+   </t:description>
+   
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+            
+         <p:string-replace match="/" replace="'text'">
+            <p:with-input>
+               <p:inline document-properties="map{'serialization':map{},
+                  'bonus-prop':'prop',
+                  'base-uri': 'http://base'}"><doc/></p:inline>
+            </p:with-input>
+         </p:string-replace>
+         <p:identity>
+            <p:with-input select="p:document-properties-document(.)" />
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:document-properties">Root element is not c:document-properties</s:assert>
+               <s:assert test="c:document-properties/base-uri/text()='http://base'">Base-uri properties is not 'http://base'.</s:assert>
+               <s:assert test="c:document-properties/bonus-prop/text()='prop'">Property 'bonus-prop' is not preserved.</s:assert>
+               <s:assert test="c:document-properties/content-type/text()='text/plain'">Content type is not 'text/plain'.</s:assert>
+               <s:assert test="not(c:document-properties/serialization)">There should be no element 'serialization'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-unwrap-007.xml
+++ b/test-suite/tests/ab-unwrap-007.xml
@@ -1,9 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
-   xmlns:err="http://www.w3.org/ns/xproc-error"
-   expected="fail" code="err:XC0023">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
       <t:title>p:unwrap 007 (AB)</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2019-07-26</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Changing the test: Matching / is not an error anymore.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2019-06-16</t:date>
             <t:author>
@@ -20,9 +27,8 @@
    </t:description>
    <t:input port='source'>
       <doc a="1">
-         <!-- comment -->
-         <?pi target ?>
-         Some text.</doc>
+         <element />
+      </doc>
    </t:input>
    
    <t:pipeline>
@@ -33,4 +39,15 @@
          <p:unwrap match="/" />
       </p:declare-step>
    </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="doc">Root element is not 'doc'.</s:assert>
+               <s:assert test="doc/@a">Root element does not have an @a.</s:assert>
+               <s:assert test="doc/element">Root element does not have child 'element'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
 </t:test>

--- a/test-suite/tests/ab-uuid-008a.xml
+++ b/test-suite/tests/ab-uuid-008a.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
    <t:info>
-      <t:title>uuid 008 (AB)</t:title>
+      <t:title>uuid 008a (AB)</t:title>
       <t:revision-history>
          <t:revision>
             <t:date>2019-07-26</t:date>
@@ -8,16 +8,7 @@
                <t:name>Achim Berndzen</t:name>
             </t:author>
             <t:description xmlns="http://www.w3.org/1999/xhtml">
-               <p>Changed test: matching / is not an error anymore.</p>
-            </t:description>
-         </t:revision>
-         <t:revision>
-            <t:date>2019-06-16</t:date>
-            <t:author>
-               <t:name>Achim Berndzen</t:name>
-            </t:author>
-            <t:description xmlns="http://www.w3.org/1999/xhtml">
-               <p>Tests for p:uuid</p>
+               <p>New test matching /.</p>
             </t:description>
          </t:revision>
       </t:revision-history>
@@ -31,18 +22,26 @@
          
          <p:uuid match="/">
             <p:with-input>
-               <doc>text</doc>
+               <p:inline document-properties="map{'serialization':map{},
+               'bonus-prop':'prop',
+               'base-uri': 'http://base'}"><doc/></p:inline>
             </p:with-input>
          </p:uuid>
-         <p:wrap-sequence wrapper="result" />
+         <p:identity>
+            <p:with-input select="p:document-properties-document(.)" />
+         </p:identity>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
       <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c" uri="http://www.w3.org/ns/xproc-step"/>
          <s:pattern>
             <s:rule context="/">
-               <s:assert test="/result">Root element is not 'result'.</s:assert>
-               <s:assert test="string-length(normalize-space(/result/text()))!=0">Text child a element 'result' should not be an empty string.</s:assert>
+               <s:assert test="c:document-properties">Root element is not c:document-properties</s:assert>
+               <s:assert test="c:document-properties/base-uri/text()='http://base'">Base-uri properties is not 'http://base'.</s:assert>
+               <s:assert test="c:document-properties/bonus-prop/text()='prop'">Property 'bonus-prop' is not preserved.</s:assert>
+               <s:assert test="c:document-properties/content-type/text()='text/plain'">Content type is not 'text/plain'.</s:assert>
+               <s:assert test="not(c:document-properties/serialization)">There should be no element 'serialization'.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>


### PR DESCRIPTION
Changed existing tests so match="/" is valid now. Added new tests to check result is changed to text document in relevant cases.