### PR TITLE
Allow err:XS0037 as well

### DIFF
--- a/test-suite/tests/ab-with-input-053f.xml
+++ b/test-suite/tests/ab-with-input-053f.xml
@@ -1,7 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079 err:XS0037">
    <t:info>
       <t:title>with-input-053f</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2024-11-04T17:00:00Z</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Also allow err:XS0037.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2018-07-11T19:09:05+02:00</t:date>
             <t:author>

--- a/test-suite/tests/ab-with-input-053g.xml
+++ b/test-suite/tests/ab-with-input-053g.xml
@@ -1,7 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079 err:XS0037">
    <t:info>
       <t:title>with-input-053g</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2024-11-04T17:00:00Z</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Also allow err:XS0037.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2018-07-11T19:09:05+02:00</t:date>
             <t:author>

--- a/test-suite/tests/ab-with-input-053h.xml
+++ b/test-suite/tests/ab-with-input-053h.xml
@@ -1,7 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079 err:XS0037">
    <t:info>
       <t:title>with-input-053h</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2024-11-04T17:00:00Z</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Also allow err:XS0037.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2018-07-11T19:09:05+02:00</t:date>
             <t:author>

--- a/test-suite/tests/ab-with-input-054.xml
+++ b/test-suite/tests/ab-with-input-054.xml
@@ -1,7 +1,16 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0079 err:XS0037">
    <t:info>
       <t:title>with-input-054</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2024-11-04T17:00:00Z</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Also allow err:XS0037.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2018-06-02T17:53:51-05:00</t:date>
             <t:author>


### PR DESCRIPTION
I think `err:XS0037`:

> It is a [static error](https://spec.xproc.org/master/head/xproc/#dt-static-error) ([err:XS0037](https://spec.xproc.org/master/head/xproc/#err.S0037)) if ... any element in the XProc namespace other than [p:inline](https://spec.xproc.org/master/head/xproc/#p.inline) directly contains text nodes that do not consist entirely of whitespace.

applies equally here. My processor detects `err:XS0037` long before it considers that this is text in an input binding.