### PR TITLE
New tests: p:load and p:document must follow redirects

### DIFF
--- a/test-suite/tests/ab-load-010.xml
+++ b/test-suite/tests/ab-load-010.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="webaccess"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>load 010 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-10-14</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Testing p:load: Redirects must be followed.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:load href="http://localhost:8246/service/this-is-a"/>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="doc">The document root is not 'doc'.</s:assert>
+               <s:assert test="doc/location">Document does not have a child element named 'location'</s:assert>
+               <s:assert test="doc/location/text()='This is d'">The text in element 'location' is not right.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-load-011.xml
+++ b/test-suite/tests/ab-load-011.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="webaccess"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>load 011 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-10-14</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Testing p:load: Redirects must be followed.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions">
+         <p:output port="result"/>
+         <p:load href="http://localhost:8246/service/this-is-a" />
+         <p:identity>
+            <p:with-input>
+               <result>
+                  <prop>{p:document-property(., 'base-uri')}</prop>
+                  <base>{fn:base-uri(.)}/</base>
+               </result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not 'result'.</s:assert>
+               <s:assert test="result/prop">Document does not have a child element named 'prop'</s:assert>
+               <s:assert test="result/prop/text()='http://localhost:8246/service/this-is-d'">The text in element 'prop' is not right.</s:assert>
+               <s:assert test="result/base">Document does not have a child element named 'base'</s:assert>
+               <s:assert test="result/base/text()='http://localhost:8246/service/this-is-d'">The text in element 'base' is not right.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-p-document-042.xml
+++ b/test-suite/tests/ab-p-document-042.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="webaccess"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-p-document 042 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-10-14</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Testing p:document: Redirects must be followed.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <p:document href="http://localhost:8246/service/this-is-a" />
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="doc">The document root is not 'doc'.</s:assert>
+               <s:assert test="doc/location">Document does not have a child element named 'location'</s:assert>
+               <s:assert test="doc/location/text()='This is d'">The text in element 'location' is not right.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/ab-p-document-043.xml
+++ b/test-suite/tests/ab-p-document-043.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="webaccess"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>ab-p-document 043 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-10-14</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Testing p:document: Redirects must be followed.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:fn="http://www.w3.org/2005/xpath-functions">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <p:document href="http://localhost:8246/service/this-is-a" />
+            </p:with-input>
+         </p:identity>
+         <p:identity>
+            <p:with-input>
+               <result>
+                  <prop>{p:document-property(., 'base-uri')}</prop>
+                  <base>{fn:base-uri(.)}/</base>
+               </result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not 'result'.</s:assert>
+               <s:assert test="result/prop">Document does not have a child element named 'prop'</s:assert>
+               <s:assert test="result/prop/text()='http://localhost:8246/service/this-is-d'">The text in element 'prop' is not right.</s:assert>
+               <s:assert test="result/base">Document does not have a child element named 'base'</s:assert>
+               <s:assert test="result/base/text()='http://localhost:8246/service/this-is-d'">The text in element 'base' is not right.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
Tests check

1. correct result of a redirected uri.
2. correct base-uri and document-property 'base-uri' of the loaded document.