### PR TITLE
Three new tests on p:text-join

### DIFF
--- a/test-suite/tests/ab-text-join-013.xml
+++ b/test-suite/tests/ab-text-join-013.xml
@@ -1,0 +1,32 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+   xmlns:err="http://www.w3.org/ns/xproc-error" 
+   expected="fail" code="err:XC0001">
+   <t:info>
+      <t:title>p:text-join 013 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-07-26</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:text-join</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:text-join: @overwrite-content-type must be a text media type.</p>
+   </t:description>
+   
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+         <p:text-join suffix="Injected text." override-content-type="image/jpeg">
+            <p:with-input>
+               <p:inline content-type="text/plain">Text</p:inline>
+            </p:with-input>
+         </p:text-join>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-text-join-014.xml
+++ b/test-suite/tests/ab-text-join-014.xml
@@ -1,0 +1,32 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+   xmlns:err="http://www.w3.org/ns/xproc-error" 
+   expected="fail" code="err:XC0001">
+   <t:info>
+      <t:title>p:text-join 014 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-07-26</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:text-join</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:text-join: @overwrite-content-type must be a text media type.</p>
+   </t:description>
+   
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+         <p:text-join suffix="Injected text." override-content-type="text/xml">
+            <p:with-input>
+               <p:inline content-type="text/plain">Text</p:inline>
+            </p:with-input>
+         </p:text-join>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-text-join-015.xml
+++ b/test-suite/tests/ab-text-join-015.xml
@@ -1,0 +1,32 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+   xmlns:err="http://www.w3.org/ns/xproc-error" 
+   expected="fail" code="err:XC0001">
+   <t:info>
+      <t:title>p:text-join 015 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-07-26</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:text-join</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:text-join: @overwrite-content-type must be a text media type.</p>
+   </t:description>
+   
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+         <p:text-join suffix="Injected text." override-content-type="text/html">
+            <p:with-input>
+               <p:inline content-type="text/plain">Text</p:inline>
+            </p:with-input>
+         </p:text-join>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
Tests that overwrite-content-type is a text media type.