### PR TITLE
Remove ambiguity from XPath tests

### DIFF
--- a/test-suite/tests/ab-insert-001.xml
+++ b/test-suite/tests/ab-insert-001.xml
@@ -41,10 +41,10 @@
             <s:pattern>
                 <s:rule context="/">
                     <s:assert test="div">The document root is not 'div'.</s:assert>
-                    <s:assert test="div/p[1]/text()='New first paragraph.'">The text of the first p is not 'New first paragraph'.</s:assert>
-                    <s:assert test="div/p[2]/text()='First paragraph.'">The text of the second p is not 'First paragraph'.</s:assert>
-                    <s:assert test="div/p[3]/text()='Middle paragraph.'">The text of the third p is not 'Middle paragraph'.</s:assert>
-                    <s:assert test="div/p[4]/text()='Last paragraph.'">The text of the fourth p is not 'Last paragraph'.</s:assert>
+                    <s:assert test="child::div/p[1]/text()='New first paragraph.'">The text of the first p is not 'New first paragraph'.</s:assert>
+                    <s:assert test="child::div/p[2]/text()='First paragraph.'">The text of the second p is not 'First paragraph'.</s:assert>
+                    <s:assert test="child::div/p[3]/text()='Middle paragraph.'">The text of the third p is not 'Middle paragraph'.</s:assert>
+                    <s:assert test="child::div/p[4]/text()='Last paragraph.'">The text of the fourth p is not 'Last paragraph'.</s:assert>
                     <s:assert test="count(/div/p)=4">Root element does not have exactly four p-children.</s:assert>                    
                 </s:rule>
             </s:pattern>

--- a/test-suite/tests/ab-insert-002.xml
+++ b/test-suite/tests/ab-insert-002.xml
@@ -41,10 +41,10 @@
             <s:pattern>
                 <s:rule context="/">
                     <s:assert test="div">The document root is not 'div'.</s:assert>
-                    <s:assert test="div/p[1]/text()='First paragraph.'">The text of the first p is not 'First paragraph'.</s:assert>
-                    <s:assert test="div/p[2]/text()='Middle paragraph.'">The text of the second p is not 'Middle paragraph'.</s:assert>
-                    <s:assert test="div/p[3]/text()='Last paragraph.'">The text of the third p is not 'Last paragraph'.</s:assert>
-                    <s:assert test="div/p[4]/text()='New last paragraph.'">The text of the fourth p is not 'New last paragraph'.</s:assert>
+                    <s:assert test="child::div/p[1]/text()='First paragraph.'">The text of the first p is not 'First paragraph'.</s:assert>
+                    <s:assert test="child::div/p[2]/text()='Middle paragraph.'">The text of the second p is not 'Middle paragraph'.</s:assert>
+                    <s:assert test="child::div/p[3]/text()='Last paragraph.'">The text of the third p is not 'Last paragraph'.</s:assert>
+                    <s:assert test="child::div/p[4]/text()='New last paragraph.'">The text of the fourth p is not 'New last paragraph'.</s:assert>
                     <s:assert test="count(/div/p)=4">Root element does not have exactly four p-children.</s:assert>                    
                 </s:rule>
             </s:pattern>

--- a/test-suite/tests/ab-insert-003.xml
+++ b/test-suite/tests/ab-insert-003.xml
@@ -21,7 +21,7 @@
             
             <p:output port="result" />
             
-            <p:insert match="div/p[1]" position="before">
+            <p:insert match="child::div/p[1]" position="before">
                 <p:with-input port="source">
                     <div>
                         <p>First paragraph.</p>
@@ -41,10 +41,10 @@
             <s:pattern>
                 <s:rule context="/">
                     <s:assert test="div">The document root is not 'div'.</s:assert>
-                    <s:assert test="div/p[1]/text()='New before paragraph.'">The text of the first p is not 'New before paragraph'.</s:assert>
-                    <s:assert test="div/p[2]/text()='First paragraph.'">The text of the second p is not 'First paragraph'.</s:assert>
-                    <s:assert test="div/p[3]/text()='Middle paragraph.'">The text of the third p is not 'Middle paragraph'.</s:assert>
-                    <s:assert test="div/p[4]/text()='Last paragraph.'">The text of the fourth p is not 'Last paragraph'.</s:assert>
+                    <s:assert test="child::div/p[1]/text()='New before paragraph.'">The text of the first p is not 'New before paragraph'.</s:assert>
+                    <s:assert test="child::div/p[2]/text()='First paragraph.'">The text of the second p is not 'First paragraph'.</s:assert>
+                    <s:assert test="child::div/p[3]/text()='Middle paragraph.'">The text of the third p is not 'Middle paragraph'.</s:assert>
+                    <s:assert test="child::div/p[4]/text()='Last paragraph.'">The text of the fourth p is not 'Last paragraph'.</s:assert>
                     <s:assert test="count(/div/p)=4">Root element does not have exactly four p-children.</s:assert>                    
                 </s:rule>
             </s:pattern>

