### PR TITLE
Adapted import XQuery function tests

### DIFF
--- a/test-suite/documents/xquery-library.xq
+++ b/test-suite/documents/xquery-library.xq
@@ -1,0 +1,19 @@
+xquery version "3.1";
+module namespace test="http://xproc.org/ns/testsuite/3.0/function-test";
+
+declare function test:function() as item(){
+  element{"function-result"}{}
+};
+
+declare function test:function1() as item(){
+  element{"function-result"}{}
+};
+declare function test:function2($par as xs:string) as item(){
+    element{"function-result"}{$par}
+};
+declare %private function test:private-function() as item(){
+    element{"function-result"}{}
+};
+declare function test:function3() as item(){
+  element{"namespaced-function"}{}
+};

--- a/test-suite/documents/xquery-library1.xq
+++ b/test-suite/documents/xquery-library1.xq
@@ -1,0 +1,4 @@
+xquery version "3.1";
+module namespace test="http://xproc.org/ns/testsuite/3.0/function-test"
+(:intentionally invalid; missing semicolon:)
+declare namespace test1="http://xproc.org/ns/testsuite/3.0/function-test1";

--- a/test-suite/documents/xquery-library2.xq
+++ b/test-suite/documents/xquery-library2.xq
@@ -1,0 +1,10 @@
+xquery version "3.1";
+module namespace test="http://xproc.org/ns/testsuite/3.0/function-test";
+
+declare function test:function() as item(){
+element{"function-result"}{}
+};
+
+declare function test:function1() as item(){
+element{"function-result1"}{}
+};

--- a/test-suite/documents/xquery-library3.xq
+++ b/test-suite/documents/xquery-library3.xq
@@ -1,0 +1,6 @@
+xquery version "3.1";
+module namespace test="http://xproc.org/ns/testsuite/3.0/function-test";
+
+declare function test:function1($par as xs:string) as item(){
+    element{"function-result"}{$par}
+};

