### PR TITLE
Fix errors in the result validation

### DIFF
--- a/test-suite/tests/ab-namespace-delete-001.xml
+++ b/test-suite/tests/ab-namespace-delete-001.xml
@@ -42,7 +42,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="/doc">The document root is not 'doc'.</s:assert>
-               <s:assert test="count(/doc/section)='2'">Element doc does not have two children 'section'.</s:assert>
+               <s:assert test="count(/doc/section)=2">Element doc does not have two children 'section'.</s:assert>
             </s:rule>
             <s:rule context="/doc/section">
                <s:assert test="./@id">Section does not have an attribute 'id'.</s:assert>

--- a/test-suite/tests/ab-namespace-delete-002.xml
+++ b/test-suite/tests/ab-namespace-delete-002.xml
@@ -42,7 +42,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="/doc">The document root is not 'doc'.</s:assert>
-               <s:assert test="count(/doc/section)='2'">Element doc does not have two children 'section'.</s:assert>
+               <s:assert test="count(/doc/section)=2">Element doc does not have two children 'section'.</s:assert>
             </s:rule>
             <s:rule context="/doc/section">
                <s:assert test="./@id">Section does not have an attribute 'id'.</s:assert>

--- a/test-suite/tests/ab-namespace-delete-003.xml
+++ b/test-suite/tests/ab-namespace-delete-003.xml
@@ -43,7 +43,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="/doc">The document root is not 'doc'.</s:assert>
-               <s:assert test="count(/doc/section)='2'">Element doc does not have two children 'section'.</s:assert>
+               <s:assert test="count(/doc/section)=2">Element doc does not have two children 'section'.</s:assert>
             </s:rule>
             <s:rule context="/doc/section">
                <s:assert test="./@other:id">Section does not have an attribute 'id'.</s:assert>

--- a/test-suite/tests/ab-namespace-delete-004.xml
+++ b/test-suite/tests/ab-namespace-delete-004.xml
@@ -43,7 +43,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="/doc">The document root is not 'doc'.</s:assert>
-               <s:assert test="count(/doc/section)='2'">Element doc does not have two children 'section'.</s:assert>
+               <s:assert test="count(/doc/section)=2">Element doc does not have two children 'section'.</s:assert>
             </s:rule>
             <s:rule context="/doc/section">
                <s:assert test="./@other:id">Section does not have an attribute 'id'.</s:assert>

--- a/test-suite/tests/ab-namespace-delete-005.xml
+++ b/test-suite/tests/ab-namespace-delete-005.xml
@@ -43,7 +43,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="/dummy:doc">The document root is not 'doc'.</s:assert>
-               <s:assert test="count(/dummy:doc/dummy:section)='2'">Element doc does not have two children 'section'.</s:assert>
+               <s:assert test="count(/dummy:doc/dummy:section)=2">Element doc does not have two children 'section'.</s:assert>
             </s:rule>
             <s:rule context="/dummy:doc/dummy:section">
                <s:assert test="./@dummy:id">Section does not have an attribute 'id'.</s:assert>

--- a/test-suite/tests/ab-namespace-delete-006.xml
+++ b/test-suite/tests/ab-namespace-delete-006.xml
@@ -42,7 +42,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="/doc">The document root is not 'doc'.</s:assert>
-               <s:assert test="count(/doc/section)='2'">Element doc does not have two children 'section'.</s:assert>
+               <s:assert test="count(/doc/section)=2">Element doc does not have two children 'section'.</s:assert>
             </s:rule>
             <s:rule context="/doc/section">
                <s:assert test="./@id">Section does not have an attribute 'id'.</s:assert>

--- a/test-suite/tests/ab-namespace-delete-007.xml
+++ b/test-suite/tests/ab-namespace-delete-007.xml
@@ -42,7 +42,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="/doc">The document root is not 'doc'.</s:assert>
-               <s:assert test="count(/doc/section)='2'">Element doc does not have two children 'section'.</s:assert>
+               <s:assert test="count(/doc/section)=2">Element doc does not have two children 'section'.</s:assert>
             </s:rule>
             <s:rule context="/doc/section">
                <s:assert test="./@id">Section does not have an attribute 'id'.</s:assert>


### PR DESCRIPTION
There are a bunch of number/string comparisons. I'm not sure why they work  for you, but I believe they are incorrect.
