### PR TITLE
Some tests for p:validate-with-dtd

### DIFF
--- a/test-suite/tests/ab-validate-with-dtd-001.xml
+++ b/test-suite/tests/ab-validate-with-dtd-001.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        features="p-validate-with-dtd"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-14</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: doctype-system in step's serialization map.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : '../documents/address.dtd'}">
+            <p:with-input>
+               <address >
+                  <first>Douglas</first>
+                  <last>Adams</last>
+                  <phone>42</phone>
+               </address>
+            </p:with-input>
+         </p:validate-with-dtd>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="address">The document is not 'address'.</s:assert>
+               <s:assert test="address/first">There is no child element 'first'.</s:assert>
+               <s:assert test="address/first/text() = 'Douglas'">There is no text child in first with 'Douglas'.</s:assert>
+               <s:assert test="address/last">There is no child element 'last'.</s:assert>
+               <s:assert test="address/last/text() = 'Adams'">There is no text child in last with 'Adam'.</s:assert>
+               <s:assert test="address/phone">There is no child element 'phone'.</s:assert>
+               <s:assert test="address/phone/text() = '42'">There is no text child in phone with '42'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-002.xml
+++ b/test-suite/tests/ab-validate-with-dtd-002.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        features="p-validate-with-dtd"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-14</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: doctype-system in document's serialization map.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd>
+            <p:with-input>
+               <p:inline document-properties="map{'serialization' : 
+                                                   map{'doctype-system' : '../documents/address.dtd'}
+                                                 }">
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="address">The document is not 'address'.</s:assert>
+               <s:assert test="address/first">There is no child element 'first'.</s:assert>
+               <s:assert test="address/first/text() = 'Douglas'">There is no text child in first with 'Douglas'.</s:assert>
+               <s:assert test="address/last">There is no child element 'last'.</s:assert>
+               <s:assert test="address/last/text() = 'Adams'">There is no text child in last with 'Adam'.</s:assert>
+               <s:assert test="address/phone">There is no child element 'phone'.</s:assert>
+               <s:assert test="address/phone/text() = '42'">There is no text child in phone with '42'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-003.xml
+++ b/test-suite/tests/ab-validate-with-dtd-003.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        features="p-validate-with-dtd"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-003</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-14</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: doctype-system in document's and step's serialization map: step's map should win.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : 'i-do-not-exist'}">
+            <p:with-input>
+               <p:inline document-properties="map{'serialization' : 
+                                                   map{'doctype-system' : '../documents/address.dtd'}
+                                                 }">
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="address">The document is not 'address'.</s:assert>
+               <s:assert test="address/first">There is no child element 'first'.</s:assert>
+               <s:assert test="address/first/text() = 'Douglas'">There is no text child in first with 'Douglas'.</s:assert>
+               <s:assert test="address/last">There is no child element 'last'.</s:assert>
+               <s:assert test="address/last/text() = 'Adams'">There is no text child in last with 'Adam'.</s:assert>
+               <s:assert test="address/phone">There is no child element 'phone'.</s:assert>
+               <s:assert test="address/phone/text() = '42'">There is no text child in phone with '42'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-004.xml
+++ b/test-suite/tests/ab-validate-with-dtd-004.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        features="p-validate-with-dtd"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-004</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: doctype-system in step's serialization map. Document is valid, 
+         so there should be no detection in xvrl.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : '../documents/address.dtd'}">
+            <p:with-input>
+               <address >
+                  <first>Douglas</first>
+                  <last>Adams</last>
+                  <phone>42</phone>
+               </address>
+            </p:with-input>
+         </p:validate-with-dtd>
+         <p:identity>
+            <p:with-input pipe="report" />
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.xproc.org/ns/xvrl"
+            prefix="xvrl"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="//xvrl:report">There is no xvrl:report element.</s:assert>
+               <s:assert test="not(exists(//xvrl:report//xvrl:detection))">There should be no element 'xvrl:detection'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-005.xml
+++ b/test-suite/tests/ab-validate-with-dtd-005.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        features="p-validate-with-dtd"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-005</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: doctype-system in document's serialization map. Document is valid, 
+         so there should be no detection in xvrl.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd>
+            <p:with-input>
+               <p:inline document-properties="map{'serialization' : 
+                                                   map{'doctype-system' : '../documents/address.dtd'}
+                                                 }">
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+         <p:identity>
+            <p:with-input pipe="report" />
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.xproc.org/ns/xvrl"
+            prefix="xvrl"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="//xvrl:report">There is no xvrl:report element.</s:assert>
+               <s:assert test="not(exists(//xvrl:report//xvrl:detection))">There should be no element 'xvrl:detection'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-006.xml
+++ b/test-suite/tests/ab-validate-with-dtd-006.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        features="p-validate-with-dtd"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-006</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: doctype-system in document's and step's serialization map: step's map should win. 
+         Document is valid, so there should be no detection in xvrl.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : 'i-do-not-exist'}">
+            <p:with-input>
+               <p:inline document-properties="map{'serialization' : 
+                                                   map{'doctype-system' : '../documents/address.dtd'}
+                                                 }">
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+         <p:identity>
+            <p:with-input pipe="report" />
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.xproc.org/ns/xvrl"
+            prefix="xvrl"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="//xvrl:report">There is no xvrl:report element.</s:assert>
+               <s:assert test="not(exists(//xvrl:report//xvrl:detection))">There should be no element 'xvrl:detection'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-007.xml
+++ b/test-suite/tests/ab-validate-with-dtd-007.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="err:XC0210"
+        features="p-validate-with-dtd" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-007</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: Error needs to be raised for no DTD.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd>
+            <p:with-input>
+               <p:inline>
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-008.xml
+++ b/test-suite/tests/ab-validate-with-dtd-008.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="err:XC0210"
+        features="p-validate-with-dtd" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-008</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: Error needs to be raised for no non existing DTD.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : 'i-do-not-exist'}">
+            <p:with-input>
+               <p:inline>
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-009.xml
+++ b/test-suite/tests/ab-validate-with-dtd-009.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="err:XC0210"
+        features="p-validate-with-dtd" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-009</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: Error needs to be raised for invalid document.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : '../documents/address.dtd'}">
+            <p:with-input>
+               <p:inline>
+                  <address >
+                     <first-name>Douglas</first-name>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-010.xml
+++ b/test-suite/tests/ab-validate-with-dtd-010.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="fail" code="err:XC0210"
+        features="p-validate-with-dtd" 
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-010</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: Error needs to be raised for non dtd.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : '../documents/Kanava.png'}">
+            <p:with-input>
+               <p:inline>
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-011.xml
+++ b/test-suite/tests/ab-validate-with-dtd-011.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="pass" 
+        features="p-validate-with-dtd" 
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-011</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: Detection element needs to be in report for non dtd.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : '../documents/Kanava.png'}" assert-valid="false">
+            <p:with-input>
+               <p:inline>
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+         <p:identity>
+            <p:with-input pipe="report" />
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.xproc.org/ns/xvrl"
+            prefix="xvrl"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="//xvrl:report">There is no xvrl:report element.</s:assert>
+               <s:assert test="exists(//xvrl:report//xvrl:detection)">There should be a element 'xvrl:detection'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-012.xml
+++ b/test-suite/tests/ab-validate-with-dtd-012.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="pass" 
+        features="p-validate-with-dtd" 
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-012</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: Detection element needs to be in report for invalid document.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : '../documents/address.dtd'}" assert-valid="false">
+            <p:with-input>
+               <p:inline>
+                  <address >
+                     <first-name>Douglas</first-name>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+         <p:identity>
+            <p:with-input pipe="report" />
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.xproc.org/ns/xvrl"
+            prefix="xvrl"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="//xvrl:report">There is no xvrl:report element.</s:assert>
+               <s:assert test="exists(//xvrl:report//xvrl:detection)">There should be a element 'xvrl:detection'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-013.xml
+++ b/test-suite/tests/ab-validate-with-dtd-013.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="pass" 
+        features="p-validate-with-dtd" 
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-013</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: Detection element needs to be in report for non existing DTD.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd serialization="map{'doctype-system' : 'i-do-no-exist.dtd'}" assert-valid="false">
+            <p:with-input>
+               <p:inline>
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+         <p:identity>
+            <p:with-input pipe="report" />
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.xproc.org/ns/xvrl"
+            prefix="xvrl"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="//xvrl:report">There is no xvrl:report element.</s:assert>
+               <s:assert test="exists(//xvrl:report//xvrl:detection)">There should be a element 'xvrl:detection'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-validate-with-dtd-014.xml
+++ b/test-suite/tests/ab-validate-with-dtd-014.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test  expected="pass" 
+        features="p-validate-with-dtd" 
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-validate-with-dtd-014</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-08-15</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test DTD validation: Detection element needs to be in report for no DTD.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-dtd assert-valid="false">
+            <p:with-input>
+               <p:inline>
+                  <address >
+                     <first>Douglas</first>
+                     <last>Adams</last>
+                     <phone>42</phone>
+                  </address>
+               </p:inline>
+            </p:with-input>
+         </p:validate-with-dtd>
+         <p:identity>
+            <p:with-input pipe="report" />
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron"
+         xmlns="http://www.w3.org/1999/xhtml">
+         <s:ns uri="http://www.xproc.org/ns/xvrl"
+            prefix="xvrl"/>
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="//xvrl:report">There is no xvrl:report element.</s:assert>
+               <s:assert test="exists(//xvrl:report//xvrl:detection)">There should be a element 'xvrl:detection'.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
Wrote some tests for p:validate-with-dtd. What is not yet covered is

- content-type change HTML -> XML if document is not valid.
- Document properties of document on result port (valid and not-valid case)