### PR TITLE
Changed expected error code

### DIFF
--- a/test-suite/tests/ab-archive-manifest-007.xml
+++ b/test-suite/tests/ab-archive-manifest-007.xml
@@ -1,9 +1,18 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
    xmlns:err="http://www.w3.org/ns/xproc-error"
-   expected="fail" code="err:XC0085">
+   expected="fail" code="err:XC0081">
    <t:info>
       <t:title>p:archive-manifest 007 (AB)</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-12</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Changed error code back to C0081 as a consequence of changed spec.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2019-12-20</t:date>
             <t:author>
@@ -25,7 +34,7 @@
       </t:revision-history>
    </t:info>
    <t:description xmlns="http://www.w3.org/1999/xhtml">
-      <p>Tests p:archive-manifest: Test XC0085 is raised, if source is not a zip.</p>
+      <p>Tests p:archive-manifest: Test XC0081 is raised, if source is not a zip.</p>
    </t:description>
    
    <t:pipeline>


### PR DESCRIPTION
If implicit format 'zip' fails with XC0081 (as in changed test "p:archive-manifest 006 (AB)", then the explicit form should be fail with XC0081 too.