### PR TITLE
Fix insignificant errors

### DIFF
--- a/test-suite/tests/ab-with-input-070.xml
+++ b/test-suite/tests/ab-with-input-070.xml
@@ -3,6 +3,15 @@
       <t:title>with-input-070</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-09-29</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Replace <code>&lt;true/></code> with <code>&lt;p:identity/></code>.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-06-21</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,7 +34,7 @@
                <p:with-input port="source">
                   <doc />
                </p:with-input>
-               <true />
+               <p:identity/>
             </p:when>
          </p:choose>
       </p:declare-step>

--- a/test-suite/tests/ab-with-input-071.xml
+++ b/test-suite/tests/ab-with-input-071.xml
@@ -3,6 +3,15 @@
       <t:title>with-input-071</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-09-29</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Replace <code>&lt;true/></code> with <code>&lt;p:identity/></code>.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-06-21</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,7 +36,7 @@
             <p:with-input port="source">
                <doc />
             </p:with-input>
-            <true />
+            <p:identity/>
          </p:if>
       </p:declare-step>
    </t:pipeline>


### PR DESCRIPTION
I think these are just typos or cut-and-paste errors. Lots of tests use `<true/>` as content in `p:with-input`, but here it's drifted below the input into the pipeline. My processor happens to detect that there's no declaration for a step of type `true` before it notices the error in `@port`.