### PR TITLE
Additional test

### DIFF
--- a/test-suite/tests/ab-archive-manifest-016.xml
+++ b/test-suite/tests/ab-archive-manifest-016.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:archive-manifest 016 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-10-19</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Additional test for p:archive-manifest</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests path in @href is correctly resolved in p:archive-manifest</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:archive-manifest>
+            <p:with-input href="../documents/archive.zip"/>
+         </p:archive-manifest>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:archive">Root element is not 'c:archive'.</s:assert>
+               <s:assert test="ends-with(c:archive/c:entry[@name='doc.xml']/@href,'/documents/archive.zip/doc.xml')">c:entry/@href for 'doc.xml' is not correct.</s:assert>
+               <s:assert test="ends-with(c:archive/c:entry[@name='folder/doc.xml']/@href,'/documents/archive.zip/folder/doc.xml')">c:entry/@href for 'folder/doc.xml' is not correct.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
As a consequence of the p:urify() changes I found a bug in my implementation which is not covered by the current tests.
This test makes sure that c:entry/@href is correctly resolved against the archive's base-uri.