### PR TITLE
Unarchive fixes

### DIFF
--- a/test-suite/tests/ab-unarchive-001.xml
+++ b/test-suite/tests/ab-unarchive-001.xml
@@ -4,6 +4,15 @@
    <t:info>
       <t:title>p:unarchive 001 (AB)</t:title>
       <t:revision-history>
+        <t:revision>
+          <t:date>2024-05-01</t:date>
+          <t:author>
+            <t:name>Norm Tovey-Walsh</t:name>
+          </t:author>
+          <t:description xmlns="http://www.w3.org/1999/xhtml">
+            <p>Fixed typos in the Schematron assertion messages.</p>
+          </t:description>
+        </t:revision>
          <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>

--- a/test-suite/tests/ab-unarchive-001.xml
+++ b/test-suite/tests/ab-unarchive-001.xml
@@ -67,9 +67,9 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">Root element is not 'result'.</s:assert>
-               <s:assert test="count(result/entry)=10">Element 'c:archive' does not have 10 children named 'entry'</s:assert>
+               <s:assert test="count(result/entry)=10">Element 'result' does not have 10 children named 'entry'</s:assert>
                <s:assert test="result/entry[ends-with(@base-uri, 'documents/archive.zip/doc.xml')]/@content-type='application/xml'">There is no entry for 'doc.xml' with 'application/xml'.</s:assert>
-               <s:assert test="result/entry[ends-with(@base-uri, 'documents/archive.zip/text.txt')]/@content-type='text/plain'">Content-type of 'text.text' is not 'text/plain'.</s:assert>
+               <s:assert test="result/entry[ends-with(@base-uri, 'documents/archive.zip/text.txt')]/@content-type='text/plain'">Content-type of 'text.txt' is not 'text/plain'.</s:assert>
                <s:assert test="result/entry[ends-with(@base-uri, 'documents/archive.zip/json.json')]/@content-type='application/json'">Content-type of 'json.json' is not 'application/json'.</s:assert>
                <s:assert test="result/entry[ends-with(@base-uri, 'documents/archive.zip/html.html')]/@content-type='text/html'">Content-type of 'html.html' is not 'text/html'.</s:assert>
                <s:assert test="result/entry[ends-with(@base-uri, 'documents/archive.zip/fish.jpg')]/@content-type='image/jpeg' or                   result/entry[ends-with(@base-uri, 'documents/archive.zip/fish.jpg')]/@content-type='application/octet-stream'">Content-type of 'fish.jpg' is not 'image/jpg' or 'application/octet-stream'.</s:assert>

--- a/test-suite/tests/ab-unarchive-006.xml
+++ b/test-suite/tests/ab-unarchive-006.xml
@@ -4,6 +4,15 @@
    <t:info>
       <t:title>p:unarchive 006 (AB)</t:title>
       <t:revision-history>
+        <t:revision>
+          <t:date>2024-05-01</t:date>
+          <t:author>
+            <t:name>Norm Tovey-Walsh</t:name>
+          </t:author>
+          <t:description xmlns="http://www.w3.org/1999/xhtml">
+            <p>Change the error code to match the description.</p>
+          </t:description>
+        </t:revision>
          <t:revision>
             <t:date>2019-12-14</t:date>
             <t:author>

--- a/test-suite/tests/ab-unarchive-006.xml
+++ b/test-suite/tests/ab-unarchive-006.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
    xmlns:err="http://www.w3.org/ns/xproc-error"
-   expected="fail" code="err:XC0085">
+   expected="fail" code="err:XC0081">
    <t:info>
       <t:title>p:unarchive 006 (AB)</t:title>
       <t:revision-history>

--- a/test-suite/tests/ab-unarchive-007.xml
+++ b/test-suite/tests/ab-unarchive-007.xml
@@ -4,6 +4,15 @@
    <t:info>
       <t:title>p:unarchive 007 (AB)</t:title>
       <t:revision-history>
+        <t:revision>
+          <t:date>2024-05-01</t:date>
+          <t:author>
+            <t:name>Norm Tovey-Walsh</t:name>
+          </t:author>
+          <t:description xmlns="http://www.w3.org/1999/xhtml">
+            <p>Allow err:XC0081 as a passing result.</p>
+          </t:description>
+        </t:revision>
          <t:revision>
             <t:date>2019-12-20</t:date>
             <t:author>
@@ -25,7 +34,7 @@
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Tests p:unarchive: Test XC0085 is raised, if source is not a zip.</p>
+      <p>Tests p:unarchive: Test XC0081 or XC0085 is raised, if source is not a zip.</p>
    </t:description>
    
    <t:pipeline>

--- a/test-suite/tests/ab-unarchive-007.xml
+++ b/test-suite/tests/ab-unarchive-007.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
    xmlns:err="http://www.w3.org/ns/xproc-error"
-   expected="fail" code="err:XC0085">
+   expected="fail" code="err:XC0081 err:XC0085">
    <t:info>
       <t:title>p:unarchive 007 (AB)</t:title>
       <t:revision-history>

--- a/test-suite/tests/ab-unarchive-019.xml
+++ b/test-suite/tests/ab-unarchive-019.xml
@@ -31,7 +31,7 @@
                 </p:with-input>
             </p:archive>
             
-            <p:set-properties properties="map{}" /> <!-- remove base URI -->
+            <p:set-properties properties="map{}" merge="false"/> <!-- remove base URI -->
             
             <p:unarchive/>
         </p:declare-step>

--- a/test-suite/tests/ab-unarchive-019.xml
+++ b/test-suite/tests/ab-unarchive-019.xml
@@ -6,6 +6,16 @@
         <t:title>p:unarchive 019 (AB)</t:title>
         <t:revision-history>
             <t:revision>
+                <t:date>2024-05-01</t:date>
+                <t:author>
+                    <t:name>Norm Tovey-Walsh</t:name>
+                </t:author>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
+                    <p>Specify merge=false on the call to set-properties so that the base URI
+                    is removed.</p>
+                </t:description>
+            </t:revision>
+            <t:revision>
                 <t:date>2019-12-21</t:date>
                 <t:author>
                     <t:name>Achim Berndzen</t:name>


### PR DESCRIPTION
* `ab-unarchive-001.xml`: just fix some typos in the Schematron messages
* `ab-unarchive-006.xml`: the test description says `err:XC0081` should be raised, but it was testing for `err:XC0085`
* `ab-unarchive-007.xml`: On closer inspection, I think either 81 or 85 should be allowed. See https://github.com/xproc/3.0-steps/issues/561
* `ab-unarchive-019.xml`: Added `merge="false"` to the `p:set-properties` call

AFAICT, the default value for `merge` is `true`, so setting the properties to `map{}` should have no effect. It's merging an empty map with whatever the current properties are. Setting merge to false forces all the properties to be deleted.