### PR TITLE
Fixed three tests

### DIFF
--- a/test-suite/tests/ab-with-input-select-011.xml
+++ b/test-suite/tests/ab-with-input-select-011.xml
@@ -3,6 +3,15 @@
       <t:title>with-input-select-011</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-08-04</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Changed test again: Result of select="p:document-property..." is a JSON documents too.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-07-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -35,9 +44,11 @@
                </p:with-input>
             </p:identity>
             
-            <p:wrap-sequence wrapper="result">
-               <p:with-input select="p:document-property(., 'content-type')" />
-            </p:wrap-sequence>
+            <p:identity>
+               <p:with-input>
+                  <result>{p:document-property(., 'content-type')}</result>
+               </p:with-input>
+            </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-with-input-select-012.xml
+++ b/test-suite/tests/ab-with-input-select-012.xml
@@ -3,6 +3,15 @@
       <t:title>with-input-select-012</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-08-04</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Changed test: Result of select="p:document-property..." is a JSON documents too.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-01-12</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -26,9 +35,11 @@
                </p:with-input>
             </p:identity>
             
-            <p:wrap-sequence wrapper="result">
-               <p:with-input select="p:document-property(., 'content-type')" />
-            </p:wrap-sequence>
+            <p:identity>
+               <p:with-input>
+                  <result>{p:document-property(., 'content-type')}</result>
+               </p:with-input>
+            </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-with-input-select-013.xml
+++ b/test-suite/tests/ab-with-input-select-013.xml
@@ -3,6 +3,15 @@
       <t:title>with-input-select-013</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-08-04</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Changed test: Result of select="p:document-property..." is a JSON documents too.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-01-12</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -26,9 +35,11 @@
                </p:with-input>
             </p:identity>
             
-            <p:wrap-sequence wrapper="result">
-               <p:with-input select="p:document-property(., 'content-type')" />
-            </p:wrap-sequence>
+            <p:identity>
+               <p:with-input>
+                  <result>{p:document-property(., 'content-type')}</result>
+               </p:with-input>
+            </p:identity>
         </p:declare-step>
    </t:pipeline>
    <t:schematron>


### PR DESCRIPTION
Changed p:wrap-sequence to p:identity, because 
````
 <p:with-input select="p:document-property(., 'content-type')" />
````
is a JSON document (atomic value!) now, which is not accepted by p:wrap-sequence.