### PR TITLE
New p:http-request tests

### DIFF
--- a/docker/apache2/service/check-multipart
+++ b/docker/apache2/service/check-multipart
@@ -13,16 +13,8 @@ if ($ENV{'REQUEST_METHOD'} eq 'POST') {
 
 my @lines = split(/\r\n/, $_);
 
-#open (F, ">/tmp/check-multipart.data");
-#foreach my $key (sort keys %ENV) {
-#    print F $key, "=", $ENV{$key}, "\n";
-#}
-#foreach my $line (@lines) {
-#    print F $line, "\n";
-#}
-#close (F);
-
 my $contentType = $ENV{'CONTENT_TYPE'};
+my $method = $ENV{'REQUEST_METHOD'};
 my $boundary = "";
 
 if ($contentType =~ /^(.*)(;\s*boundary=([^;\s]+))\s*(.*)$/) {
@@ -39,7 +31,7 @@ while (@lines && $lines[0] ne "--$boundary") {
 }
 shift @lines; # skip the boundary
 
-print "<check-multipart boundary='$boundary' content-type='$contentType'>\n";
+print "<check-multipart method='$method' boundary='$boundary' content-type='$contentType'>\n";
 
 my %skipHeader = ('accept' => 1,
                   'boundary' => 1,
@@ -77,7 +69,16 @@ while (@lines) {
             || $partType =~ /^text\//
             || $partType =~ /\/xml/
             || $partType =~ /\+xml/) {
-            print "<body>$body</body>\n";
+            if ($body =~ /^\s*<\?(xml.*?)\?>(.*)$/si) {
+                my $decl = $1;
+                $body = $2;
+
+                $decl =~ s/'/&apos;/g;
+
+                print "<body xml-declaration='$decl'>$body</body>\n";
+            } else {        
+                print "<body>$body</body>\n";
+            }
         } else {
             print "<body>", encode_base64($body), "</body>\n";
         }

--- a/docker/apache2/service/check-singlepart
+++ b/docker/apache2/service/check-singlepart
@@ -1,0 +1,58 @@
+#!/usr/bin/perl -- # -*- Perl -*-
+
+use strict;
+use English;
+#use CGI::Carp qw(fatalsToBrowser);
+use MIME::Base64;
+
+my $contentType = $ENV{'CONTENT_TYPE'};
+my $method = $ENV{'REQUEST_METHOD'};
+my $bodySent = exists($ENV{'CONTENT_LENGTH'});
+my $contentLength = undef;
+
+my $content = "";
+if ($bodySent) {
+    $contentLength = $ENV{'CONTENT_LENGTH'};
+    read(STDIN, $content, $contentLength);
+} elsif ($method eq 'POST' or $method eq 'PUT') {
+    $content = $ENV{'QUERY_STRING'};
+}
+
+my $decl = undef;
+if ($content ne '' && $contentType =~ /xml/) {
+    if ($content =~ /^\s*<\?(xml.*?)\?>(.*)$/si) {
+        $decl = $1;
+        $content = $2;
+        $decl =~ s/'/&apos;/g;
+    }
+}
+
+print "Content-type: application/xml\r\n\r\n";
+
+print "<check-singlepart method='$method' content-type='$contentType'";
+if (defined($decl)) {
+    print " xml-declaration='$decl'";
+}
+print ">\n";
+
+my %skipHeader = ('accept' => 1,
+                  'accept_encoding' => 1,
+                  'boundary' => 1,
+                  'host' => 1,
+                  'connection' => 1,
+                  'bluecoat_via' => 1,
+                  'user_agent' => 1);
+foreach my $key (sort keys %ENV) {
+    next if $key !~ /^HTTP_(.*)$/;
+    my $name = lc($1);
+    #my $name = lc($key);
+    my $value = $ENV{$key};
+    next if exists $skipHeader{$name};
+    print "<header name='", $name, "'>", $value, "</header>\n";
+}
+
+if ($bodySent) {
+    print "<body>$content</body>\n";
+}
+
+print "</check-singlepart>\n";

--- a/docker/apache2/service/head-with-body
+++ b/docker/apache2/service/head-with-body
@@ -1,0 +1,19 @@
+#!/usr/bin/perl -- # -*- Perl -*-
+
+use strict;
+use English;
+use CGI;
+
+my $cgi = CGI->new;
+
+my $bodySent = exists($ENV{'CONTENT_LENGTH'});
+
+if ($cgi->request_method eq 'HEAD') {
+    if ($bodySent) {
+        print $cgi->header('text/plain', '202 Accepted');
+    } else {
+        print $cgi->header('text/plain', '400 Bad Request');
+    }
+} else {
+    print $cgi->header('text/plain', '405 Method Not Allowed');
+}

--- a/test-suite/tests/nw-http-request-117.xml
+++ b/test-suite/tests/nw-http-request-117.xml
@@ -1,0 +1,39 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XC0203">
+   <t:info>
+      <t:title>p:http-request 117 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Multipart boundary test for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Its a dynamic error, if the boundary is invalid.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-multipart" method="post"
+                       headers="map{
+                         'content-type': 'multipart/mixed; boundary=--not-an-acceptable-boundary'
+                       }">
+         <p:with-input>
+           <p:inline><doc1 xmlns=""/></p:inline>
+           <p:inline><doc2 xmlns=""/></p:inline>
+         </p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-http-request-118.xml
+++ b/test-suite/tests/nw-http-request-118.xml
@@ -1,0 +1,39 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="fail" code="err:XC0203">
+   <t:info>
+      <t:title>p:http-request 117 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Multipart boundary test for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Its a dynamic error, if the boundary is invalid.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-multipart" method="post"
+                       headers="map{
+                         'content-type': 'multipart/alternative; boundary=--not-an-acceptable-boundary'
+                       }">
+         <p:with-input>
+           <p:inline><doc1 xmlns=""/></p:inline>
+           <p:inline><doc2 xmlns=""/></p:inline>
+         </p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-http-request-118.xml
+++ b/test-suite/tests/nw-http-request-118.xml
@@ -2,7 +2,7 @@
         xmlns:err="http://www.w3.org/ns/xproc-error"
         expected="fail" code="err:XC0203">
    <t:info>
-      <t:title>p:http-request 117 (NW)</t:title>
+      <t:title>p:http-request 118 (NW)</t:title>
       <t:revision-history>
          <t:revision>
             <t:date>2021-09-09</t:date>

--- a/test-suite/tests/nw-http-request-119.xml
+++ b/test-suite/tests/nw-http-request-119.xml
@@ -1,0 +1,56 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 119 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Multipart boundary test for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If you specify a boundary, it will be used.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-multipart" method="post"
+                       headers="map{
+                         'content-type': 'multipart/mixed; boundary=this-is-my-boundary'
+                       }">
+         <p:with-input>
+           <p:inline><doc1 xmlns=""/></p:inline>
+           <p:inline><doc2 xmlns=""/></p:inline>
+         </p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-multipart">The pipeline root is not check-multipart.</s:assert>
+               <s:assert test="@boundary = 'this-is-my-boundary'">The boundary is wrong.</s:assert>
+               <s:assert test="@content-type = 'multipart/mixed'">The content-type is wrong.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-120.xml
+++ b/test-suite/tests/nw-http-request-120.xml
@@ -1,0 +1,56 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 120 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Multipart boundary test for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If you specify a boundary, it will be used.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-multipart" method="post"
+                       headers="map{
+                         'content-type': 'multipart/alternative; boundary=this-is-my-boundary'
+                       }">
+         <p:with-input>
+           <p:inline><doc1 xmlns=""/></p:inline>
+           <p:inline><doc2 xmlns=""/></p:inline>
+         </p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-multipart">The pipeline root is not check-multipart.</s:assert>
+               <s:assert test="@boundary = 'this-is-my-boundary'">The boundary is wrong.</s:assert>
+               <s:assert test="@content-type = 'multipart/alternative'">The content-type is wrong.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-121.xml
+++ b/test-suite/tests/nw-http-request-121.xml
@@ -1,0 +1,56 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 121 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Multipart boundary test for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If you don’t specify a boundary, one will be created for you.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-multipart" method="post"
+                       headers="map{
+                         'content-type': 'multipart/mixed'
+                       }">
+         <p:with-input>
+           <p:inline><doc1 xmlns=""/></p:inline>
+           <p:inline><doc2 xmlns=""/></p:inline>
+         </p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-multipart">The pipeline root is not check-multipart.</s:assert>
+               <s:assert test="string(@boundary) != ''">The boundary is wrong.</s:assert>
+               <s:assert test="@content-type = 'multipart/mixed'">The content-type is wrong.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-122.xml
+++ b/test-suite/tests/nw-http-request-122.xml
@@ -1,0 +1,56 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 122 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Multipart boundary test for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If you don’t specify a boundary, one will be created for you.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-multipart" method="post"
+                       headers="map{
+                         'content-type': 'multipart/alternative'
+                       }">
+         <p:with-input>
+           <p:inline><doc1 xmlns=""/></p:inline>
+           <p:inline><doc2 xmlns=""/></p:inline>
+         </p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-multipart">The pipeline root is not check-multipart.</s:assert>
+               <s:assert test="string(@boundary) != ''">The boundary is wrong.</s:assert>
+               <s:assert test="@content-type = 'multipart/alternative'">The content-type is wrong.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-123.xml
+++ b/test-suite/tests/nw-http-request-123.xml
@@ -1,0 +1,50 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 123 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test send-body-anyway for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If you don’t specify send-body-anyway=true, the body isn’t sent.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-singlepart"
+                       method="delete">
+         <p:with-input><doc1/></p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-singlepart">The pipeline root is not check-singlepart.</s:assert>
+               <s:assert test="empty(*)">Request included a body.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-124.xml
+++ b/test-suite/tests/nw-http-request-124.xml
@@ -1,0 +1,51 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 124 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test send-body-anyway for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If send-body-anyway is explicitly false, the body isn’t sent.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-singlepart"
+                       method="delete"
+                       parameters="map{'send-body-anyway': false()}">
+         <p:with-input><doc1/></p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-singlepart">The pipeline root is not check-singlepart.</s:assert>
+               <s:assert test="empty(*)">Request included a body.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-125.xml
+++ b/test-suite/tests/nw-http-request-125.xml
@@ -1,0 +1,51 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 125 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test send-body-anyway for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If send-body-anyway is explicitly true, the body is sent. This tests DELETE.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-singlepart"
+                       method="delete"
+                       parameters="map{'send-body-anyway': true()}">
+         <p:with-input><doc1/></p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-singlepart">The pipeline root is not check-singlepart.</s:assert>
+               <s:assert test="body/doc1">Request body is absent.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-126.xml
+++ b/test-suite/tests/nw-http-request-126.xml
@@ -1,0 +1,57 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 126 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>The default content-type for multipart requests is multipart/mixed</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If no content-type is provided, multipart/mixed must be used.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+  <p:http-request href="http://localhost:8246/service/check-multipart" method="post">
+    <p:with-input>
+      <p:inline>
+        <doc1 xmlns=""/>
+      </p:inline>
+      <p:inline>
+        <doc2 xmlns=""/>
+      </p:inline>
+    </p:with-input>
+  </p:http-request>
+
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-multipart">The root is not check-multipart.</s:assert>
+               <s:assert test="@content-type='multipart/mixed'">Wrong defualt content-type.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-127.xml
+++ b/test-suite/tests/nw-http-request-127.xml
@@ -1,0 +1,63 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 127 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Check multipart serialization properties.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If no content-type is provided, multipart/mixed must be used.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+  <p:http-request href="http://localhost:8246/service/check-multipart" method="post">
+    <p:with-input>
+      <p:inline document-properties="map{'serialization': map {'encoding': 'iso-8859-1'}}">
+        <doc1 xmlns="">These characters will be encoded as ISO Latin 1, but will
+        be returned in the middle of a UTF-8 document by check-multipart. So don’t
+        actually put any characters in here that would be invalid UTF-8 sequences when
+        encoded in ISO Latin 1.</doc1>
+      </p:inline>
+      <p:inline document-properties="map{'serialization': map {'encoding': 'utf-8'}}">
+        <doc2 xmlns="">Résumé</doc2>
+      </p:inline>
+    </p:with-input>
+  </p:http-request>
+
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-multipart">The root is not check-multipart.</s:assert>
+               <s:assert test="contains(part[1]/header[lower-case(@name) = 'content-type'], '8859')"
+                         >The first part has the wrong charset.</s:assert>
+               <s:assert test="contains(lower-case(part[2]/header[lower-case(@name) = 'content-type']), 'utf-8')"
+                         >The second part has the wrong charset.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-128.xml
+++ b/test-suite/tests/nw-http-request-128.xml
@@ -1,0 +1,77 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 128 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Check that xproc-http properties become headers in multipart documents.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If the documents in a mulitpart request have document properties in the
+      <code>http://www.w3.org/ns/xproc-http</code> namespace, those properties
+      become headers.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+  <p:http-request xmlns:chttp="http://www.w3.org/ns/xproc-http"
+                  href="http://localhost:8246/service/check-multipart" method="post">
+    <p:with-input>
+      <p:inline document-properties="map{
+                   'chttp:content-id': 'abcdefg',
+                   'chttp:content-description': 'First document'
+                }">
+        <doc1 xmlns=""/>
+      </p:inline>
+      <p:inline document-properties="map{
+                   'chttp:content-description': 'Second document',
+                   'chttp:content-disposition': 'attachment; filename=abc.xml',
+                   'chttp:random-header': 'value'
+                }">
+        <doc2 xmlns=""/>
+      </p:inline>
+    </p:with-input>
+  </p:http-request>
+
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-multipart">The root is not check-multipart.</s:assert>
+<s:assert test="part[1]/header[lower-case(@name) = 'content-description'] = 'First document'"
+>The content-description of the first part is incorrect.</s:assert>
+<s:assert test="part[1]/header[lower-case(@name) = 'content-id'] = 'abcdefg'"
+>The content-id of the first part is incorrect.</s:assert>
+<s:assert test="part[2]/header[lower-case(@name) = 'content-description'] = 'Second document'"
+>The content-description of the second part is incorrect.</s:assert>
+<s:assert test="part[2]/header[lower-case(@name) = 'content-disposition']
+                = 'attachment; filename=abc.xml'"
+>The content-disposition of the second part is incorrect.</s:assert>
+<s:assert test="part[2]/header[lower-case(@name) = 'random-header'] = 'value'"
+>The random-header of the second part is incorrect.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-129.xml
+++ b/test-suite/tests/nw-http-request-129.xml
@@ -1,0 +1,51 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 129 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test send-body-anyway for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If send-body-anyway is explicitly true, the body is sent. This tests GET.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/check-singlepart"
+                       method="get"
+                       parameters="map{'send-body-anyway': true()}">
+         <p:with-input><doc1/></p:with-input>
+       </p:http-request>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::check-singlepart">The pipeline root is not check-singlepart.</s:assert>
+               <s:assert test="body/doc1">Request body is absent.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-130.xml
+++ b/test-suite/tests/nw-http-request-130.xml
@@ -1,0 +1,61 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        expected="pass">
+   <t:info>
+      <t:title>p:http-request 129 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-09-09</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test send-body-anyway for p:http-request.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>If send-body-anyway is explicitly true, the body is sent. This tests HEAD.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     exclude-inline-prefixes="c xs" version="3.0">
+       <p:output port="result"/>
+
+       <p:http-request href="http://localhost:8246/service/head-with-body"
+                       method="head"
+                       parameters="map{'send-body-anyway': true()}">
+         <p:with-input><doc1/></p:with-input>
+       </p:http-request>
+
+       <p:identity>
+         <p:with-input pipe="report"/>
+       </p:identity>
+
+       <p:identity>
+         <p:with-input>
+           <result>{.?status-code}</result>
+         </p:with-input>
+       </p:identity>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::result">The root is not result.</s:assert>
+               <s:assert test=".='202'">The resonse code is incorrect.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-http-request-130.xml
+++ b/test-suite/tests/nw-http-request-130.xml
@@ -2,7 +2,7 @@
         xmlns:err="http://www.w3.org/ns/xproc-error"
         expected="pass">
    <t:info>
-      <t:title>p:http-request 129 (NW)</t:title>
+      <t:title>p:http-request 130 (NW)</t:title>
       <t:revision-history>
          <t:revision>
             <t:date>2021-09-09</t:date>


### PR DESCRIPTION
New tests for multipart requests. Also tests to check `send-body-anyway`.

* `check-multipart` has been updated so that it adds a `method` attribute to the document element. If XML parts are sent, the XML declaration, if present, is moved into an attribute on the `body` element so that the result can be parsed.
* `check-singlepart` is like `check-multipart` but for single parts :-)
* `head-with-body` returns 202 if the HEAD request includes a body, otherwise 400.
