### PR TITLE
New tests for p:make-absolute-uris

### DIFF
--- a/test-suite/tests/nw-make-absolute-uris-001.xml
+++ b/test-suite/tests/nw-make-absolute-uris-001.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test features="p:http-request"
+        expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error">
+   <t:info>
+      <t:title>p:make-absolute-uris 001 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-15</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Add test for p:make-absolute-uris.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Replace the content of an element.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step exclude-inline-prefixes="c xs"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:c="http://www.w3.org/ns/xproc-step"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:output port="result"/>
+
+         <p:make-absolute-uris match="uri">
+           <p:with-input>
+             <doc>
+               <uri>filename</uri>
+             </doc>
+           </p:with-input>
+         </p:make-absolute-uris>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+              <s:assert test="self::doc">The root is not doc.</s:assert>
+              <s:assert test="ends-with(uri, '/tests/filename')">The uri is incorrect.</s:assert>
+              <s:assert test="starts-with(uri, 'file:')">The uri appears not to be absolute.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-make-absolute-uris-002.xml
+++ b/test-suite/tests/nw-make-absolute-uris-002.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test features="p:http-request"
+        expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error">
+   <t:info>
+      <t:title>p:make-absolute-uris 002 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-15</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Add test for p:make-absolute-uris.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Replace the content of an element.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step exclude-inline-prefixes="#all"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:c="http://www.w3.org/ns/xproc-step"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:output port="result"/>
+
+         <p:make-absolute-uris match="info/@uri">
+           <p:with-input>
+             <doc xml:base="http://example.com/path/">
+               <info uri="to/thing"/>
+             </doc>
+           </p:with-input>
+         </p:make-absolute-uris>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+              <s:assert test="self::doc">The root is not doc.</s:assert>
+              <s:assert test="info/@uri = 'http://example.com/path/to/thing'">The uri is incorrect.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-make-absolute-uris-003.xml
+++ b/test-suite/tests/nw-make-absolute-uris-003.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test features="p:http-request"
+        expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error">
+   <t:info>
+      <t:title>p:make-absolute-uris 003 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-05-15</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Add test for p:make-absolute-uris.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Use an explicit base URI.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step exclude-inline-prefixes="#all"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:c="http://www.w3.org/ns/xproc-step"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:output port="result"/>
+         <p:make-absolute-uris match="info/@uri" base-uri="http://example.com/abs/">
+           <p:with-input>
+             <doc>
+               <info uri="value"/>
+             </doc>
+           </p:with-input>
+         </p:make-absolute-uris>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns prefix="p"
+               uri="http://www.w3.org/ns/xproc"/>
+         <s:ns prefix="c"
+               uri="http://www.w3.org/ns/xproc-step"/>
+         <s:pattern>
+            <s:rule context="/*">
+              <s:assert test="self::doc">The root is not doc.</s:assert>
+              <s:assert test="info/@uri = 'http://example.com/abs/value'">The uri is incorrect.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
There didn't appear to be any tests for `p:make-absolute-uris`.