### PR TITLE
Test with wrong uri modified, and new test for xd0011

### DIFF
--- a/test-suite/tests/ab-p-document004.xml
+++ b/test-suite/tests/ab-p-document004.xml
@@ -6,6 +6,15 @@
       <t:title>p:document 004</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-14</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Changed test, so an existing resource is resolved.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -64,8 +73,8 @@
          <p:output port="result"/>
          <p:identity>
             <p:with-input>
-               <p:document href="about.html"
-                           xml:base="http://xproc.org/"/>
+               <p:document href="test-suite.html"
+                           xml:base="https://xproc.org/"/>
             </p:with-input>
          </p:identity>
          <p:cast-content-type content-type="application/xml">
@@ -85,7 +94,7 @@
             <s:rule context="/">
                <s:assert test="j:map">The document root is not map.</s:assert>
                <s:assert test="starts-with(j:map/j:string[@key='content-type']/text(), 'text/html')">Content type is not text/html.</s:assert>
-               <s:assert test="j:map/j:string[@key='base-uri']/text() = 'http://xproc.org/about.html'">The base-uri property is not correct.</s:assert>
+               <s:assert test="j:map/j:string[@key='base-uri']/text() = 'https://xproc.org/test-suite.html'">The base-uri property is not correct.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-p-document004a.xml
+++ b/test-suite/tests/ab-p-document004a.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XD0011"
+        features="webaccess"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:document 004a</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-10-14</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial check in.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:document raises an error (XD0011) if the referenced resource doesnot exist.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <p:document href="i-do-no-exist.html"
+                           xml:base="https://xproc.org/"/>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
@ndw This PR is a replacement for #733 

1. I modified the original test to refer to an existing resource.
2. Wrote a new test refering to a non-existing resource to raise XD0011

Hope that does not overlap with something you do.
