### PR TITLE
Added @features for xslt 2.0

### DIFF
--- a/test-suite/tests/nw-xslt-001.xml
+++ b/test-suite/tests/nw-xslt-001.xml
@@ -1,7 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" features="xslt-2">
   <t:info>
     <t:title>nw-xslt-001</t:title>
     <t:revision-history>
+      <t:revision>
+        <t:date>2019-08-03</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Added @features xslt-2</p>
+        </t:description>
+      </t:revision>
       <t:revision>
         <t:date>2019-07-20</t:date>
         <t:author initials="ndw">

--- a/test-suite/tests/nw-xslt-002.xml
+++ b/test-suite/tests/nw-xslt-002.xml
@@ -1,7 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" features="xslt-2">
   <t:info>
     <t:title>nw-xslt-002</t:title>
     <t:revision-history>
+      <t:revision>
+        <t:date>2019-08-03</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Added @features xslt-2</p>
+        </t:description>
+      </t:revision>
       <t:revision>
         <t:date>2019-07-20</t:date>
         <t:author initials="ndw">


### PR DESCRIPTION
Changed two tests for p:xslt because they only run if an xslt 2.0 processor is used. I added
@features="xslt-2" to mark this.
Tests with version="3.0" should have @features="xslt-3"
Tests with version="1.0" should have @features="xslt-1"
