### PR TITLE
Fix ab-xslt-037

### DIFF
--- a/test-suite/tests/ab-xslt-037.xml
+++ b/test-suite/tests/ab-xslt-037.xml
@@ -3,6 +3,15 @@
       <t:title>AB-xslt-037</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2020-03-22</t:date>
+            <t:author>
+               <t:name>Norman Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove initial-mode option for which there was no corresponding mode.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2019-08-04</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -19,7 +28,7 @@
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
          <p:output port="result"/>
-         <p:xslt version="3.0" template-name="template" initial-mode="initial">
+         <p:xslt version="3.0" template-name="template">
             <p:with-input port="source">
                <doc />
             </p:with-input>


### PR DESCRIPTION
I think the `initial-mode` setting is just a cut-and-paste error. I don't think it's relevant to the test. However, if it's present, I think the test should fail with `err:XC0008`