### PR TITLE
Changes archive related steps to latest development

### DIFF
--- a/test-suite/tests/ab-p-archive-001.xml
+++ b/test-suite/tests/ab-p-archive-001.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 001 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -39,7 +48,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
          
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-002.xml
+++ b/test-suite/tests/ab-p-archive-002.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 002 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-003.xml
+++ b/test-suite/tests/ab-p-archive-003.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 003 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-004.xml
+++ b/test-suite/tests/ab-p-archive-004.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 004 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-005.xml
+++ b/test-suite/tests/ab-p-archive-005.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 005 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+         <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-007.xml
+++ b/test-suite/tests/ab-p-archive-007.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 007 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-008.xml
+++ b/test-suite/tests/ab-p-archive-008.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 008 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,7 +36,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-009.xml
+++ b/test-suite/tests/ab-p-archive-009.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 009 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -39,7 +48,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
          
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-010.xml
+++ b/test-suite/tests/ab-p-archive-010.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 010 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-011.xml
+++ b/test-suite/tests/ab-p-archive-011.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 011 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-012.xml
+++ b/test-suite/tests/ab-p-archive-012.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 012 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-013.xml
+++ b/test-suite/tests/ab-p-archive-013.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 013 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-015.xml
+++ b/test-suite/tests/ab-p-archive-015.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 015 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-016.xml
+++ b/test-suite/tests/ab-p-archive-016.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 016 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,7 +36,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-017.xml
+++ b/test-suite/tests/ab-p-archive-017.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 017 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -39,7 +48,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
          
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-018.xml
+++ b/test-suite/tests/ab-p-archive-018.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 018 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-019.xml
+++ b/test-suite/tests/ab-p-archive-019.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 019 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-020.xml
+++ b/test-suite/tests/ab-p-archive-020.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 020 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-021.xml
+++ b/test-suite/tests/ab-p-archive-021.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 021 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-022.xml
+++ b/test-suite/tests/ab-p-archive-022.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 022 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-023.xml
+++ b/test-suite/tests/ab-p-archive-023.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 023 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -39,7 +48,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
          
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-024.xml
+++ b/test-suite/tests/ab-p-archive-024.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 024 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-025.xml
+++ b/test-suite/tests/ab-p-archive-025.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 025 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-026.xml
+++ b/test-suite/tests/ab-p-archive-026.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 026 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-027.xml
+++ b/test-suite/tests/ab-p-archive-027.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 027 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-028.xml
+++ b/test-suite/tests/ab-p-archive-028.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 028 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-029.xml
+++ b/test-suite/tests/ab-p-archive-029.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 029 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -39,7 +48,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
          
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-030.xml
+++ b/test-suite/tests/ab-p-archive-030.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 030 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-031.xml
+++ b/test-suite/tests/ab-p-archive-031.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 031 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
                <p:with-input port="archive"><p:empty /></p:with-input>
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-032.xml
+++ b/test-suite/tests/ab-p-archive-032.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 032 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -41,7 +50,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-033.xml
+++ b/test-suite/tests/ab-p-archive-033.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 033 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -41,7 +50,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-034.xml
+++ b/test-suite/tests/ab-p-archive-034.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 034 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -41,7 +50,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-035.xml
+++ b/test-suite/tests/ab-p-archive-035.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 035 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -41,7 +50,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-036.xml
+++ b/test-suite/tests/ab-p-archive-036.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 036 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -44,7 +53,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-039.xml
+++ b/test-suite/tests/ab-p-archive-039.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 039 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -44,7 +53,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-040.xml
+++ b/test-suite/tests/ab-p-archive-040.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 040 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -44,7 +53,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-041.xml
+++ b/test-suite/tests/ab-p-archive-041.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 041 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -44,7 +53,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-042.xml
+++ b/test-suite/tests/ab-p-archive-042.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 042 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -44,7 +53,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-043.xml
+++ b/test-suite/tests/ab-p-archive-043.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 043 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -44,7 +53,7 @@
                <p:with-input port="archive" pipe="result" />
             </p:archive>
  
-            <p:archive-manifest />
+            <p:archive-manifest  relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-p-archive-044.xml
+++ b/test-suite/tests/ab-p-archive-044.xml
@@ -3,6 +3,15 @@
       <t:title>p:archive 044 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-09-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -42,7 +51,7 @@
                </p:with-input>
                <p:with-input port="archive"><p:empty/></p:with-input>
             </p:archive>
-            <p:archive-manifest />
+            <p:archive-manifest relative-to="http://xproc.org/ns/testsuite"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-unarchive-018.xml
+++ b/test-suite/tests/ab-unarchive-018.xml
@@ -5,6 +5,15 @@
       <t:title>p:unarchive 018 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2019-12-21</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added option "relative-to" to p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-11-24</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -29,7 +38,7 @@
             </p:with-input>
          </p:archive>
         
-         <p:unarchive />
+         <p:unarchive relative-to="%gg"/>
       </p:declare-step>
    </t:pipeline>
 </t:test>


### PR DESCRIPTION
All tests now have a `relative-to" option, so XC0120 (no base URI, no value for `relative-to`) is guaranteed not to be raised. 