### PR TITLE
Propose change to base URI

### DIFF
--- a/test-suite/tests/ab-p-document004.xml
+++ b/test-suite/tests/ab-p-document004.xml
@@ -65,7 +65,7 @@
          <p:identity>
             <p:with-input>
                <p:document href="about.html"
-                           xml:base="http://xproc.org/"/>
+                           xml:base="https://xproc.org/"/>
             </p:with-input>
          </p:identity>
          <p:cast-content-type content-type="application/xml">
@@ -85,7 +85,7 @@
             <s:rule context="/">
                <s:assert test="j:map">The document root is not map.</s:assert>
                <s:assert test="starts-with(j:map/j:string[@key='content-type']/text(), 'text/html')">Content type is not text/html.</s:assert>
-               <s:assert test="j:map/j:string[@key='base-uri']/text() = 'http://xproc.org/about.html'">The base-uri property is not correct.</s:assert>
+               <s:assert test="j:map/j:string[@key='base-uri']/text() = 'https://xproc.org/about.html'">The base-uri property is not correct.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>


### PR DESCRIPTION
If you `GET` a document, I think the base URI of the document you "got" is the final URI after any redirects have been applied. So I think the right answer here is `http**s**://...`
