### PR TITLE
Add a new text-sort test

### DIFF
--- a/test-suite/tests/nw-text-sort-001.xml
+++ b/test-suite/tests/nw-text-sort-001.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:text-sort-001 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-03-25</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>One common implementation strategy for this step is to generate an XSLT
+               stylesheet. Let’s play with the namespaces!</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:text-sort with specific namespace bindings</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:xsl="http://example.com/xsl"
+                      xmlns:xslt="http://example.com/xslt"
+                      xmlns:xs="http://example.com/xs">
+         <p:output port="result"/>
+         <p:text-sort>
+            <p:with-input>
+               <p:inline content-type="text/plain">C
+A
+D
+B</p:inline>
+            </p:with-input>
+         </p:text-sort>
+         <p:wrap-sequence wrapper="wrapper"/>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="wrapper">The root element is not wrapper.</s:assert>
+               <s:assert test="wrapper/text()='A&#xA;B&#xA;C&#xA;D&#xA;'">Text is not sorted correctly.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
If the implementation generates a stylesheet to implement this, make sure it gets the namespaces correct!