### PR TITLE
Various typos

### DIFF
--- a/test-suite/tests/ab-archive-manifest-006.xml
+++ b/test-suite/tests/ab-archive-manifest-006.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
    xmlns:err="http://www.w3.org/ns/xproc-error"
-   expected="fail" code="err:XC0085">
+   expected="fail" code="err:XC0081">
    <t:info>
       <t:title>p:archive-manifest 006 (AB)</t:title>
       <t:revision-history>

--- a/test-suite/tests/ab-archive-manifest-012.xml
+++ b/test-suite/tests/ab-archive-manifest-012.xml
@@ -18,7 +18,7 @@
     </t:info>
     <t:description xmlns="http://www.w3.org/1999/xhtml">
         <p>Tests XC0120 is raised if the source of p:archive-manifest does not have base URI and
-        option `relative-to`is not present.</p>
+        option “relative-to” is not present.</p>
     </t:description>
     
     <t:pipeline>
@@ -31,7 +31,7 @@
                 </p:with-input>
             </p:archive>
             
-            <p:set-properties properties="map{}" /> <!-- remove base URI -->
+            <p:set-properties properties="map{}" merge="false"/> <!-- remove base URI -->
             
             <p:archive-manifest />
         </p:declare-step>

--- a/test-suite/tests/ab-choose-043.xml
+++ b/test-suite/tests/ab-choose-043.xml
@@ -16,7 +16,7 @@
         </t:revision-history>
     </t:info>
     <t:description xmlns="http://www.w3.org/1999/xhtml">
-        <p>Test XS0038 is raised, if @when is missing on p:when</p>
+        <p>Test XS0038 is raised, if @test is missing on p:when</p>
     </t:description>
     <t:pipeline>
         <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">

--- a/test-suite/tests/ab-connection-016.xml
+++ b/test-suite/tests/ab-connection-016.xml
@@ -23,7 +23,7 @@
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Tests that XD0006 is raised, if default binding for a non-sequence input port contains more than one document and non binding is supplied.</p>
+      <p>Tests that XD0006 is raised, if default binding for a non-sequence input port contains more than one document and no binding is supplied.</p>
    </t:description>
    <t:pipeline>
       <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:test="http://test" version="3.0">

--- a/test-suite/tests/ab-p-archive-056.xml
+++ b/test-suite/tests/ab-p-archive-056.xml
@@ -1,6 +1,6 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XC0085">
+        expected="fail" code="err:XC0081">
    <t:info>
       <t:title>p:archive 056 (AB)</t:title>
       <t:revision-history>


### PR DESCRIPTION
Mostly these are typos in descriptions, but there were a couple of tests where the expected error code didn't match what the test description said.