### PR TITLE
Initial tests for p:filter

### DIFF
--- a/test-suite/tests/nw-filter-001.xml
+++ b/test-suite/tests/nw-filter-001.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:filter 001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-03</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test p:filter</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:filter with a static select expression.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+
+         <p:filter select="/book/chapter">
+           <p:with-input>
+             <book>
+               <chapter/>
+             </book>
+           </p:with-input>
+         </p:filter>
+      </p:declare-step>
+   </t:pipeline>
+
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::chapter">The result root is not chapter.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-filter-002.xml
+++ b/test-suite/tests/nw-filter-002.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:filter 002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-03</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test p:filter</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:filter with a dynamic select expression.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+
+         <p:identity>
+           <p:with-input>
+             <book pick="appendix">
+               <chapter/>
+               <appendix/>
+             </book>
+           </p:with-input>
+         </p:identity>
+
+         <p:filter select="/book/*[local-name(.)=/book/@pick]"/>
+      </p:declare-step>
+   </t:pipeline>
+
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::appendix">The result root is not appendix.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-filter-003.xml
+++ b/test-suite/tests/nw-filter-003.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:filter 003</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-03</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test p:filter</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:filter selecting nothing.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+
+         <p:identity>
+           <p:with-input>
+             <book>
+               <chapter/>
+               <appendix/>
+             </book>
+           </p:with-input>
+         </p:identity>
+
+         <p:filter select="/book/*[local-name(.)=/book/@pick]"/>
+
+         <p:wrap-sequence wrapper="wrapper"/>
+
+      </p:declare-step>
+   </t:pipeline>
+
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::wrapper">The result root is not wrapper.</s:assert>
+               <s:assert test="empty(/wrapper/node())">The wrapper is not empty.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-filter-004.xml
+++ b/test-suite/tests/nw-filter-004.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:filter 004</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-03</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test p:filter</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:filter selects more than one thing.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+
+         <p:identity>
+           <p:with-input>
+             <book>
+               <chapter/>
+               <appendix/>
+             </book>
+           </p:with-input>
+         </p:identity>
+
+         <p:filter select="/book/*"/>
+
+         <p:wrap-sequence wrapper="wrapper"/>
+
+      </p:declare-step>
+   </t:pipeline>
+
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::wrapper">The result root is not wrapper.</s:assert>
+               <s:assert test="chapter">The wrapper doesn’t have a chapter.</s:assert>
+               <s:assert test="appendix">The wrapper doesn’t have an appendix.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-filter-005.xml
+++ b/test-suite/tests/nw-filter-005.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:filter 005</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-03</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test p:filter</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:filter computes the base URI correctly.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+
+         <p:identity>
+           <p:with-input>
+             <book>
+               <chapter xml:base="https://example.com/"/>
+             </book>
+           </p:with-input>
+         </p:identity>
+
+         <p:filter select="/book/chapter"/>
+
+         <p:identity>
+           <p:with-input>
+             <result>{base-uri(.)}</result>
+           </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::result">The result root is not result.</s:assert>
+               <s:assert test=". = 'https://example.com/'">The base URI is incorrect.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-filter-006.xml
+++ b/test-suite/tests/nw-filter-006.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:filter 006</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-03</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test p:filter</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:filter selecting a text node.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+         <p:output port="result"/>
+
+         <p:identity>
+           <p:with-input>
+             <book>
+               <chapter>Hello, world.</chapter>
+             </book>
+           </p:with-input>
+         </p:identity>
+
+         <p:filter select="/book/chapter/text()"/>
+
+         <p:identity>
+           <p:with-input>
+             <result content-type="{p:document-property(., 'content-type')}">{.}</result>
+           </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+               <s:assert test="self::result">The result root is not result.</s:assert>
+               <s:assert test=". = 'Hello, world.'">The text content is incorrect.</s:assert>
+               <s:assert test="@content-type = 'text/plain'">The content-type is incorrect.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
There was only one incidental test for `p:filter`, so I created a few explicit tests.