### PR TITLE
New tests for p:set-attributes

### DIFF
--- a/test-suite/tests/nw-set-attributes-001.xml
+++ b/test-suite/tests/nw-set-attributes-001.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XC0059"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:set-attributes-001 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-04</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:set-attributes; adapted from ab-add-attribute-025.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that an error to be raised if attribute-name is 'xmlns'.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result" />
+         <p:set-attributes match="/doc" attributes="map { 'xmlns': '5' }">
+           <p:with-input>
+               <doc attribute="3">
+                  Some text
+                  <!-- a comment -->
+                  <?pi ?>
+               </doc>
+            </p:with-input>
+         </p:set-attributes>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-set-attributes-002.xml
+++ b/test-suite/tests/nw-set-attributes-002.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XC0059"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:set-attributes-002 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-04</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:set-attributes; adapted from ab-add-attribute-026.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that an error to be raised if attribute-name is 'xmlns'.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result" />
+         <p:variable name="ns" select="'http://www.w3.org/2000/xmlns/'"/>
+         <p:set-attributes match="/doc" attributes="map { Q{http://www.w3.org/2000/xmlns/}x: '5' }">
+           <p:with-input>
+               <doc attribute="3">
+                  Some text
+                  <!-- a comment -->
+                  <?pi ?>
+               </doc>
+            </p:with-input>
+         </p:set-attributes>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
Make sure `p:set-attributes` can't add namespace bindings or invalid bindings for `xml:`