### PR TITLE
Strict alternatives for lazy eval

### DIFF
--- a/test-suite/tests/ab-option-057-strict.xml
+++ b/test-suite/tests/ab-option-057-strict.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XD0030"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-option-057 (strict)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-12-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test added.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests a typing error in an p:option/@select XPath expression is raises an
+         error even if option value is not used.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:option name="opt" select="false()+1" />
+         
+         <p:identity>
+            <p:with-input><result /></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-option-064-strict.xml
+++ b/test-suite/tests/ab-option-064-strict.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XD0001"
+   xmlns:err="http://www.w3.org/ns/xproc-error"
+   xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-option-064 (strict)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-12-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test added.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Checks a dynamic error is raised, if option/@select refers to the (undefined) context item,
+      but is not used.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:option name="opt" select="." />
+         
+         <p:identity>
+            <p:with-input><result /></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-option-066-strict.xml
+++ b/test-suite/tests/ab-option-066-strict.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XD0030"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-option-066 (strict)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-12-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test added.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests a typing error in an p:option/@select XPath expression raises an
+         error even if option value is not used.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:test="http://test">
+         
+         <p:output port="result"/>
+         
+         <p:declare-step type="test:test">
+            <p:output></p:output>
+            <p:option name="var" select="false()+1" />
+            <p:identity>
+               <p:with-input><doc /></p:with-input>
+            </p:identity>
+         </p:declare-step>
+         
+         <test:test />
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-018a-strict.xml
+++ b/test-suite/tests/ab-variable-018a-strict.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XD0036"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>Variable declaration 018a (strict)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-12-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test added.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests XD0036 is raised if select result in p:variable does not match required type even if the variable is not used.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:output port="result"/>
+         <p:variable name="var"
+                     select="'X'"
+                     as="xs:float"/>
+         <p:identity>
+            <p:with-input>
+               <doc/>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-variable-021a-strict.xml
+++ b/test-suite/tests/ab-variable-021a-strict.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XD0001"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>Variable declaration 021a (strict)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2021-12-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test added.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Checks XD0008 is raised if more than one document appears as connection of p:variable and @connection is missing even if the variable is not used.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:variable name="var"
+                     select="count(.)">
+            <doc/>
+            <doc/>
+         </p:variable>
+         <p:identity>
+            <p:with-input>
+               <doc/>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
As discussed here are the strict counterparts for the tests marked with "lazy-eval". I did not mark those tests requiring a feature, making strict evaluation the expected default behaviour. I think this is what we agreed about.