### PR TITLE
Added xerces dependency explicitly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.3.5'
     classpath group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.22-98'
     classpath group: 'org.xmlresolver', name: 'xmlresolver', version: '0.13.2'
+    classpath group: 'xerces', name: 'xerces', version: '2.2.1'
   }
 }
 


### PR DESCRIPTION
My build would sometimes fail saying it couldn't find one of the Xerces parser classes. I have no idea why it was sporadic. This seems to fix it.
