### PR TITLE
Fixed nw-viewport-tests

### DIFF
--- a/test-suite/tests/nw-viewport-001.xml
+++ b/test-suite/tests/nw-viewport-001.xml
@@ -3,6 +3,15 @@
     <t:title>Viewport 001</t:title>
     <t:revision-history>
       <t:revision>
+        <t:date>2019-09-07</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Fix test so it fails if there is no ex:p.</p>
+        </t:description>
+      </t:revision>
+      <t:revision>
         <t:date>2019-07-08</t:date>
         <t:author initials="ndw">
           <t:name>Norman Walsh</t:name>
@@ -33,8 +42,9 @@
       <s:pattern>
         <s:rule context="/">
           <s:assert test="ex:doc">The pipeline root is not “doc”.</s:assert>
+          <s:assert test="count(ex:doc//ex:p)=2">The pipeline root does not have two descendants "ex:p".</s:assert>
         </s:rule>
-        <s:rule context="p">
+        <s:rule context="ex:p">
           <s:assert test=".[@v='true']">The ‘p’ elements don’t have the correct ‘v’ attributes.</s:assert>
         </s:rule>
         <s:rule context="*[not(self::ex:p)]">

--- a/test-suite/tests/nw-viewport-002.xml
+++ b/test-suite/tests/nw-viewport-002.xml
@@ -3,6 +3,15 @@
     <t:title>Viewport 002</t:title>
     <t:revision-history>
       <t:revision>
+        <t:date>2019-09-07</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Fix test so it fails if there is no ex:p.</p>
+        </t:description>
+      </t:revision>
+      <t:revision>
         <t:date>2019-07-08</t:date>
         <t:author initials="ndw">
           <t:name>Norman Walsh</t:name>
@@ -33,8 +42,9 @@
       <s:pattern>
         <s:rule context="/">
           <s:assert test="ex:doc">The pipeline root is not “doc”.</s:assert>
+          <s:assert test="count(ex:doc//ex:p)=2">The pipeline root does not have two descendants "ex:p".</s:assert>
         </s:rule>
-        <s:rule context="p">
+        <s:rule context="ex:p">
           <s:assert test=".[@v='true']">The ‘p’ elements don’t have the correct ‘v’ attributes.</s:assert>
         </s:rule>
         <s:rule context="*[not(self::ex:p)]">

--- a/test-suite/tests/nw-viewport-003.xml
+++ b/test-suite/tests/nw-viewport-003.xml
@@ -3,6 +3,15 @@
     <t:title>Viewport 003</t:title>
     <t:revision-history>
       <t:revision>
+        <t:date>2019-09-07</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Fix test so it fails if there is no ex:p.</p>
+        </t:description>
+      </t:revision>
+      <t:revision>
         <t:date>2019-07-08</t:date>
         <t:author initials="ndw">
           <t:name>Norman Walsh</t:name>
@@ -37,8 +46,9 @@
       <s:pattern>
         <s:rule context="/">
           <s:assert test="ex:doc">The pipeline root is not “doc”.</s:assert>
+          <s:assert test="count(ex:doc//ex:p)=2">The pipeline root does not have two descendants "ex:p".</s:assert>
         </s:rule>
-        <s:rule context="p">
+        <s:rule context="ex:p">
           <s:assert test=".[@v='true']">The ‘p’ elements don’t have the correct ‘v’ attributes.</s:assert>
         </s:rule>
         <s:rule context="*[not(self::ex:p)]">

--- a/test-suite/tests/nw-viewport-004.xml
+++ b/test-suite/tests/nw-viewport-004.xml
@@ -3,6 +3,15 @@
     <t:title>Viewport 004</t:title>
     <t:revision-history>
       <t:revision>
+        <t:date>2019-09-07</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Fix test so it fails if there is no ex:p.</p>
+        </t:description>
+      </t:revision>
+      <t:revision>
         <t:date>2019-07-08</t:date>
         <t:author initials="ndw">
           <t:name>Norman Walsh</t:name>
@@ -37,8 +46,9 @@
       <s:pattern>
         <s:rule context="/">
           <s:assert test="ex:doc">The pipeline root is not “doc”.</s:assert>
+          <s:assert test="count(ex:doc//ex:p)=2">The pipeline root does not have two descendants "ex:p".</s:assert>
         </s:rule>
-        <s:rule context="p">
+        <s:rule context="ex:p">
           <s:assert test=".[@v='true']">The ‘p’ elements don’t have the correct ‘v’ attributes.</s:assert>
         </s:rule>
         <s:rule context="*[not(self::ex:p)]">


### PR DESCRIPTION
Fixed four tests so they fail if there is no ex:p and no element having an attribute v.