### PR TITLE
Remove spurious whitespace from input

### DIFF
--- a/test-suite/tests/ab-wrap-sequence-001.xml
+++ b/test-suite/tests/ab-wrap-sequence-001.xml
@@ -5,6 +5,15 @@
       <t:title>p:wrap-sequence 001 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-10-16</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove spurious whitespace from input document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,9 +36,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:wrap-sequence</p>
    </t:description>
-   <t:input port="source">
-      <doc/>
-   </t:input>
+   <t:input port="source"><doc/></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"

--- a/test-suite/tests/ab-wrap-sequence-002.xml
+++ b/test-suite/tests/ab-wrap-sequence-002.xml
@@ -5,6 +5,15 @@
       <t:title>p:wrap-sequence 002 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-10-16</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove spurious whitespace from input document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,9 +36,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:wrap-sequence</p>
    </t:description>
-   <t:input port="source">
-      <doc/>
-   </t:input>
+   <t:input port="source"><doc/></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"

--- a/test-suite/tests/ab-wrap-sequence-003.xml
+++ b/test-suite/tests/ab-wrap-sequence-003.xml
@@ -5,6 +5,15 @@
       <t:title>p:wrap-sequence 003 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-10-16</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove spurious whitespace from input document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,9 +36,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:wrap-sequence</p>
    </t:description>
-   <t:input port="source">
-      <doc/>
-   </t:input>
+   <t:input port="source"><doc/></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"

--- a/test-suite/tests/ab-wrap-sequence-009.xml
+++ b/test-suite/tests/ab-wrap-sequence-009.xml
@@ -5,6 +5,15 @@
       <t:title>p:wrap-sequence 009 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-10-16</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove spurious whitespace from input document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,9 +36,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:wrap-sequence</p>
    </t:description>
-   <t:input port="source">
-      <doc/>
-   </t:input>
+   <t:input port="source"><doc/></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"

--- a/test-suite/tests/ab-wrap-sequence-010.xml
+++ b/test-suite/tests/ab-wrap-sequence-010.xml
@@ -5,6 +5,15 @@
       <t:title>p:wrap-sequence 010 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-10-16</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove spurious whitespace from input document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,9 +36,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:wrap-sequence</p>
    </t:description>
-   <t:input port="source">
-      <doc/>
-   </t:input>
+   <t:input port="source"><doc/></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"

--- a/test-suite/tests/ab-wrap-sequence-011.xml
+++ b/test-suite/tests/ab-wrap-sequence-011.xml
@@ -5,6 +5,15 @@
       <t:title>p:wrap-sequence 011 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-10-16</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove spurious whitespace from input document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,9 +36,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:wrap-sequence</p>
    </t:description>
-   <t:input port="source">
-      <doc/>
-   </t:input>
+   <t:input port="source"><doc/></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"

--- a/test-suite/tests/ab-wrap-sequence-012.xml
+++ b/test-suite/tests/ab-wrap-sequence-012.xml
@@ -5,6 +5,15 @@
       <t:title>p:wrap-sequence 012 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-10-16</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove spurious whitespace from input document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,9 +36,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests sequence result in group-adjacent is correctly evaluated in p:wrap-sequence</p>
    </t:description>
-   <t:input port="source">
-      <doc/>
-   </t:input>
+   <t:input port="source"><doc/></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"

--- a/test-suite/tests/ab-wrap-sequence-013.xml
+++ b/test-suite/tests/ab-wrap-sequence-013.xml
@@ -5,6 +5,15 @@
       <t:title>p:wrap-sequence 013 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-10-16</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove spurious whitespace from input document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,9 +36,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests group-adjacent is correctly atomized in p:wrap-sequence</p>
    </t:description>
-   <t:input port="source">
-      <doc/>
-   </t:input>
+   <t:input port="source"><doc/></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"

--- a/test-suite/tests/ab-wrap-sequence-015.xml
+++ b/test-suite/tests/ab-wrap-sequence-015.xml
@@ -5,6 +5,15 @@
       <t:title>p:wrap-sequence 015 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-10-16</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Remove spurious whitespace from input document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-07-09</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -18,9 +27,7 @@
    <t:description xmlns="http://www.w3.org/1999/xhtml">
       <p>Tests p:wrap-sequence produces the correct number of documents.</p>
    </t:description>
-   <t:input port="source">
-      <doc/>
-   </t:input>
+   <t:input port="source"><doc/></t:input>
    <t:pipeline>
       <p:declare-step name="pipeline"
                       version="3.0"


### PR DESCRIPTION
Several of the wrap sequence tests depend on the output not having any whitespace between the elements in the sequence. But the `t:input` introduced whitespace:

```
<t:input>
   <doc/>
</t:input>
```

That's a document that consists of a whitespace node followed by a `doc` element followed by another whitespace node. That is, my understanding of the intent of the `t:input` element is that it is taken literally. Whitespace is not trimmed off the beginning and the end. (If it was, you couldn't write a test that *had* whitespace in those places.)

This PR removes the extra whitespace.
