### PR TITLE
Allow err:XD0030 as a passing result

### DIFF
--- a/test-suite/tests/ab-text-sort-017.xml
+++ b/test-suite/tests/ab-text-sort-017.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XC0098">
+        expected="fail" code="err:XD0030 err:XC0098">
    <t:info>
       <t:title>p:text-sort-017 (AB)</t:title>
       <t:revision-history>

--- a/test-suite/tests/ab-text-sort-018.xml
+++ b/test-suite/tests/ab-text-sort-018.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XC0099">
+        expected="fail" code="err:XD0030 err:XC0099">
    <t:info>
       <t:title>p:text-sort-018 (AB)</t:title>
       <t:revision-history>


### PR DESCRIPTION
I think `err:XD0030` should be allowed as an alternative result for these tests.