### PR TITLE
Add expand-text to p:run inline pipelines

### DIFF
--- a/test-suite/tests/ab-p-run-033.xml
+++ b/test-suite/tests/ab-p-run-033.xml
@@ -5,6 +5,15 @@
       <t:title>p:run-033</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2022-09-28</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -23,7 +32,7 @@
          xmlns:xs = "http://www.w3.org/2001/XMLSchema">
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0">
                      <p:output port="result" />
                      <p:option name="opt" as="xs:boolean" required="true" />

--- a/test-suite/tests/ab-p-run-035.xml
+++ b/test-suite/tests/ab-p-run-035.xml
@@ -4,6 +4,15 @@
       <t:title>p:run-035</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-05-28</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0">
                      <p:output port="result" />
                      <p:option name="opt" as="xs:boolean" required="true" />

--- a/test-suite/tests/ab-p-run-035a.xml
+++ b/test-suite/tests/ab-p-run-035a.xml
@@ -5,6 +5,15 @@
       <t:title>p:run-035a</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-05-28</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,7 +34,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0">
                      <p:output port="result" />
                      <p:option name="opt" as="xs:boolean" required="true" />

--- a/test-suite/tests/ab-p-run-036.xml
+++ b/test-suite/tests/ab-p-run-036.xml
@@ -4,6 +4,15 @@
       <t:title>p:run-036</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-05-28</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0">
                      <p:output port="result" />
                      <p:option name="opt" as="map(xs:QName, xs:string)" required="true" />

--- a/test-suite/tests/ab-p-run-036a.xml
+++ b/test-suite/tests/ab-p-run-036a.xml
@@ -5,6 +5,15 @@
       <t:title>p:run-036a</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-05-28</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -27,7 +36,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0">
                      <p:output port="result" />
                      <p:option name="opt" as="map(xs:QName, xs:string)" required="true" />

--- a/test-suite/tests/ab-p-run-037.xml
+++ b/test-suite/tests/ab-p-run-037.xml
@@ -4,6 +4,15 @@
       <t:title>p:run-037</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2022-10-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -22,7 +31,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0">
                      <p:output port="result" />
                      <p:option name="opt" required="true" />

--- a/test-suite/tests/ab-p-run-038.xml
+++ b/test-suite/tests/ab-p-run-038.xml
@@ -4,6 +4,15 @@
       <t:title>p:run-038</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2022-10-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -22,7 +31,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0" xmlns:fn="http://www.w3.org/2005/xpath-functions">
                      <p:output port="result" />
                      <p:option name="opt"  />

--- a/test-suite/tests/ab-p-run-039.xml
+++ b/test-suite/tests/ab-p-run-039.xml
@@ -4,6 +4,15 @@
       <t:title>p:run-039</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-08-03</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,7 +40,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0" xmlns:fn="http://www.w3.org/2005/xpath-functions">
                      <p:output port="result" />
                      <p:option name="opt"  select="42"/>

--- a/test-suite/tests/ab-p-run-040.xml
+++ b/test-suite/tests/ab-p-run-040.xml
@@ -5,6 +5,15 @@
       <t:title>p:run-040</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-08-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0" xmlns:fn="http://www.w3.org/2005/xpath-functions"
                      xmlns:xs="http://www.w3.org/2001/XMLSchema">
                      <p:output port="result" />

--- a/test-suite/tests/ab-p-run-043.xml
+++ b/test-suite/tests/ab-p-run-043.xml
@@ -4,6 +4,15 @@
       <t:title>p:run-043</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2022-10-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -23,7 +32,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0" xmlns:fn="http://www.w3.org/2005/xpath-functions">
                      <p:input port="source" sequence="true" primary="false"/>
                      <p:output port="result" />

--- a/test-suite/tests/ab-p-run-044.xml
+++ b/test-suite/tests/ab-p-run-044.xml
@@ -5,6 +5,15 @@
       <t:title>p:run-044</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2022-10-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,7 +33,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0" xmlns:fn="http://www.w3.org/2005/xpath-functions">
                      <p:input port="source" primary="false"/>
                      <p:output port="result" />

--- a/test-suite/tests/ab-p-run-048.xml
+++ b/test-suite/tests/ab-p-run-048.xml
@@ -4,6 +4,15 @@
       <t:title>p:run-048</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2024-10-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added expand-text=false where necessary.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2022-10-01</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -22,7 +31,7 @@
          <p:output port="result" />
          <p:run>
             <p:with-input>
-               <p:inline>
+               <p:inline expand-text="false">
                   <p:declare-step version="3.0">
                      <p:option name="static" static="true" />
                      <p:output port="result" />


### PR DESCRIPTION
Several pipelines need `exapand-text="false"` to avoid premature evaluation of the inine AVT expression.