### PR TITLE
Fixed test

### DIFF
--- a/test-suite/tests/ab-use-when-002.xml
+++ b/test-suite/tests/ab-use-when-002.xml
@@ -5,6 +5,15 @@
       <t:title>AB use-when-002</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2022-01-22</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Fixed test to make sure, @use-when is applied in p:inline.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,7 +34,7 @@
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Tests that use-when is not applied in the descendants of p:inline.</p>
+      <p>Tests that use-when IS  applied in the descendants of p:inline.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step name="pipeline"
@@ -35,7 +44,7 @@
          <p:identity>
             <p:with-input port="source">
                <p:inline>
-                  <p:empty use-when="false()"/>
+                  <p:empty use-when="false()" />
                </p:inline>
             </p:with-input>
          </p:identity>
@@ -49,8 +58,7 @@
                prefix="p"/>
          <s:pattern>
             <s:rule context="/">
-               <s:assert test="p:empty">The document root is not 'p:empty'.</s:assert>
-               <s:assert test="p:empty/@use-when='false()'">Document root does not have an attribute @use-when with 'false'.</s:assert>
+               <s:assert test="count(/*) = 0">Document root should not have a child element.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>


### PR DESCRIPTION
This test was copied from the 1.0 test suite, but with 
https://github.com/xproc/3.0-specification/pull/701
we removed the special behaviour of att `use-when` inside p:inlines.