### PR TITLE
Add Sendria to the container environment

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,5 +18,24 @@ services:
       networks:
         - external_net
 
+    sendriasmtp:
+      image: msztolcman/sendria:v2.2.2.0
+      container_name: sendriasmtp
+      ports:
+        - 1025:1025
+        - 1080:1080
+      stdin_open: true
+      tty: true
+      environment:
+        - MAIL_DRIVER=smtp
+        - MAIL_HOST=127.0.0.1
+        - MAIL_PORT=1025
+        - MAIL_USERNAME=username
+        - MAIL_PASSWORD=password
+        - MAIL_ENCRYPTION=tcp
+        - MAIL_FROM_ADDRESS=nobody@example.com
+      networks:
+        - external_net
+
 networks:
   external_net: {}


### PR DESCRIPTION
This should make it possible to pass the p:send-email tests.

If spinning up the Docker containers fails, let me know.