### PR TITLE
Fix #322 with an extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ buildscript {
   }
 
   dependencies {
-    classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.3.5'
-    classpath group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.22-98'
+    classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.3.6'
+    classpath group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.30-98'
     classpath group: 'org.xmlresolver', name: 'xmlresolver', version: '0.13.2'
     classpath group: 'xerces', name: 'xerces', version: '2.2.1'
   }
@@ -118,6 +118,7 @@ task test_index_setup(dependsOn: ["process_all_tests","git_log_shorter","get_spe
   inputs.file "tools/xsl/merge-git-log.xsl"
   output("result", "build/indexing.xml")
   extensionValues true
+  ignoreInvalidXmlBase true
   option("spec-dir", "build/specs")
   pipeline "tools/xpl/test-index-setup.xpl"
   doFirst {


### PR DESCRIPTION
Updated XML Calabash and the gradle extension to support a new option to allow invalid base URIs to slip through.
