### PR TITLE
Fix http 76

### DIFF
--- a/test-suite/tests/ab-http-request-076.xml
+++ b/test-suite/tests/ab-http-request-076.xml
@@ -5,6 +5,15 @@
       <t:title>http-request-076 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2020-03-19</t:date>
+            <t:author>
+               <t:name>Norman Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Corrected key name.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-14</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>

--- a/test-suite/tests/ab-http-request-076.xml
+++ b/test-suite/tests/ab-http-request-076.xml
@@ -23,7 +23,7 @@
          <p:output port="result" />
          
          <p:http-request href="http://tests.xproc.org/service/echo" method="post"
-            auth="map{'preemptive-auth' : 89}">
+            auth="map{'send-authorization' : 89}">
             <p:with-input>
                <p:inline><doc /></p:inline>
             </p:with-input>


### PR DESCRIPTION
The name of the 'send-authorization' key was out-of-date. We must have called it 'preemptive-auth' in som earlier version. Fixed.

(I don't think this can be controversial, so I'm just going to merge it.)