### PR TITLE
Simple tests for step type and option transitivity

### DIFF
--- a/test-suite/pipelines/nw-library-001.xpl
+++ b/test-suite/pipelines/nw-library-001.xpl
@@ -1,0 +1,13 @@
+<p:library xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+
+  <p:import href="ab-library-001.xpl"/>
+  
+  <p:declare-step type="Q{http://test}three"
+                  xmlns:t="http://test">
+    <p:output port="result" />
+    <t:one/>
+    <p:rename match="/one" new-name="three"/>
+  </p:declare-step>
+    
+</p:library>
+

--- a/test-suite/pipelines/nw-library-002.xpl
+++ b/test-suite/pipelines/nw-library-002.xpl
@@ -1,0 +1,8 @@
+<p:library xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+
+  <p:import href="ab-library-015.xpl"/>
+
+  <p:option name="option2" static="true" select="'π'"/>
+    
+</p:library>
+

--- a/test-suite/tests/ab-library-024.xml
+++ b/test-suite/tests/ab-library-024.xml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test expected="pass"
+<t:test expected="fail" code="err:XS0088"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
         xmlns:t="http://xproc.org/ns/testsuite/3.0">
    <t:info>
       <t:title>Library import 024 (AB)</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-06</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>On closer examination, this test shadows static option1, which is an error.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
@@ -47,16 +57,4 @@
          </p:wrap-sequence>
       </p:declare-step>
    </t:pipeline>
-   <t:schematron>
-      <s:schema queryBinding="xslt2"
-                xmlns:s="http://purl.oclc.org/dsdl/schematron">
-         <s:pattern>
-            <s:rule context="/">
-               <s:assert test="result">The document root is not result.</s:assert>
-               <s:assert test="result/doc[1]/text()=99">Text child of doc is not 99.</s:assert>
-               <s:assert test="result/doc[2]/text()=42">Text child of doc is not 42.</s:assert>
-            </s:rule>
-         </s:pattern>
-      </s:schema>
-   </t:schematron>
 </t:test>

--- a/test-suite/tests/nw-library-001.xml
+++ b/test-suite/tests/nw-library-001.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-library-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-06</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that step imports are transitive.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step version="3.0"
+                     xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:x="http://test">
+         <p:import href="../pipelines/nw-library-001.xpl"/>
+         <p:output port="result"/>
+
+         <x:one name="a"/>
+         <x:two name="b"/>
+         <x:three name="c"/>
+
+         <p:wrap-sequence wrapper="result">
+           <p:with-input pipe="@a @b @c"/>
+         </p:wrap-sequence>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/*[1]/self::one">The first child is not ‘one’</s:assert>
+               <s:assert test="result/*[2]/self::two">The first child is not ‘two’</s:assert>
+               <s:assert test="result/*[3]/self::three">The first child is not ‘three’</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-library-002.xml
+++ b/test-suite/tests/nw-library-002.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0036"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-library-002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-06</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that step imports are transitive.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step version="3.0"
+                     xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:x="http://test">
+         <p:import href="../pipelines/nw-library-001.xpl"/>
+         <p:output port="result"/>
+
+         <p:declare-step type="x:one">
+           <p:output port="result" />
+           <p:identity>
+             <p:with-input><one-prime /></p:with-input>
+           </p:identity>
+         </p:declare-step>
+
+         <x:one name="a"/>
+         <x:two name="b"/>
+         <x:three name="c"/>
+
+         <p:wrap-sequence wrapper="result">
+           <p:with-input pipe="@a @b @c"/>
+         </p:wrap-sequence>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-library-003.xml
+++ b/test-suite/tests/nw-library-003.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-library-003</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-06</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that option imports are transitive.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step version="3.0"
+                     xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:x="http://test">
+         <p:import href="../pipelines/nw-library-002.xpl"/>
+         <p:output port="result"/>
+         
+         <p:identity>
+           <p:with-input>
+             <result>
+               <option>{$option}</option>
+               <pi>{$option2}</pi>
+             </result>
+           </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/option = 42">The option value isn’t 42.</s:assert>
+               <s:assert test="result/pi = 'π'">The pi value isn’t π.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-library-004.xml
+++ b/test-suite/tests/nw-library-004.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0088"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-library-004</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-06</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that option imports are transitive.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step version="3.0"
+                     xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:x="http://test">
+         <p:import href="../pipelines/nw-library-002.xpl"/>
+         <p:output port="result"/>
+
+         <p:option name="option" select="'bzzzt. nope.'"/>
+
+         <p:identity>
+           <p:with-input>
+             <result>
+               <option>{$option}</option>
+             </result>
+           </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
I tried to write four tests to demonstrate transitivity of step types and options across imports.

These results reflect my current interpretatation of the spec, which is not always correct :-)