### PR TITLE
Initial tests for p:ixml

### DIFF
--- a/test-suite/tests/ab-i-xml-001.xml
+++ b/test-suite/tests/ab-i-xml-001.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:ixml"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml (Example 1 from spec)</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml>
+            <p:with-input port="grammar"><p:empty/></p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+            </p:with-input>
+         </p:ixml>
+         
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="ixml">The root element is not 'ixml'.</s:assert>
+               <s:assert test="ixml/rule">The root element does not have a 'rule' child.</s:assert>
+               <s:assert test="ixml/rule/@name='date'">The 'rule' element does not have an attribute 'name' with value 'date'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-i-xml-002.xml
+++ b/test-suite/tests/ab-i-xml-002.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:ixml"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml (Example 2 from spec)</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml>
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="text/plain">31 December 2021</p:inline>
+            </p:with-input>
+         </p:ixml>
+         
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="date">The root element is not 'date'.</s:assert>
+               <s:assert test="date/day">The root element does not have a 'day' child.</s:assert>
+               <s:assert test="date/day/text()='31'">The value of 'day' is not '31'.</s:assert>
+               <s:assert test="date/month">The root element does not have a 'month' child.</s:assert>
+               <s:assert test="date/month/text()='December'">The value of 'month' is not 'December'.</s:assert>
+               <s:assert test="date/year">The root element does not have a 'year' child.</s:assert>
+               <s:assert test="date/year/text()='2021'">The value of 'year' is not '2021'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-i-xml-003.xml
+++ b/test-suite/tests/ab-i-xml-003.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:ixml"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 003</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml (Example 3 from spec)</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml fail-on-error="false">
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="text/plain">31 Mumble 2021</p:inline>
+            </p:with-input>
+         </p:ixml>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://invisiblexml.org/NS" prefix="ixml"/>
+         <s:pattern>   
+            <s:rule context="/">
+               <s:assert test="*/@ixml:state='failed'">The root element does not have attribute 'ixml:state' with value 'fail'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-i-xml-004.xml
+++ b/test-suite/tests/ab-i-xml-004.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="p:ixml"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 004</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml (Example 4 from spec)</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>        
+         <p:ixml>
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  letters: X, (A; B; C) .
+                  A: digits .
+                  B: digits .
+                  C: digits .
+                  X: "a" .
+                  digits: ["0"-"9"]+ .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="text/plain">a123</p:inline>
+            </p:with-input>
+         </p:ixml>     
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://invisiblexml.org/NS" prefix="ixml"/>
+         <s:pattern>   
+            <s:rule context="/">
+               <s:assert test="letters">The root element is not 'letters'.</s:assert>
+               <s:assert test="letters/@ixml:state='ambiguous'">The root element does not have attribute 'ixml:state' with value 'ambiguous'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-i-xml-005.xml
+++ b/test-suite/tests/ab-i-xml-005.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:ixml" code="err:XC0205"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 005</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml (Example 3 from spec) -  fail-on-error default</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml>
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="text/plain">31 Mumble 2021</p:inline>
+            </p:with-input>
+         </p:ixml>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-i-xml-006.xml
+++ b/test-suite/tests/ab-i-xml-006.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:ixml" code="err:XC0205"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 006</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml (Example 3 from spec) -  fail-on-error explicit true</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml fail-on-error="true">
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="text/plain">31 Mumble 2021</p:inline>
+            </p:with-input>
+         </p:ixml>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-i-xml-007.xml
+++ b/test-suite/tests/ab-i-xml-007.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:ixml" code="err:XD0038"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 007</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml: Content type xml not allowed for port 'source'.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml fail-on-error="true">
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="application/xml"><test /></p:inline>
+            </p:with-input>
+         </p:ixml>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-i-xml-008.xml
+++ b/test-suite/tests/ab-i-xml-008.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:ixml" code="err:XD0038"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 008</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml: Content type html not allowed for port 'source'.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml fail-on-error="true">
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="text/html"><test /></p:inline>
+            </p:with-input>
+         </p:ixml>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-i-xml-009.xml
+++ b/test-suite/tests/ab-i-xml-009.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:ixml" code="err:XD0038"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 009</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml: Content type xml is default, but not allowed for port 'source'.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml fail-on-error="true">
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline><test /></p:inline>
+            </p:with-input>
+         </p:ixml>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-i-xml-010.xml
+++ b/test-suite/tests/ab-i-xml-010.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:ixml" code="err:XD0030"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 010</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml: Either no or one document on port 'grammar'.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml fail-on-error="true">
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+               <p:inline content-type="text/plain">
+                  digits: ["0"-"9"]+ .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="text/plain">a123</p:inline>
+            </p:with-input>
+         </p:ixml>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-i-xml-011.xml
+++ b/test-suite/tests/ab-i-xml-011.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" features="p:ixml" code="err:XD0030"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>AB p:ixml 011</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2023-11-25</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:ixml: Error raised for invalid grammar.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         version="3.0">
+         <p:output port="result"/>
+         
+         <p:ixml fail-on-error="true">
+            <p:with-input port="grammar">
+               <p:inline content-type="text/plain">
+                  date: s?, day, s, month, (s, year)? .
+                  -s: -" "+ .
+                  day: digit, digit? .
+                  -XdigitX: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+                  month: "January"; "February"; "March"; "April";
+                  "May"; "June"; "July"; "August";
+                  "September"; "October"; "November"; "December".
+                  year: (digit, digit)?, digit, digit .
+               </p:inline>
+            </p:with-input>
+            <p:with-input port="source">
+               <p:inline content-type="text/plain">a123</p:inline>
+            </p:with-input>
+         </p:ixml>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
Initial tests for p:ixml. Not sure about "AB p:ixml 010". What should happen if more than one document appears on sequence port "grammar". My implementation raises XD0030 (general error), but may be we should have a special error for this. 