### PR TITLE
Added endpoints to test PUT/POST

### DIFF
--- a/docker/apache2/cache/tests.xproc.digest-auth.passwd
+++ b/docker/apache2/cache/tests.xproc.digest-auth.passwd
@@ -1,0 +1,1 @@
+testuser:TestDigestAuthentication:d08a222167122f02f38831509f11b501

--- a/docker/apache2/conf/httpd.conf
+++ b/docker/apache2/conf/httpd.conf
@@ -84,7 +84,7 @@ LoadModule authz_core_module modules/mod_authz_core.so
 LoadModule access_compat_module modules/mod_access_compat.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
 #LoadModule auth_form_module modules/mod_auth_form.so
-#LoadModule auth_digest_module modules/mod_auth_digest.so
+LoadModule auth_digest_module modules/mod_auth_digest.so
 #LoadModule allowmethods_module modules/mod_allowmethods.so
 #LoadModule isapi_module modules/mod_isapi.so
 #LoadModule file_cache_module modules/mod_file_cache.so

--- a/docker/apache2/htdocs/docs/digest-auth/.htaccess
+++ b/docker/apache2/htdocs/docs/digest-auth/.htaccess
@@ -1,0 +1,8 @@
+AuthType Digest
+AuthName TestDigestAuthentication
+AuthDigestProvider file
+AuthUserFile /usr/local/apache2/cache/tests.xproc.digest-auth.passwd
+AuthGroupFile /dev/null
+<Limit GET POST>
+require valid-user
+</Limit>

--- a/docker/apache2/htdocs/docs/digest-auth/index.html
+++ b/docker/apache2/htdocs/docs/digest-auth/index.html
@@ -1,0 +1,9 @@
+<html xmlns='http://www.w3.org/1999/xhtml'>
+<head>
+<title>Digest authentication test</title>
+</head>
+<body>
+<h1>Digest authentication test</h1>
+<p>Success!</p>
+</body>
+</html>

--- a/docker/apache2/htdocs/index.html
+++ b/docker/apache2/htdocs/index.html
@@ -1,1 +1,15 @@
-<p>Hello, XProc Tester</p>
+<!DOCTYPE html>
+<html xmlns='http://www.w3.org/1999/xhtml'>
+<head>
+<title>XProc Test Suite Server</title>
+</head>
+<body>
+<h1>XProc Test Suite Server</h1>
+
+<p>Hello, XProc Tester. This web server provides predictable responses to a number
+of endpoints. These are used by the HTTP tests in the
+<a href="https://test-suite.xproc.org/">XProc 3.0 Test Suite</a>.</p>
+
+</body>
+</html>
+

--- a/docker/apache2/service/accept-delete
+++ b/docker/apache2/service/accept-delete
@@ -1,0 +1,15 @@
+#!/usr/bin/perl -- # -*- Perl -*-
+
+use strict;
+use English;
+use CGI;
+
+my $cgi = CGI->new;
+
+if ($cgi->request_method eq 'DELETE') {
+    print $cgi->header('text/plain', '204 No Content');
+    print "OK\n";
+} else {
+    print $cgi->header('text/plain', '405 Method Not Allowed');
+    print "This endpoint only accepts DELETE requests\n";
+}

--- a/docker/apache2/service/accept-post
+++ b/docker/apache2/service/accept-post
@@ -1,0 +1,15 @@
+#!/usr/bin/perl -- # -*- Perl -*-
+
+use strict;
+use English;
+use CGI;
+
+my $cgi = CGI->new;
+
+if ($cgi->request_method eq 'POST') {
+    print $cgi->header('text/plain', '201 Created');
+    print "OK\n";
+} else {
+    print $cgi->header('text/plain', '405 Method Not Allowed');
+    print "This endpoint only accepts POST requests\n";
+}

