### PR TITLE
Small fixes

### DIFF
--- a/test-suite/tests/ab-depends-058.xml
+++ b/test-suite/tests/ab-depends-058.xml
@@ -5,6 +5,16 @@
       <t:title>depends 058 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -28,7 +38,9 @@
            </p:identity>
            
            <p:catch>
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-059.xml
+++ b/test-suite/tests/ab-depends-059.xml
@@ -5,6 +5,16 @@
       <t:title>depends 059 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -28,7 +38,9 @@
            </p:identity>
            
            <p:catch>
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-060.xml
+++ b/test-suite/tests/ab-depends-060.xml
@@ -5,6 +5,16 @@
       <t:title>depends 060 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -29,7 +39,9 @@
                </p:identity>
            </p:group>
            <p:catch>
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-061.xml
+++ b/test-suite/tests/ab-depends-061.xml
@@ -5,6 +5,16 @@
       <t:title>depends 061 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,7 +37,9 @@
                <p:with-input><doc /></p:with-input>
            </p:identity>
            <p:catch name="not-inscope">
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-062.xml
+++ b/test-suite/tests/ab-depends-062.xml
@@ -5,6 +5,16 @@
       <t:title>depends 062 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,7 +37,9 @@
                <p:with-input><doc /></p:with-input>
            </p:identity>
            <p:catch>
-              <p:identity name="not-inscope"/>
+              <p:identity name="not-inscope">
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-063.xml
+++ b/test-suite/tests/ab-depends-063.xml
@@ -5,6 +5,16 @@
       <t:title>depends 063 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,7 +37,9 @@
                <p:with-input><doc /></p:with-input>
            </p:identity>
            <p:catch>
-              <p:identity/>
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-064.xml
+++ b/test-suite/tests/ab-depends-064.xml
@@ -5,6 +5,16 @@
       <t:title>depends 064 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -29,7 +39,9 @@
             </p:identity>
            </p:group>
            <p:catch>
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-065.xml
+++ b/test-suite/tests/ab-depends-065.xml
@@ -5,6 +5,16 @@
       <t:title>depends 065 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -29,7 +39,9 @@
             </p:identity>
            </p:group>
            <p:catch>
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-066.xml
+++ b/test-suite/tests/ab-depends-066.xml
@@ -5,6 +5,16 @@
       <t:title>depends 066 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -29,7 +39,9 @@
             </p:identity>
            </p:group>
            <p:catch>
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-067.xml
+++ b/test-suite/tests/ab-depends-067.xml
@@ -5,6 +5,16 @@
       <t:title>depends 067 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -29,7 +39,9 @@
             </p:identity>
            </p:group>
            <p:catch>
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-068.xml
+++ b/test-suite/tests/ab-depends-068.xml
@@ -5,6 +5,16 @@
       <t:title>depends 068 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -29,7 +39,9 @@
             </p:identity>
            </p:group>
            <p:catch name="not-inscope">
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
          

--- a/test-suite/tests/ab-depends-069.xml
+++ b/test-suite/tests/ab-depends-069.xml
@@ -5,6 +5,16 @@
       <t:title>depends 069 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2021-11-20</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Removed error unrelated to this test where there was no binding
+               for an input and no default readable port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -29,7 +39,9 @@
             </p:identity>
            </p:group>
            <p:catch>
-              <p:identity />
+              <p:identity>
+                <p:with-input><doc /></p:with-input>
+              </p:identity>
            </p:catch>
         </p:try>
         <p:identity name="last"/>

--- a/tools/xsl/format-test.xsl
+++ b/tools/xsl/format-test.xsl
@@ -391,12 +391,6 @@
 <xsl:template match="t:schematron">
   <div class="schematron">
     <h2>Schematron validation</h2>
-
-    <xsl:if xmlns:s="http://purl.oclc.org/dsdl/schematron"
-            test=".//s:pattern[count(s:rule) gt 1]">
-      <xsl:message>Suspicious schematron rules</xsl:message>
-    </xsl:if>
-
     <xsl:call-template name="insert-content"/>
   </div>
 </xsl:template>


### PR DESCRIPTION
My implementation happened to detect the missing port before the problems with `depends` which meant I produced the wrong error.

Since the port is unrelated to this test, I simply provided a default binding.