### PR TITLE
Allow err:XS0107 as an alternative error code

### DIFF
--- a/test-suite/tests/ab-system-property-011.xml
+++ b/test-suite/tests/ab-system-property-011.xml
@@ -1,9 +1,18 @@
 <t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" 
         xmlns:err="http://www.w3.org/ns/xproc-error"
-        expected="fail" code="err:XD0015">
+        expected="fail" code="err:XD0015 err:XS0107">
    <t:info>
       <t:title>ab-system-property-011</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-04</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Allow <code>err:XS0107</code> as an alternative</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2019-07-14</t:date>
             <t:author>


### PR DESCRIPTION
It is a static error in an XPath expression. It turns out, I have no way of working out that the error occurs in the argument to `p:system-property`.