--- a/test-suite/tests/nw-import-functions-001.xml
+++ b/test-suite/tests/nw-import-functions-001.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="xquery-function-import"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-06</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-functions.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: tests importing the same library twice.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input>
+               <result>{test:function1()}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/function-result">Result does not have a child "function-result".</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-import-functions-002.xml
+++ b/test-suite/tests/nw-import-functions-002.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="xquery-function-import"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-06</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-functions.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: tests limiting XQuery imports by namespace.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq"
+                             namespace="http://example.com/1 http://example.com/1"
+                             content-type="application/xquery" />
+         <p:output port="result" />
+
+         <p:try>
+           <p:identity>
+             <p:with-input>
+               <result>{test:function1()}</result>
+             </p:with-input>
+           </p:identity>
+           <p:catch xmlns:err="http://www.w3.org/ns/xproc-error"
+                    code="err:XS0107">
+             <p:identity>
+               <p:with-input>
+                 <correct/>
+               </p:with-input>
+             </p:identity>
+           </p:catch>
+         </p:try>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="correct">The document root is not correct.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-import-functions-003.xml
+++ b/test-suite/tests/nw-import-functions-003.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="xquery-function-import"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-003</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-06</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-functions.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: tests limiting XSLT imports by namespace.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test"
+                      xmlns:test1="http://xproc.org/ns/testsuite/3.0/function-test1">
+         <p:import-functions href="../documents/xslt-functions.xsl"
+                             namespace="http://xproc.org/ns/testsuite/3.0/function-test1"
+                             content-type="application/xslt" />
+         <p:output port="result" />
+
+         <p:try>
+           <p:identity>
+             <p:with-input>
+               <result>{test:function1()}</result>
+             </p:with-input>
+           </p:identity>
+           <p:catch xmlns:err="http://www.w3.org/ns/xproc-error"
+                    code="err:XS0107">
+             <p:identity>
+               <p:with-input>
+                 <correct/>
+               </p:with-input>
+             </p:identity>
+           </p:catch>
+         </p:try>
+
+         <p:insert position="last-child">
+           <p:with-input port="insertion">
+             <result>{test1:function1()}</result>
+           </p:with-input>
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="correct">The document root is not correct.</s:assert>
+               <s:assert test="correct/result/namespaced-function">Result doesn’t include test1:function1 output</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-import-functions-015.xml
+++ b/test-suite/tests/nw-import-functions-015.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="xquery-function-import"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-015</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-015 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions from an XQuery library module.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{test:function1()}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/function-result">Result does not have a child "function-result".</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-import-functions-016.xml
+++ b/test-suite/tests/nw-import-functions-016.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="xquery-function-import"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-016</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-016 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: function with par</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery"/>
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{test:function2("test")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/function-result">Result does not have a child "function-result".</s:assert>
+               <s:assert test="result/function-result/text()='test'">There is not text child 'test' in "function-result".</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-import-functions-017.xml
+++ b/test-suite/tests/nw-import-functions-017.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="xquery-function-import"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-017</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-017 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Test function is visible in inner steps.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         <p:declare-step type="test:step">
+            <p:output port="result"/>
+            <p:identity>
+               <p:with-input>
+                  <result>{test:function1()}</result>
+               </p:with-input>
+            </p:identity>
+         </p:declare-step>
+         <test:step />
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/function-result">Result does not have a child "function-result".</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-import-functions-018.xml
+++ b/test-suite/tests/nw-import-functions-018.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="xquery-function-import"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-018</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-018 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Test function imported globally and locally.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         
+         <p:declare-step type="test:step">
+            <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+            <p:output port="result"/>
+            <p:identity>
+               <p:with-input>
+                  <result>{test:function1()}</result>
+               </p:with-input>
+            </p:identity>
+         </p:declare-step>
+         <test:step />
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/function-result">Result does not have a child "function-result".</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-import-functions-019.xml
+++ b/test-suite/tests/nw-import-functions-019.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0107" features="xquery-function-import"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-019</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-019 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Test function imported locally imported function is not visible globally.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:output port="result" />
+         
+         <p:declare-step type="test:step">
+            <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+            <p:output port="result"/>
+            <p:identity>
+               <p:with-input>
+                  <result>{test:function1()}</result>
+               </p:with-input>
+            </p:identity>
+         </p:declare-step>
+         
+         <p:identity>
+            <p:with-input>
+               <result>{test:function1()}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-import-functions-020.xml
+++ b/test-suite/tests/nw-import-functions-020.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0107" features="xquery-function-import"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-020</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-020 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Test function imported locally imported function is not visible in other step.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:output port="result" />
+         
+         <p:declare-step type="test:step">
+            <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+            <p:output port="result"/>
+            <p:identity>
+               <p:with-input>
+                  <result>{test:function1()}</result>
+               </p:with-input>
+            </p:identity>
+         </p:declare-step>
+         
+         <p:declare-step type="test:step1">
+            <p:output port="result" />
+            <p:identity>
+               <p:with-input>
+                  <result>{test:function1()}</result>
+               </p:with-input>
+            </p:identity>
+         </p:declare-step>
+         
+         <test:step1 />
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-import-functions-021.xml
+++ b/test-suite/tests/nw-import-functions-021.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0107" features="xquery-function-import"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-021</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-021 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Calling non defined function is an error.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input><result>{test:undefined-function()}</result></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-import-functions-022.xml
+++ b/test-suite/tests/nw-import-functions-022.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0107" features="xquery-function-import"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-022</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-022 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Calling private function is an error.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input><result>{test:private-function()}</result></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-import-functions-023.xml
+++ b/test-suite/tests/nw-import-functions-023.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0107" features="xquery-function-import"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-023</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-023 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Calling private function is an error.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input><result>{test:private-function()}</result></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-import-functions-024.xml
+++ b/test-suite/tests/nw-import-functions-024.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0106" features="xquery-function-import"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-024</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-024 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Calling no invalid query is an error.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library1.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input><result>{test:function()}</result></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-import-functions-025.xml
+++ b/test-suite/tests/nw-import-functions-025.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="xquery-function-import"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-025</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-025 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Test function global and local import with same name.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         
+         <p:declare-step type="test:step">
+            <p:import-functions href="../documents/xquery-library2.xq" content-type="application/xquery" />
+            <p:output port="result"/>
+            <p:identity>
+               <p:with-input>
+                  <result>
+                     <one>{test:function1()}</one>
+                  </result>
+               </p:with-input>
+            </p:identity>
+         </p:declare-step>
+         <test:step />
+         <p:insert match="result" position="last-child">
+            <p:with-input port="insertion">
+               <two>{test:function1()}</two>
+            </p:with-input>
+         </p:insert>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/one/function-result1">Element "one" does not have a child "function-result1".</s:assert>
+               <s:assert test="result/two/function-result">Element "two" does not have a child "function-result".</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-import-functions-026.xml
+++ b/test-suite/tests/nw-import-functions-026.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0105" features="xquery-function-import"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-026</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-026 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Importing stylesheet with same named functions.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:import-functions href="../documents/xquery-library2.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input><result>{test:function()}</result></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-import-functions-027.xml
+++ b/test-suite/tests/nw-import-functions-027.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" features="xquery-function-import"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-027</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-027 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Importing functions with the same name, but different arity.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xquery" />
+         <p:import-functions href="../documents/xquery-library3.xq" content-type="application/xquery" />
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input>
+               <result>
+                  <one>{test:function1()}</one>
+                  <two>{test:function1("text")}</two>
+                  <two></two>
+               </result></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/one/function-result">Element "one" does not have a child "function-result".</s:assert>
+               <s:assert test="result/two/function-result/text()='text'">Element "two" does not have a child "function-result" with "text".</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-import-functions-030.xml
+++ b/test-suite/tests/nw-import-functions-030.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0106 err:XS0107" features="xslt-function-import"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-030</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-030 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Laoding xquery with xslt mime type.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library.xq" content-type="application/xslt+xml" />
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input><result>{test:function()}</result></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-import-functions-031.xml
+++ b/test-suite/tests/nw-import-functions-031.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0105" features="xslt-function-import xquery-function-import"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-functions-031</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-05</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Tests for p:import-function; adapted from ab-import-functions-031 but
+               uses an XQuery library module.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import-functions: Laoding function with same name from xquery and xslt.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://xproc.org/ns/testsuite/3.0/function-test">
+         <p:import-functions href="../documents/xquery-library3.xq" content-type="application/xquery" />
+         <p:import-functions href="../documents/xslt-functions3.xsl" content-type="application/xslt+xml" />
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input><result>{test:function1('arg')}</result></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
My implementation can only import XQuery library modules. I've adapted the relevant XQuery import function tests to import library modules. I think I got them all correct, but it was a bit of a tedious task. I can't run tests 25, 26, or 31, so those might be wrong.

@xml-project I'd be curious if you can run them and if they all pass...