### PR TITLE
Build improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx4096m

--- a/tools/xpl/test-index-setup.xpl
+++ b/tools/xpl/test-index-setup.xpl
@@ -5,7 +5,7 @@
 <p:input port="parameters" kind="parameter"/>
 <p:output port="result"/>
 
-<p:directory-list path="../../test-suite/tests"/>
+<p:directory-list path="../../test-suite/tests" include-filter=".*\.xml"/>
 
 <p:xslt>
   <p:input port="stylesheet">


### PR DESCRIPTION
Add filter so that we don't attempt to parse non-XML files. (Also added an explicit memory setting in gradle.properties.)