### PR TITLE
Proposed changes for json-merge tests

### DIFF
--- a/test-suite/tests/ab-json-merge-017.xml
+++ b/test-suite/tests/ab-json-merge-017.xml
@@ -41,11 +41,11 @@
                <s:assert test="map:map">The document node is not 'map:map'.</s:assert>
                <s:assert test="count(map:map/*)=5">Element 'map:map' does not have five children.</s:assert>
                <s:assert test="count(map:map/map:string)=5">Element 'map:map' does not have five children 'map:string'.</s:assert>
-               <s:assert test="map:map/map:string[1]/@key = 'label-1'">The first entry does not have @key 'label-1'.</s:assert>
-               <s:assert test="map:map/map:string[2]/@key = 'key1'">The second entry does not have @key 'lkey1'.</s:assert>
-               <s:assert test="map:map/map:string[3]/@key = 'label-3'">The third entry does not have @key 'label-3'.</s:assert>
-               <s:assert test="map:map/map:string[4]/@key = 'key2'">The forth entry does not have @key 'key2'.</s:assert>
-               <s:assert test="map:map/map:string[5]/@key = 'label-5'">The fifth entry does not have @key 'label-5'.</s:assert>
+               <s:assert test="map:map/map:string[@key='label-1']='one'">The ‘one’ entry does not have @key 'label-1'.</s:assert>
+               <s:assert test="map:map/map:string[@key='key1']='value1'">The ‘value1’ entry does not have @key 'key1'.</s:assert>
+               <s:assert test="map:map/map:string[@key='label-3']='two'">The ‘two’ entry does not have @key 'label-3'.</s:assert>
+               <s:assert test="map:map/map:string[@key='key2']='value2'">The ‘value2’ entry does not have @key 'key2'.</s:assert>
+               <s:assert test="map:map/map:string[@key='label-5']='three'">The ‘three’ entry does not have @key 'label-5'.</s:assert>
              </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-json-merge-018.xml
+++ b/test-suite/tests/ab-json-merge-018.xml
@@ -48,7 +48,6 @@
    </t:pipeline>
    <t:schematron>
       <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
-        <s:ns prefix="h" uri="http://www.w3.org/1999/xhtml"/>
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The document node is not 'result'.</s:assert>
@@ -57,7 +56,7 @@
                <s:assert test="result/second/two='2'">Entry 'second/two' is not '2'.</s:assert>
                <s:assert test="result/third ='This is a text document.'">Entry for 'third' is not 'This is a text document.'</s:assert>
                <s:assert test="result/forth/xml">Entry for 'forth' is not an element 'xml'.</s:assert>
-               <s:assert test="result/fifth/h:html">Entry for 'fifth' is not an element 'html'.</s:assert>               
+               <s:assert test="result/fifth/*:html">Entry for 'fifth' is not an element 'html'.</s:assert>               
              </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-json-merge-018.xml
+++ b/test-suite/tests/ab-json-merge-018.xml
@@ -48,6 +48,7 @@
    </t:pipeline>
    <t:schematron>
       <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
+        <s:ns prefix="h" uri="http://www.w3.org/1999/xhtml"/>
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The document node is not 'result'.</s:assert>
@@ -56,7 +57,7 @@
                <s:assert test="result/second/two='2'">Entry 'second/two' is not '2'.</s:assert>
                <s:assert test="result/third ='This is a text document.'">Entry for 'third' is not 'This is a text document.'</s:assert>
                <s:assert test="result/forth/xml">Entry for 'forth' is not an element 'xml'.</s:assert>
-               <s:assert test="result/fifth/html">Entry for 'fifth' is not an element 'html'.</s:assert>               
+               <s:assert test="result/fifth/h:html">Entry for 'fifth' is not an element 'html'.</s:assert>               
              </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-json-merge-019.xml
+++ b/test-suite/tests/ab-json-merge-019.xml
@@ -70,7 +70,7 @@
             <s:rule context="/fn:map/*[5]">
                <s:assert test="local-name(.)='string'">Local name of child element 5 is not 'string'.</s:assert>
                <s:assert test="./@key='label-5'">Child element 5 does not have @key with 'label-5'.</s:assert>
-               <s:assert test="./text()='&lt;html/&gt;'">Child element 5 does not have text child with '&lt;html/&gt;'.</s:assert>
+               <s:assert test="starts-with(./text(), '&lt;html')">Child element 5 does not have text child with '&lt;html/&gt;'.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>


### PR DESCRIPTION
The first patch fixes #338 

In tests 18 and 19, the test checks for an "html" element in no-namespace after parsing as text/html. I don't believe that is possible. I believe our HTML5 story is that we always produce html elements in the (X)HTML namespace.
