### PR TITLE
Clarify ab-try-027.xml

### DIFF
--- a/test-suite/tests/ab-try-027.xml
+++ b/test-suite/tests/ab-try-027.xml
@@ -27,7 +27,10 @@
             </p:identity>
             
            <p:catch name="catch">
-              <p:output port="catcher" />
+              <p:output port="result" primary="true"/>
+              <p:output port="catcher">
+                 <p:empty/>
+              </p:output>
               <p:identity>
                  <p:with-input pipe="error@catch" />
               </p:identity>


### PR DESCRIPTION
As written, I think this test also violates `err:XS0102` which my implementation happened to catch first, causing it to raise a different error code. This change assures that the only static error is `err:XS0072`.