### PR TITLE
Two changed, one new on p:xslt

### DIFF
--- a/test-suite/tests/ab-xslt-026.xml
+++ b/test-suite/tests/ab-xslt-026.xml
@@ -1,9 +1,18 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XC0056" features="xslt-3">
+        expected="fail" code="err:XC0008" features="xslt-3">
    <t:info>
       <t:title>AB-xslt-026</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2019-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Chnaged error code according to spec changes.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2019-08-04</t:date>
             <t:author>

--- a/test-suite/tests/ab-xslt-051.xml
+++ b/test-suite/tests/ab-xslt-051.xml
@@ -1,7 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" features="xslt-3">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" features="xslt-3 xslt-serialization">
    <t:info>
       <t:title>AB-xslt-051</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2019-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added feature xslt-serialization to test.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2019-08-04</t:date>
             <t:author>

--- a/test-suite/tests/ab-xslt-052.xml
+++ b/test-suite/tests/ab-xslt-052.xml
@@ -1,0 +1,78 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" features="xslt-3">
+   <t:info>
+      <t:title>AB-xslt-052</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2019-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added feature xslt-serialization to test.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
+            <t:date>2019-08-04</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that stylesheet's uri is used as output base-uri if no other is found. (3.0)</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+         <p:xslt version="3.0" template-name="start">
+            <p:with-input port="source">
+               <p:empty />
+            </p:with-input>
+            <p:with-input port="stylesheet">
+               <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xml:base="http://xproc-test/doc.xml">
+                  <xsl:output method="xml" indent="true" encoding="UTF-8"/>
+                  <xsl:template name="start">
+                     <doc />
+                     <xsl:result-document href="doc1.xml" >
+                        <doc1 />
+                     </xsl:result-document>
+                  </xsl:template>
+               </xsl:stylesheet>
+            </p:with-input>
+         </p:xslt>
+         
+         <p:variable name="uri1" select="base-uri(.)" />
+         <p:variable name="uri2" select="base-uri(.)" pipe="secondary" />
+         <p:variable name="prop-uri1" select="p:document-property(.,'base-uri')" />
+         <p:variable name="prop-uri2" select="p:document-property(.,'base-uri')" pipe="secondary"/>
+         
+         <p:identity>
+            <p:with-input>
+               <result>
+                  <primary-uri>{$uri1}</primary-uri>
+                  <secondary-uri>{$uri2}</secondary-uri>
+                  <primary-docprop>{$prop-uri1}</primary-docprop>
+                  <secondary-docprop>{$prop-uri2}</secondary-docprop>
+               </result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not 'result'.</s:assert>
+               <s:assert test="result/primary-uri/text()='http://xproc-test/doc.xml'">URI is not 'http://xproc-test/doc.xml'.</s:assert>
+               <s:assert test="result/secondary-uri/text()='http://xproc-test/doc1.xml'">URI is not 'http://xproc-test/doc1.xml'.</s:assert>
+               <s:assert test="result/primary-docprop/text()='http://xproc-test/doc.xml'">URI is not 'http://xproc-test/doc.xml'.</s:assert>
+               <s:assert test="result/secondary-docprop/text()='http://xproc-test/doc1.xml'">URI is not 'http://xproc-test/doc1.xml'.</s:assert>               
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
1. Changed error code according to previous pull request.
2. Added feature "xslt-serialization" to test
3. New test: No output-base-uri, no doc on source -> base URI of stylesheet is used.