### PR TITLE
Fixed error code in test

### DIFF
--- a/test-suite/tests/ab-avt-012.xml
+++ b/test-suite/tests/ab-avt-012.xml
@@ -1,9 +1,18 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XD0030">
+        expected="fail" code="err:XD0051">
    <t:info>
       <t:title>Attribute value templates 012 (AB)</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-04</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Replaced unspecific error XD0030 with more specific XD0051.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2020-04-13</t:date>
             <t:author>


### PR DESCRIPTION
For 
`<p:add-attribute match="/*" attribute-name="avt" attribute-value="{map{'a' : '5'} }">`
the unspecific error XD0030 is replaced by the more specific code XD0051 (no maps, arrays or functions in AVTs/TVTs).