### PR TITLE
Propose additional error code, err:XD0049

### DIFF
--- a/test-suite/tests/ab-http-request-071.xml
+++ b/test-suite/tests/ab-http-request-071.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <t:test features="p:http-request"
         expected="fail"
-        code="err:XC0030"
+        code="err:XC0030 err:XD0049"
         xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error">
    <t:info>


### PR DESCRIPTION
My implementation generates `err:XD0049`. I think that's a reasonable error code and I propose that we allow it. (I did investigate mapping 49 to 30 in this case, but it wouldn't be straightforward.)