--- a/test-suite/tests/ab-insert-004.xml
+++ b/test-suite/tests/ab-insert-004.xml
@@ -21,7 +21,7 @@
             
             <p:output port="result" />
             
-            <p:insert match="div/p[3]" position="after">
+            <p:insert match="child::div/p[3]" position="after">
                 <p:with-input port="source">
                     <div>
                         <p>First paragraph.</p>
@@ -41,10 +41,10 @@
             <s:pattern>
                 <s:rule context="/">
                     <s:assert test="div">The document root is not 'div'.</s:assert>
-                    <s:assert test="div/p[1]/text()='First paragraph.'">The text of the first p is not 'First paragraph'.</s:assert>
-                    <s:assert test="div/p[2]/text()='Middle paragraph.'">The text of the second p is not 'Middle paragraph'.</s:assert>
-                    <s:assert test="div/p[3]/text()='Last paragraph.'">The text of the third p is not 'Last paragraph'.</s:assert>
-                    <s:assert test="div/p[4]/text()='New after paragraph.'">The text of the last p is not 'New after paragraph'.</s:assert>
+                    <s:assert test="child::div/p[1]/text()='First paragraph.'">The text of the first p is not 'First paragraph'.</s:assert>
+                    <s:assert test="child::div/p[2]/text()='Middle paragraph.'">The text of the second p is not 'Middle paragraph'.</s:assert>
+                    <s:assert test="child::div/p[3]/text()='Last paragraph.'">The text of the third p is not 'Last paragraph'.</s:assert>
+                    <s:assert test="child::div/p[4]/text()='New after paragraph.'">The text of the last p is not 'New after paragraph'.</s:assert>
                     <s:assert test="count(/div/p)=4">Root element does not have exactly four p-children.</s:assert>                    
                 </s:rule>
             </s:pattern>

--- a/test-suite/tests/ab-insert-026.xml
+++ b/test-suite/tests/ab-insert-026.xml
@@ -21,7 +21,7 @@
             
             <p:output port="result" />
             
-            <p:insert match="div/p[3]">
+            <p:insert match="child::div/p[3]">
                 <p:with-input port="source">
                     <div>
                         <p>First paragraph.</p>
@@ -41,10 +41,10 @@
             <s:pattern>
                 <s:rule context="/">
                     <s:assert test="div">The document root is not 'div'.</s:assert>
-                    <s:assert test="div/p[1]/text()='First paragraph.'">The text of the first p is not 'First paragraph'.</s:assert>
-                    <s:assert test="div/p[2]/text()='Middle paragraph.'">The text of the second p is not 'Middle paragraph'.</s:assert>
-                    <s:assert test="div/p[3]/text()='Last paragraph.'">The text of the third p is not 'Last paragraph'.</s:assert>
-                    <s:assert test="div/p[4]/text()='New after paragraph.'">The text of the last p is not 'New after paragraph'.</s:assert>
+                    <s:assert test="child::div/p[1]/text()='First paragraph.'">The text of the first p is not 'First paragraph'.</s:assert>
+                    <s:assert test="child::div/p[2]/text()='Middle paragraph.'">The text of the second p is not 'Middle paragraph'.</s:assert>
+                    <s:assert test="child::div/p[3]/text()='Last paragraph.'">The text of the third p is not 'Last paragraph'.</s:assert>
+                    <s:assert test="child::div/p[4]/text()='New after paragraph.'">The text of the last p is not 'New after paragraph'.</s:assert>
                     <s:assert test="count(/div/p)=4">Root element does not have exactly four p-children.</s:assert>                    
                 </s:rule>
             </s:pattern>


### PR DESCRIPTION
The latest Saxon observes that `div/` is ambiguous in that it might be a `child::div` or it might be an attempt to use the `div` operator. I amended the XPath expressions to make it explicit in order to get Saxon to shut up.