### PR TITLE
Two additional tests for feature in p:valiadate-with-releax-ng

### DIFF
--- a/test-suite/tests/ab-validate-with-relax-ng-015.xml
+++ b/test-suite/tests/ab-validate-with-relax-ng-015.xml
@@ -1,0 +1,53 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XC0053" features="p-validate-with-relax-ng dtd-id-ref-warning">
+  <t:info>
+    <t:title>ab-validate-with-relax-ng-015</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2019-08-06</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Initial publication</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Testing dtd-id-idref-warnings: set to true, source not valid.</p>
+  </t:description>
+  <t:pipeline>
+<p:declare-step name="pipeline" xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+  <p:output port="result"/>
+  <p:validate-with-relax-ng dtd-id-idref-warnings="true">
+    <p:with-input port="source">
+      <doc>
+        <title>Title</title>
+        <p>Some paragraph.</p>
+        <p idref="foo">Some other paragraph</p>
+      </doc>
+    </p:with-input>
+    <p:with-input port="schema">
+      <p:inline content-type="text/plain" expand-text="false">
+        namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
+        
+        element doc {
+        element title {
+        [ a:defaultValue="en-us" ]
+        attribute language { text }?,
+        text
+        }?,
+        element p {
+        attribute id { xsd:ID }?,
+        attribute idref { xsd:IDREF }?,
+        text
+        }*
+        }
+      </p:inline>
+    </p:with-input>
+  </p:validate-with-relax-ng>
+</p:declare-step>
+</t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-validate-with-relax-ng-016.xml
+++ b/test-suite/tests/ab-validate-with-relax-ng-016.xml
@@ -1,0 +1,64 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass" 
+  features="p-validate-with-relax-ng dtd-id-ref-warning">
+  <t:info>
+    <t:title>ab-validate-with-relax-ng-016</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2019-08-06</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Initial publication</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Testing dtd-id-idref-warnings: set to true, source is valid.</p>
+  </t:description>
+  <t:pipeline>
+<p:declare-step name="pipeline" xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+  <p:output port="result"/>
+  <p:validate-with-relax-ng dtd-id-idref-warnings="true">
+    <p:with-input port="source">
+      <doc>
+        <title>Title</title>
+        <p id="foo">Some paragraph.</p>
+        <p idref="foo">Some other paragraph</p>
+      </doc>
+    </p:with-input>
+    <p:with-input port="schema">
+      <p:inline content-type="text/plain" expand-text="false">
+        namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
+        
+        element doc {
+        element title {
+        [ a:defaultValue="en-us" ]
+        attribute language { text }?,
+        text
+        }?,
+        element p {
+        attribute id { xsd:ID }?,
+        attribute idref { xsd:IDREF }?,
+        text
+        }*
+        }
+      </p:inline>
+    </p:with-input>
+  </p:validate-with-relax-ng>
+</p:declare-step>
+</t:pipeline>
+  
+  <t:schematron>
+    <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="doc">The element root is not “doc”.</s:assert>
+          <s:assert test="doc/title">The element root does not have a child 'title'.</s:assert>
+          <s:assert test="doc/p">Element root does not have child 'p'.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>


### PR DESCRIPTION
@ndw These test introduce feature label "dtd-id-ref-warning" to mark that they require a processor implementing this optional feature.

I think we should find a way to mark feature labels, so we use the same. A wiki page?