### PR TITLE
Fix the input to ab-unwrap-005

### DIFF
--- a/test-suite/tests/ab-unwrap-005.xml
+++ b/test-suite/tests/ab-unwrap-005.xml
@@ -27,9 +27,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:unwrap</p>
    </t:description>
-   <t:input port="source">
-      <doc>Some <doc>text.</doc></doc>
-   </t:input>
+   <t:input port="source"><doc>Some <doc>text.</doc></doc></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"


### PR DESCRIPTION
My interpretation of the `t:input` element in this test is that the document has whitespace before and after the outermost `doc` element. That breaks the comparison. The simple fix is to take out the irrelevant whitespace.