### PR TITLE
Fix formatting of examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ tasks.register("test_index_setup", XMLCalabashTask) {
   inputs.file "tools/xsl/test-index.xsl"
   inputs.file "tools/xsl/functions.xsl"
   inputs.file "tools/xsl/merge-git-log.xsl"
+  inputs.file "tools/xsl/inline-src.xsl"
 
   output("result", "build/indexing.xml")
   extensionValues true
@@ -163,6 +164,9 @@ tasks.register("test_indexes") {
   String name = "idx_test_${itype}_index"
   tasks.register(name, XMLCalabashTask) {
     dependsOn "test_index_setup"
+
+    inputs.file "tools/xsl/test-index.xsl"
+
     input("source", "build/indexing.xml")
     output("result", "build/html/" + itype + ".html")
     param("index-type", itype)

--- a/src/main/resources/js/filter.js
+++ b/src/main/resources/js/filter.js
@@ -1,0 +1,19 @@
+'use strict';
+
+document.addEventListener("keydown", filter, false);
+
+function filter(event) {
+  if (event.code == 'F2') {
+    document.querySelectorAll("tr").forEach(function (row) {
+      let fail = row.querySelector("td.fail") != null;
+      let pass = row.querySelector("td.pass") != null;
+      let unk = row.querySelector("td.unknown") != null;
+      if (pass || fail || unk) {
+        // It's a result row
+        if (pass && !fail && !unk) {
+          row.style.display = "none";
+        }
+      }
+    });
+  }
+}

--- a/tools/xpl/test-index-setup.xpl
+++ b/tools/xpl/test-index-setup.xpl
@@ -19,23 +19,14 @@
     <p:with-option name="href" select="$baseuri"/>
   </p:load>
 
-  <!-- Some of the tests include invalid base URIs. That causes the
-       add-attribute step to fail. Just ignore it in those cases. -->
-  <p:try>
-    <p:group>
-      <p:add-attribute attribute-name="xml:base" match="/*">
-        <p:with-option name="attribute-value" select="$baseuri"/>
-      </p:add-attribute>
-    </p:group>
-    <p:catch>
-      <p:identity/>
-    </p:catch>
-  </p:try>
-
+  <!-- You'd like tou se p:add-attribute to add the xml:base attribute,
+       but some of the examples contain invalid base URIs and that
+       causes the step to fail. We cheat and use XSLT instead. -->
   <p:xslt>
     <p:input port="stylesheet">
       <p:document href="../xsl/inline-src.xsl"/>
     </p:input>
+    <p:with-param name="baseuri" select="$baseuri"/>
   </p:xslt>
   <p:xslt>
     <p:input port="stylesheet">

--- a/tools/xsl/format-test.xsl
+++ b/tools/xsl/format-test.xsl
@@ -6,9 +6,10 @@
                 xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns="http://www.w3.org/1999/xhtml"
 		exclude-result-prefixes="h p t xs"
-                version="2.0">
+                version="3.0">
 
 <xsl:import href="functions.xsl"/>
+<xsl:import href="xml2text.xsl"/>
 
 <xsl:output method="html" encoding="utf-8" omit-xml-declaration="yes"/>
 
@@ -399,13 +400,10 @@
     <code>
       <xsl:choose>
         <xsl:when test="@src">
-          <xsl:apply-templates mode="copy" select="doc(resolve-uri(@src, base-uri(.)))"/>
+          <xsl:sequence select="t:format-markup(doc(resolve-uri(@src, base-uri(.)))/*)"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:variable name="content" as="node()*">
-            <xsl:apply-templates select="node()" mode="namespace-shelter"/>
-          </xsl:variable>
-          <xsl:apply-templates mode="copy" select="$content"/>
+          <xsl:sequence select="* ! t:format-markup(.)"/>
         </xsl:otherwise>
       </xsl:choose>
     </code>
@@ -502,66 +500,6 @@
     </xsl:if>
   </xsl:for-each>
 
-  <xsl:variable name="pdef" select="string(parent::*/namespace::*[local-name(.) = ''])"/>
-  <xsl:variable name="tdef" select="string(./namespace::*[local-name(.) = ''])"/>
-
-  <xsl:if test="parent::* and $pdef != $tdef and $tdef ne 'http://test.xproc.org/placeholder/'">
-    <xsl:text> </xsl:text>
-    <span class="attr nsattr">
-      <span class="aname">
-        <xsl:text>xmlns</xsl:text>
-      </span>
-      <span class="aeq">=</span>
-      <span class="aq">"</span>
-      <span class="avalue">
-        <xsl:value-of select="$tdef"/>
-      </span>
-      <span class="aq">"</span>
-    </span>
-  </xsl:if>
-
-  <xsl:for-each select="@*">
-    <xsl:text> </xsl:text>
-    <span class="attr">
-      <span class="aname{if (namespace-uri(.) = 'http://www.w3.org/ns/xproc') then ' paname' else ''}">
-        <xsl:value-of select="node-name(.)"/>
-      </span>
-      <span class="aeq">=</span>
-      <span class="aq">"</span>
-      <span class="avalue">
-        <xsl:value-of select="."/>
-      </span>
-      <span class="aq">"</span>
-    </span>
-  </xsl:for-each>
-</xsl:template>
-
-<xsl:template name="x-attributes">
-  <!--
-      <xsl:message>=== <xsl:value-of select="node-name(.)"/></xsl:message>
-  -->
-  <xsl:variable name="ancestors" select="ancestor::*"/>
-  <xsl:for-each select="namespace::*">
-    <xsl:if test="not(t:ancestor-namespace($ancestors, .))">
-      <xsl:text> </xsl:text>
-      <span class="attr nsattr">
-        <span class="aname">
-          <xsl:text>xmlns</xsl:text>
-          <xsl:if test="local-name(.) ne ''">
-            <xsl:text>:</xsl:text>
-            <xsl:value-of select="local-name(.)"/>
-          </xsl:if>
-        </span>
-        <span class="aeq">=</span>
-        <span class="aq">"</span>
-        <span class="avalue">
-          <xsl:value-of select="."/>
-        </span>
-        <span class="aq">"</span>
-      </span>
-    </xsl:if>
-  </xsl:for-each>
-    
   <xsl:variable name="pdef" select="string(parent::*/namespace::*[local-name(.) = ''])"/>
   <xsl:variable name="tdef" select="string(./namespace::*[local-name(.) = ''])"/>
 

--- a/tools/xsl/inline-src.xsl
+++ b/tools/xsl/inline-src.xsl
@@ -5,6 +5,17 @@
 		exclude-result-prefixes="xs"
                 version="2.0">
 
+<xsl:param name="baseuri" as="xs:string?"/>
+
+<xsl:template match="/*">
+  <xsl:copy>
+    <xsl:if test="exists($baseuri)">
+      <xsl:attribute name="xml:base" select="$baseuri"/>
+    </xsl:if>
+    <xsl:apply-templates select="@*,node()"/>
+  </xsl:copy>
+</xsl:template>
+
 <xsl:template match="*[@src]">
   <xsl:copy>
     <xsl:apply-templates select="@* except @src"/>

--- a/tools/xsl/test-index.xsl
+++ b/tools/xsl/test-index.xsl
@@ -7,7 +7,7 @@
                 xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns="http://www.w3.org/1999/xhtml"
                 exclude-result-prefixes="c h p t xs"
-                version="2.0">
+                version="3.0">
 <xsl:import href="functions.xsl"/>
 <xsl:output method="xml" encoding="utf-8" omit-xml-declaration="yes"/>
 
@@ -608,6 +608,7 @@
   <html>
     <head>
       <xsl:sequence select="t:head('Implementation index')"/>
+      <script src="js/filter.js"/>
     </head>
     <body>
       <nav>
@@ -700,7 +701,7 @@
                     <td class="pass" align="center">pass</td>
                   </xsl:when>
                   <xsl:otherwise>
-                    <td align="center">(no report)</td>
+                    <td class="unknown" align="center">(no report)</td>
                   </xsl:otherwise>
                 </xsl:choose>
               </xsl:for-each>

--- a/tools/xsl/xml2text.xsl
+++ b/tools/xsl/xml2text.xsl
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:t="http://xproc.org/ns/testsuite/3.0"
+                xmlns:h="http://www.w3.org/1999/xhtml"
+                xmlns="http://www.w3.org/1999/xhtml"
+                exclude-result-prefixes="xs t h"
+                version="3.0">
+
+<xsl:function name="t:format-markup" as="node()*">
+  <xsl:param name="node" as="element()"/>
+  <xsl:variable name="serial"
+                select="serialize($node, map{'method':'xml', 'indent': true()})"/>
+  <xsl:sequence select="t:format(tokenize($serial, '&lt;'))"/>
+</xsl:function>
+
+<xsl:function name="t:format" as="node()*">
+  <xsl:param name="tokens" as="xs:string*"/>
+  <xsl:sequence select="t:text($tokens[1])"/>
+  <xsl:for-each select="$tokens[position() gt 1]">
+    <xsl:variable name="body" select="tokenize(., '&gt;')[1]"/>
+    <xsl:variable name="rest" select="tokenize(., '&gt;')[2]"/>
+    <xsl:choose>
+      <xsl:when test="starts-with($body, '!--')">
+        <span class="com">
+          <span class="como">&lt;!--</span>
+          <xsl:sequence select="substring-before(substring($body, 4), '--')"/>
+          <span class="come">--&gt;</span>
+        </span>
+      </xsl:when>
+      <xsl:when test="starts-with($body, '?')">
+        <span class="pi">
+          <span class="pio">&lt;?</span>
+          <xsl:sequence select="substring($body, 2, string-length($body) - 2)"/>
+          <span class="pie">?&gt;</span>
+        </span>
+      </xsl:when>
+      <xsl:when test="starts-with($body, '/')">
+        <span class="etag">
+          <span class="eto">&lt;/</span>
+          <span class="gi endgi">
+            <xsl:sequence select="substring($body,2)"/>
+          </span>
+          <span class="etc">&gt;</span>
+        </span>
+      </xsl:when>
+      <xsl:when test="contains($body, '=')">
+        <xsl:sequence select="t:stag($body)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <span class="stag">
+          <span class="sto">&lt;</span>
+          <span class="gi">
+            <xsl:sequence select="$body"/>
+          </span>
+          <span class="eto">&gt;</span>
+        </span>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:sequence select="t:text($rest)"/>
+  </xsl:for-each>
+</xsl:function>
+
+<xsl:function name="t:text" as="node()?">
+  <xsl:param name="text" as="xs:string?"/>
+  <xsl:if test="exists($text) and $text ne ''">
+    <xsl:choose>
+      <xsl:when test="normalize-space($text) = ''">
+        <xsl:value-of select="$text"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <span class="text"><xsl:sequence select="$text"/></span>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:if>
+</xsl:function>
+
+<xsl:function name="t:stag" as="node()">
+  <xsl:param name="text" as="xs:string"/>
+  <span class="stag">
+    <span class="sto">&lt;</span>
+    <span class="gi">
+      <xsl:sequence select="substring-before($text,' ')"/>
+    </span>
+    <xsl:sequence select="t:attr(substring-after($text,' '))"/>
+    <span class="eto">&gt;</span>
+  </span>
+</xsl:function>
+
+<xsl:function name="t:attr" as="node()*">
+  <xsl:param name="text" as="xs:string"/>
+  <xsl:variable name="name" as="xs:string"
+                select="substring-before($text, '=')"/>
+  <xsl:variable name="value" as="xs:string">
+    <xsl:choose>
+      <xsl:when test="matches($text, '^[^=]+=&quot;[^&quot;]*&quot;.*$', 's')">
+        <xsl:sequence select="replace($text, '^[^=]+=&quot;([^&quot;]*)&quot;.*$', '$1', 's')"/>
+      </xsl:when>
+      <xsl:when test="matches($text, '^[^=]+=''[^'']*''.*$', 's')">
+        <xsl:sequence select="replace($text, '^[^=]+=''([^'']*)''.*$', '$1', 's')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="error(xs:QName('badattr'), 'Unparseable: [' || $text || ']')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  <xsl:variable name="rest" as="xs:string">
+    <xsl:choose>
+      <xsl:when test="matches($text, '^[^=]+=&quot;[^&quot;]*&quot;\s+.+$', 's')">
+        <xsl:sequence select="replace($text, '^[^=]+=&quot;[^&quot;]*&quot;\s+(.+)$', '$1', 's')"/>
+      </xsl:when>
+      <xsl:when test="matches($text, '^[^=]+=''.*?''\s+.+$', 's')">
+        <xsl:sequence select="replace($text, '^[^=]+=''[^'']*''\s+(.+)$', '$1', 's')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="''"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+
+  <xsl:choose>
+    <xsl:when test="$name eq 'xmlns:t'"/>
+    <xsl:when test="$name eq 'xmlns' or starts-with($name, 'xmlns:')">
+      <xsl:text> </xsl:text>
+      <span class="attr nsattr">
+        <span class="aname">
+          <xsl:sequence select="$name"/>
+        </span>
+        <span class="aeq">=</span>
+        <span class="aq">"</span>
+        <span class="avalue">
+          <xsl:value-of select="$value"/>
+        </span>
+        <span class="aq">"</span>
+      </span>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:text> </xsl:text>
+      <span class="attr">
+        <span class="aname">
+          <xsl:sequence select="$name"/>
+        </span>
+        <span class="aeq">=</span>
+        <span class="aq">"</span>
+        <span class="avalue">
+          <xsl:value-of select="normalize-space($value)"/>
+        </span>
+        <span class="aq">"</span>
+      </span>
+    </xsl:otherwise>
+  </xsl:choose>
+
+  <xsl:if test="$rest ne ''">
+    <xsl:sequence select="t:attr($rest)"/>
+  </xsl:if>
+</xsl:function>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This PR fixes the formatting of code samples. It now passes the XML through serialization so that namespaces are made manifest. (I got tired of stumbling over tests where I couldn't copy-and-paste from the web page because there was a namespace missing.)

I also fixed the bug where the implementation report had a bunch of random tests marked "no report" that didn't appear to have a filename:

```
  <!-- You'd like to use p:add-attribute to add the xml:base attribute,
       but some of the examples contain invalid base URIs and that
       causes the step to fail. We cheat and use XSLT instead. -->
```

Finally, I added the secret feature that if you press F2 on the implementation results page, it'll hide all the rows that don't contain at least one fail.