### PR TITLE
Added test for p:file-copy

### DIFF
--- a/test-suite/tests/ab-file-copy-001.xml
+++ b/test-suite/tests/ab-file-copy-001.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 001 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file1.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file1.txt" target="../testfolder/file2.txt" name="copy"/>
+         <p:directory-list path="../testfolder" depends="copy"/>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file1.txt']">There is no file entry for 'file1.txt'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file2.txt']">There is no file entry for 'file2.txt'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-002.xml
+++ b/test-suite/tests/ab-file-copy-002.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 002 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" />
+      <t:folder path="folder" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder" name="copy"/>
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy"/>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file.txt']">There is no file entry for 'file.txt'.</s:assert>
+               <s:assert test="c:directory/c:directory[@name='folder']">There is no directory entry for 'folder'.</s:assert>
+               <s:assert test="c:directory/c:directory[@name='folder']/c:file[@name='file.txt']">There is no file entry for 'file.txt' in 'folder'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-003.xml
+++ b/test-suite/tests/ab-file-copy-003.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 003 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder/file.txt" name="copy"/>
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy"/>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file.txt']">There is no file entry for 'file.txt'.</s:assert>
+               <s:assert test="c:directory/c:directory[@name='folder']">There is no directory entry for 'folder'.</s:assert>
+               <s:assert test="c:directory/c:directory[@name='folder']/c:file[@name='file.txt']">There is no file entry for 'file.txt' in 'folder'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-004.xml
+++ b/test-suite/tests/ab-file-copy-004.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 004 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder/inner/file.txt" name="copy"/>
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy"/>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file.txt']">There is no file entry for 'file.txt'.</s:assert>
+               <s:assert test="c:directory/c:directory[@name='folder']">There is no directory entry for 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:directory[@name='inner']">There is no directory entry for 'inner' in 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='inner']/c:file[@name='file.txt']">There is no file entry for 'file.txt' in 'inner'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-005.xml
+++ b/test-suite/tests/ab-file-copy-005.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 005 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file1.txt" >file1</t:file>
+      <t:file path="file2.txt" >file2</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file1.txt" target="../testfolder/file2.txt" name="copy"/>
+         <p:directory-list path="../testfolder" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:file[@name='file2.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory/c:file[@name='file2.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file1.txt']">There is no file entry for 'file1.txt'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file2.txt']">There is no file entry for 'file2.txt'.</s:assert>
+               <s:assert test="//c:file[@name='file2.txt']/content/text()='file1'">Content of 'file2.txt' is not 'file1'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-006.xml
+++ b/test-suite/tests/ab-file-copy-006.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 006 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file1.txt" >file1</t:file>
+      <t:file path="file2.txt" >file2</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file1.txt" target="../testfolder/file2.txt" overwrite="true" name="copy"/>
+         <p:directory-list path="../testfolder" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:file[@name='file2.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory/c:file[@name='file2.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file1.txt']">There is no file entry for 'file1.txt'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file2.txt']">There is no file entry for 'file2.txt'.</s:assert>
+               <s:assert test="//c:file[@name='file2.txt']/content/text()='file1'">Content of 'file2.txt' is not 'file1'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-007.xml
+++ b/test-suite/tests/ab-file-copy-007.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 007 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" >file1</t:file>
+      <t:file path="folder/file.txt" >file2</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:directory[@name='folder']/c:file[@name='file.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory[@name='folder']/c:file[@name='file.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file.txt']">There is no file entry for 'file.txt'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']">There is no directory entry for 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:file[@name='file.txt']">There is no file entry for 'file.txt' in 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:file[@name='file.txt']/content/text()='file1'">Content of 'file.txt' is not 'file1'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-008.xml
+++ b/test-suite/tests/ab-file-copy-008.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 008 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" >file1</t:file>
+      <t:file path="folder/file.txt" >file2</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder" overwrite="true" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:directory[@name='folder']/c:file[@name='file.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory[@name='folder']/c:file[@name='file.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file.txt']">There is no file entry for 'file.txt'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']">There is no directory entry for 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:file[@name='file.txt']">There is no file entry for 'file.txt' in 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:file[@name='file.txt']/content/text()='file1'">Content of 'file.txt' is not 'file1'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-009.xml
+++ b/test-suite/tests/ab-file-copy-009.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 009 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" >file1</t:file>
+      <t:file path="folder/inner/file.txt" >file2</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder/inner/file.txt" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:directory[@name='inner']/c:file[@name='file.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory[@name='inner']/c:file[@name='file.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file.txt']">There is no file entry for 'file.txt'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']">There is no directory entry for 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:directory[@name='inner']">There is no directory entry for 'inner' in 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='inner']/c:file[@name='file.txt']">There is no file entry for 'file.txt' in 'inner'.</s:assert>
+               <s:assert test="//c:directory[@name='inner']/c:file[@name='file.txt']/content/text()='file1'">Content of 'file.txt' is not 'file1'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-010.xml
+++ b/test-suite/tests/ab-file-copy-010.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 010 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" >file1</t:file>
+      <t:file path="folder/inner/file.txt" >file2</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder/inner/file.txt" overwrite="true" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:directory[@name='inner']/c:file[@name='file.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory[@name='inner']/c:file[@name='file.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file.txt']">There is no file entry for 'file.txt'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']">There is no directory entry for 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:directory[@name='inner']">There is no directory entry for 'inner' in 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='inner']/c:file[@name='file.txt']">There is no file entry for 'file.txt' in 'inner'.</s:assert>
+               <s:assert test="//c:directory[@name='inner']/c:file[@name='file.txt']/content/text()='file1'">Content of 'file.txt' is not 'file1'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-011.xml
+++ b/test-suite/tests/ab-file-copy-011.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 011 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file1.txt" >file1</t:file>
+      <t:file path="file2.txt" >file2</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file1.txt" target="../testfolder/file2.txt" overwrite="false" name="copy"/>
+         <p:directory-list path="../testfolder" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:file[@name='file2.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory/c:file[@name='file2.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file1.txt']">There is no file entry for 'file1.txt'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file2.txt']">There is no file entry for 'file2.txt'.</s:assert>
+               <s:assert test="//c:file[@name='file2.txt']/content/text()='file2'">Content of 'file2.txt' is not 'file2'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-012.xml
+++ b/test-suite/tests/ab-file-copy-012.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 012 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" >file1</t:file>
+      <t:file path="folder/file.txt" >file2</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder" overwrite="false" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:directory[@name='folder']/c:file[@name='file.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory[@name='folder']/c:file[@name='file.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file.txt']">There is no file entry for 'file.txt'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']">There is no directory entry for 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:file[@name='file.txt']">There is no file entry for 'file.txt' in 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:file[@name='file.txt']/content/text()='file2'">Content of 'file.txt' is not 'file2'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-013.xml
+++ b/test-suite/tests/ab-file-copy-013.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 013 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" >file1</t:file>
+      <t:file path="folder/inner/file.txt" >file2</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder/inner/file.txt" overwrite="true" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:directory[@name='inner']/c:file[@name='file.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory[@name='inner']/c:file[@name='file.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:file[@name='file.txt']">There is no file entry for 'file.txt'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']">There is no directory entry for 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='folder']/c:directory[@name='inner']">There is no directory entry for 'inner' in 'folder'.</s:assert>
+               <s:assert test="//c:directory[@name='inner']/c:file[@name='file.txt']">There is no file entry for 'file.txt' in 'inner'.</s:assert>
+               <s:assert test="//c:directory[@name='inner']/c:file[@name='file.txt']/content/text()='file1'">Content of 'file.txt' is not 'file1'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-014.xml
+++ b/test-suite/tests/ab-file-copy-014.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 014 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-05</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" />
+      <t:file path="source/file2.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" />
+         
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file2.txt'">There is no entry for target/source/file2.txt</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-015.xml
+++ b/test-suite/tests/ab-file-copy-015.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 015 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" />
+      <t:file path="source/file2.txt" />
+      <t:folder path="target" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" />
+         
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file2.txt'">There is no entry for target/source/file2.txt</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-016.xml
+++ b/test-suite/tests/ab-file-copy-016.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 016 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" />
+      <t:file path="source/file2.txt" />
+      <t:file path="target/file3.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" />
+         
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file2.txt'">There is no entry for target/source/file2.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:file/@name='file3.txt'">There is no entry for target/file3.txt.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-017.xml
+++ b/test-suite/tests/ab-file-copy-017.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 017 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" />
+      <t:file path="source/file2.txt" />
+      <t:file path="target/file3.txt" />
+      <t:folder path="target/source" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" />
+         
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file2.txt'">There is no entry for target/source/file2.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:file/@name='file3.txt'">There is no entry for target/file3.txt.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-018.xml
+++ b/test-suite/tests/ab-file-copy-018.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 018 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" />
+      <t:file path="source/file2.txt" />
+      <t:file path="target/file3.txt" />
+      <t:file path="target/source" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" />
+         
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file2.txt'">There is no entry for target/source/file2.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:file/@name='file3.txt'">There is no entry for target/file3.txt.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-019.xml
+++ b/test-suite/tests/ab-file-copy-019.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 019 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" />
+      <t:file path="source/file2.txt" />
+      <t:file path="target/file3.txt" />
+      <t:file path="target/source/file4.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" />
+         
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file2.txt'">There is no entry for target/source/file2.txt</s:assert>       
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file4.txt'">There is no entry for target/source/file4.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:file/@name='file3.txt'">There is no entry for target/file3.txt.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-020.xml
+++ b/test-suite/tests/ab-file-copy-020.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 020 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" >source</t:file>
+      <t:file path="target/source/file1.txt" >target</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:directory[@name='target']/c:directory[@name='source']/c:file[@name='file1.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory[@name='target']/c:directory[@name='source']/c:file[@name='file1.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file[@name='file1.txt']/content/text()='source'">Content of target/source/file1.txt is not 'source'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-021.xml
+++ b/test-suite/tests/ab-file-copy-021.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 021 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" />
+      <t:file path="source/file2.txt" />
+      <t:file path="target/file3.txt" />
+      <t:file path="target/source" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" overwrite="true" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" />
+         
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file2.txt'">There is no entry for target/source/file2.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:file/@name='file3.txt'">There is no entry for target/file3.txt.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-022.xml
+++ b/test-suite/tests/ab-file-copy-022.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 022 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" />
+      <t:file path="source/file2.txt" />
+      <t:file path="target/file3.txt" />
+      <t:file path="target/source" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" overwrite="false" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" />
+         
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:file/@name='source'">There is no entry for file 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:file/@name='file3.txt'">There is no entry for target/file3.txt.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-023.xml
+++ b/test-suite/tests/ab-file-copy-023.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 023 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" >source</t:file>
+      <t:file path="target/source/file1.txt" >target</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" overwrite="true" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:directory[@name='target']/c:directory[@name='source']/c:file[@name='file1.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory[@name='target']/c:directory[@name='source']/c:file[@name='file1.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file[@name='file1.txt']/content/text()='source'">Content of target/source/file1.txt is not 'source'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-024.xml
+++ b/test-suite/tests/ab-file-copy-024.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy p:directory-list"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 024 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="source/file1.txt" >source</t:file>
+      <t:file path="target/source/file1.txt" >target</t:file>
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                      xmlns:c="http://www.w3.org/ns/xproc-step">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/source" target="../testfolder/target" overwrite="false" name="copy"/>
+         
+         <p:directory-list path="../testfolder" max-depth="unbounded" depends="copy" name="listing"/>
+         
+         <p:wrap-sequence wrapper="content" name="content">
+            <p:with-input href="{fn:base-uri(//c:directory[@name='target']/c:directory[@name='source']/c:file[@name='file1.txt']/@name)}" />
+         </p:wrap-sequence>
+         
+         <p:insert match="//c:directory[@name='target']/c:directory[@name='source']/c:file[@name='file1.txt']" position="first-child">
+            <p:with-input port="source" pipe="@listing"  />
+            <p:with-input port="insertion" pipe="@content" />
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2001/XMLSchema" prefix="ns" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:directory">Root element is not c:directory.</s:assert>
+               <s:assert test="c:directory/@name='testfolder'">Attribute 'name' of root is not 'testfolder'.</s:assert>
+               <s:assert test="c:directory/c:directory/@name='target'">There is no entry for folder 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory/@name='source'">There is no entry for 'source' in 'target'.</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file/@name='file1.txt'">There is no entry for target/source/file1.txt</s:assert>
+               <s:assert test="//c:directory[@name='target']/c:directory[@name='source']/c:file[@name='file1.txt']/content/text()='target'">Content of target/source/file1.txt is not 'target'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-025.xml
+++ b/test-suite/tests/ab-file-copy-025.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 025 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file1.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file1.txt" target="../testfolder/file2.txt" />
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2005/xpath-functions" prefix="fn" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:result">Root element is not c:result.</s:assert>
+               <s:assert test="fn:ends-with(c:result/text(),'/testfolder/file2.txt')">Path in c:result does not end with '/testfolder/file2.txt'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-026.xml
+++ b/test-suite/tests/ab-file-copy-026.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 026 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file1.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file1.txt" target="../testfolder/folder/file2.txt" />
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2005/xpath-functions" prefix="fn" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:result">Root element is not c:result.</s:assert>
+               <s:assert test="fn:ends-with(c:result/text(),'/testfolder/folder/file2.txt')">Path in c:result does not end with '/testfolder/folder/file2.txt'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-027.xml
+++ b/test-suite/tests/ab-file-copy-027.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 027 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file1.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file1.txt" target="../testfolder/folder/" />
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2005/xpath-functions" prefix="fn" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:result">Root element is not c:result.</s:assert>
+               <s:assert test="fn:ends-with(c:result/text(),'/testfolder/folder/')">Path in c:result does not end with '/testfolder/folder/'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-028.xml
+++ b/test-suite/tests/ab-file-copy-028.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 028 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file2.txt" target="../testfolder/" fail-on-error="false"/>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2005/xpath-functions" prefix="fn" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:error">Root element is not c:error.</s:assert>
+               <s:assert test="c:error/@code='{http://www.w3.org/ns/xproc-error}XD0011'">Error code is not XD0011.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-029.xml
+++ b/test-suite/tests/ab-file-copy-029.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:file-copy"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 029 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" />
+      <t:folder path="target" writable="false" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/target" fail-on-error="false"/>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.w3.org/ns/xproc-step" prefix="c"/>
+         <s:ns uri="http://www.w3.org/2005/xpath-functions" prefix="fn" />
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="c:error">Root element is not c:error.</s:assert>
+               <s:assert test="c:error/@code='{http://www.w3.org/ns/xproc-error}XC0050'">Error code is not XC0050.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-file-copy-030.xml
+++ b/test-suite/tests/ab-file-copy-030.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:file-copy" code="err:XD0011"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error">
+   <t:info>
+      <t:title>p:file-copy 030 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file2.txt" target="../testfolder/" />
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-file-copy-031.xml
+++ b/test-suite/tests/ab-file-copy-031.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:file-copy" code="err:XD0011"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error">
+   <t:info>
+      <t:title>p:file-copy 031 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file2.txt" target="../testfolder/" fail-on-error="true"/>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-file-copy-032.xml
+++ b/test-suite/tests/ab-file-copy-032.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:file-copy" code="err:XC0050"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 032 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" />
+      <t:folder path="target" writable="false" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/target" fail-on-error="true"/>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-file-copy-033.xml
+++ b/test-suite/tests/ab-file-copy-033.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:file-copy" code="err:XC0050"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 033 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" />
+      <t:folder path="target" writable="false" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/target" />
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-file-copy-034.xml
+++ b/test-suite/tests/ab-file-copy-034.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:file-copy" code="err:XC0157"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 034 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:folder path="folder" />
+      <t:file path="file.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/folder" target="../testfolder/file.txt" />
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-file-copy-035.xml
+++ b/test-suite/tests/ab-file-copy-035.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:file-copy" code="err:XC0144"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 035 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="unsupported-schema://i-do-not-exist" target="../testfolder/file.txt" />
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-file-copy-036.xml
+++ b/test-suite/tests/ab-file-copy-036.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:file-copy" code="err:XC0144"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 036 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="unsupported-schema://i-do-not-exist" />
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-file-copy-037.xml
+++ b/test-suite/tests/ab-file-copy-037.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:file-copy" code="err:XD0064"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 037 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/%gg" target="../testfolder/folder/file.txt" />
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-file-copy-038.xml
+++ b/test-suite/tests/ab-file-copy-038.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:file-copy" code="err:XD0064"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:file-copy 038 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2022-08-06</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>       
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:file-copy</p>
+   </t:description>
+ 
+   <t:file-environment>
+      <t:file path="file.txt" />
+   </t:file-environment>
+   
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:file-copy href="../testfolder/file.txt" target="../testfolder/folder/%gg" />
+      </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
Adding test for p:file-copy. This was the last step to do, so now we have a first coverage of the file-step library.