### PR TITLE
Aren't these tests backward?

### DIFF
--- a/test-suite/tests/ab-validate-with-dtd-003.xml
+++ b/test-suite/tests/ab-validate-with-dtd-003.xml
@@ -24,10 +24,10 @@
                       version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:validate-with-dtd serialization="map{'doctype-system' : 'i-do-not-exist'}">
+         <p:validate-with-dtd serialization="map{'doctype-system' : '../documents/address.dtd'}">
             <p:with-input>
                <p:inline document-properties="map{'serialization' : 
-                                                   map{'doctype-system' : '../documents/address.dtd'}
+                                                   map{'doctype-system' : 'i-do-not-exist'}
                                                  }">
                   <address >
                      <first>Douglas</first>

--- a/test-suite/tests/ab-validate-with-dtd-006.xml
+++ b/test-suite/tests/ab-validate-with-dtd-006.xml
@@ -25,10 +25,10 @@
                       version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:validate-with-dtd serialization="map{'doctype-system' : 'i-do-not-exist'}">
+         <p:validate-with-dtd serialization="map{'doctype-system' : '../documents/address.dtd'}">
             <p:with-input>
                <p:inline document-properties="map{'serialization' : 
-                                                   map{'doctype-system' : '../documents/address.dtd'}
+                                                   map{'doctype-system' : 'i-do-not-exist'}
                                                  }">
                   <address >
                      <first>Douglas</first>


### PR DESCRIPTION
The tests say, correctly, that the properties on the step take precedence over the properties on the document.

But then the properties on the step are the *incorrect* ones.

Or am I misunderstanding something?
