### PR TITLE
Fixed schematron tests

### DIFF
--- a/test-suite/tests/ab-validate-with-schematron-011.xml
+++ b/test-suite/tests/ab-validate-with-schematron-011.xml
@@ -4,6 +4,15 @@
     <t:title>ab-validate-with-schematron-011</t:title>
     <t:revision-history>
       <t:revision>
+        <t:date>2020-01-03</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Added explicit request for xvrl because svrl is default now.</p>
+        </t:description>
+      </t:revision>
+      <t:revision>
         <t:date>2019-08-18</t:date>
         <t:author>
           <t:name>Achim Berndzen</t:name>
@@ -21,7 +30,7 @@
 <p:declare-step name="pipeline" xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
   <p:output port="result"/>
   
-  <p:validate-with-schematron assert-valid="false">
+  <p:validate-with-schematron assert-valid="false" report-format="xvrl">
     <p:with-input port="source" href="../documents/docbook-invalid.xml" />
     <p:with-input port="schema" href="../documents/docbook.sch" />
   </p:validate-with-schematron>

--- a/test-suite/tests/ab-validate-with-schematron-012.xml
+++ b/test-suite/tests/ab-validate-with-schematron-012.xml
@@ -4,6 +4,15 @@
     <t:title>ab-validate-with-schematron-012</t:title>
     <t:revision-history>
       <t:revision>
+        <t:date>2020-01-03</t:date>
+        <t:author>
+          <t:name>Achim Berndzen</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Added explicit request for xvrl because svrl is default now.</p>
+        </t:description>
+      </t:revision>
+      <t:revision>
         <t:date>2019-08-18</t:date>
         <t:author>
           <t:name>Achim Berndzen</t:name>
@@ -21,7 +30,7 @@
 <p:declare-step name="pipeline" xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
   <p:output port="result"/>
   
-  <p:validate-with-schematron phase="full" assert-valid="false">
+  <p:validate-with-schematron phase="full" assert-valid="false" report-format="xvrl">
     <p:with-input port="source" href="../documents/docbook-invalid.xml" />
     <p:with-input port="schema" href="../documents/docbook-phases.sch" />
   </p:validate-with-schematron>

--- a/test-suite/tests/ab-validate-with-schematron-013.xml
+++ b/test-suite/tests/ab-validate-with-schematron-013.xml
@@ -3,6 +3,15 @@
   <t:info>
     <t:title>ab-validate-with-schematron-013</t:title>
     <t:revision-history>
+        <t:revision>
+          <t:date>2020-01-03</t:date>
+          <t:author>
+            <t:name>Achim Berndzen</t:name>
+          </t:author>
+          <t:description xmlns="http://www.w3.org/1999/xhtml">
+            <p>Added explicit request for xvrl because svrl is default now.</p>
+          </t:description>
+        </t:revision>
       <t:revision>
         <t:date>2019-08-18</t:date>
         <t:author>
@@ -21,7 +30,7 @@
 <p:declare-step name="pipeline" xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
   <p:output port="result"/>
   <p:try>
-    <p:validate-with-schematron >
+    <p:validate-with-schematron report-format='xvrl'>
       <p:with-input port="source" href="../documents/docbook-invalid.xml" />
       <p:with-input port="schema" href="../documents/docbook.sch" />
     </p:validate-with-schematron>


### PR DESCRIPTION
Changed tests by explicitly requesting XVRL as SVRL is now default for p:validate-with-schematron.