--- a/docker/apache2/service/accept-put
+++ b/docker/apache2/service/accept-put
@@ -1,0 +1,15 @@
+#!/usr/bin/perl -- # -*- Perl -*-
+
+use strict;
+use English;
+use CGI;
+
+my $cgi = CGI->new;
+
+if ($cgi->request_method eq 'PUT') {
+    print $cgi->header('text/plain', '202 Accepted');
+    print "OK\n";
+} else {
+    print $cgi->header('text/plain', '405 Method Not Allowed');
+    print "This endpoint only accepts PUT requests\n";
+}

--- a/docker/apache2/service/file-download
+++ b/docker/apache2/service/file-download
@@ -1,0 +1,12 @@
+#!/usr/bin/perl -- # -*- Perl -*-
+
+use strict;
+use English;
+use CGI;
+
+my $cgi = CGI->new;
+
+print "Content-type: application/xml\n";
+print "Content-Disposition: attachment; filename=download-test.xml\n";
+print "\n";
+print "<doc><p>This is a test.</p></doc>\n";

--- a/docker/apache2/service/file-multidownload
+++ b/docker/apache2/service/file-multidownload
@@ -1,0 +1,41 @@
+#!/usr/bin/perl -- # -*- Perl -*-
+
+use strict;
+use English;
+
+# This result is like fixed-multipart except that it includes filenames
+# for the parts. (I'm assuming that http-request should honor those in
+# constructing the URIs for the parts.)
+
+my $boundary = "=-=-=-=-=";
+
+print "Content-type: multipart/related; boundary=\"$boundary\"\r\n\r\n";
+
+print "--$boundary\r\n";
+
+my $file = "/usr/local/apache2/htdocs/docs/helloworld.html";
+print "Content-type: text/html\r\n";
+print "Content-Disposition: attachment; filename=download-part1.html\n";
+print "Content-length: ", -s $file, "\r\n";
+print "\r\n";
+open (F, "/usr/local/apache2/htdocs/docs/helloworld.html");
+while (<F>) {
+    print $_;
+}
+close (F);
+
+print "\r\n--$boundary\r\n";
+
+$file = "/usr/local/apache2/htdocs/docs/helloworld.png";
+print "Content-type: image/png\r\n";
+print "Content-Disposition: attachment; filename=images/download-part2.png\n";
+print "Content-length: ", -s $file, "\r\n";
+print "\r\n";
+open (F, "/usr/local/apache2/htdocs/docs/helloworld.png");
+binmode F;
+while (read(F, $_, 4096)) {
+    print $_;
+}
+close (F);
+
+print "\r\n--${boundary}--\r\n";

--- a/docker/apache2/service/fixed-html
+++ b/docker/apache2/service/fixed-html
@@ -1,0 +1,25 @@
+#!/usr/bin/perl -- # -*- Perl -*-
+
+use strict;
+use English;
+use CGI::Carp qw(fatalsToBrowser);
+
+# To satisfy Apache, always read the input
+if ($ENV{'REQUEST_METHOD'} eq 'POST') {
+    read(STDIN, $_, $ENV{'CONTENT_LENGTH'});
+}
+
+print "Content-type: text/html\n\n";
+print "<!DOCTYPE html>\n";
+print "<html xmlns='http://www.w3.org/1999/xhtml'>\n";
+print "<head>\n";
+print "<title>Example document</title>\n";
+print "</head>\n";
+print "<body>\n";
+print "<h1>Example document</h1>\n";
+print "<p>This is an <a href='https://en.wikipedia.org/wiki/HTML5'>HTML</a> document.\n";
+print "</p>\n";
+print "</body>\n";
+print "</html>\n";
+
+exit(0);


### PR DESCRIPTION
This PR adds two new endpoints: `http://localhost:8246/service/accept-post` and `http://localhost:8246/service/accept-post`.

* The `accept-post` endpoint replies with a 201 for any `POST` request and 405 for any other request.
* The `accept-put` endpoint replies with a 202 for any `PUT`request and 405 for any other request.
