### PR TITLE
A few more step-available/use-when tests

### DIFF
--- a/test-suite/pipelines/nw-decl1.xpl
+++ b/test-suite/pipelines/nw-decl1.xpl
@@ -1,0 +1,12 @@
+<p:library version="3.0" 
+           xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:x="http://example.com/steps">
+    
+  <p:declare-step type="x:step1">
+    <p:output port="result" />
+    <p:identity>
+      <p:with-input><step1/></p:with-input>        
+    </p:identity>
+  </p:declare-step>
+
+</p:library>

--- a/test-suite/pipelines/nw-decl2.xpl
+++ b/test-suite/pipelines/nw-decl2.xpl
@@ -1,0 +1,12 @@
+<p:library version="3.0" 
+           xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:x="http://example.com/steps">
+    
+  <p:declare-step type="x:step2">
+    <p:output port="result" />
+    <p:identity>
+      <p:with-input><step2/></p:with-input>        
+    </p:identity>
+  </p:declare-step>
+
+</p:library>

--- a/test-suite/pipelines/nw-decl3.xpl
+++ b/test-suite/pipelines/nw-decl3.xpl
@@ -1,0 +1,12 @@
+<p:library version="3.0" 
+           xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:x="http://example.com/steps">
+    
+  <p:declare-step type="x:step3">
+    <p:output port="result" />
+    <p:identity>
+      <p:with-input><step3/></p:with-input>        
+    </p:identity>
+  </p:declare-step>
+
+</p:library>

--- a/test-suite/tests/nw-step-available-005.xml
+++ b/test-suite/tests/nw-step-available-005.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>nw-step-available-005</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2024-12-06</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Initial commit</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests p:step-available with use-when and a chain of hidden steps, ending successfully.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step name="main"
+                    version="3.0"
+                    xmlns:p="http://www.w3.org/ns/xproc"
+                    xmlns:imp="http://example.com/steps"
+                    xmlns:ex="http://extension">
+
+      <p:import href="../pipelines/nw-decl1.xpl" use-when="p:step-available('imp:step2')"/>
+      <p:import href="../pipelines/nw-decl2.xpl" use-when="p:step-available('imp:step3')"/>
+      <p:import href="../pipelines/nw-decl3.xpl"/>
+
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input>
+          <result>
+            <test>{p:step-available('imp:step1')}</test>
+          </result>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron"
+              xmlns="http://www.w3.org/1999/xhtml">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="result">The document root is not “result”.</s:assert>
+          <s:assert test="result/test/text()='true'">p:step-available for 'imp:step1' is wrong.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron> 
+</t:test>

--- a/test-suite/tests/nw-step-available-006.xml
+++ b/test-suite/tests/nw-step-available-006.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>nw-step-available-006</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2024-12-06</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Initial commit</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests p:step-available with use-when and a chain of hidden steps, ending in failure.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step name="main"
+                    version="3.0"
+                    xmlns:p="http://www.w3.org/ns/xproc"
+                    xmlns:imp="http://example.com/steps"
+                    xmlns:ex="http://extension">
+
+      <p:import href="../pipelines/nw-decl1.xpl" use-when="p:step-available('imp:step2')"/>
+      <p:import href="../pipelines/nw-decl2.xpl" use-when="p:step-available('imp:step3')"/>
+      <p:import href="../pipelines/nw-decl3.xpl" use-when="p:step-available('ex:spoon')"/>
+
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input>
+          <result>
+            <test>{p:step-available('imp:step1')}</test>
+          </result>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron"
+              xmlns="http://www.w3.org/1999/xhtml">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="result">The document root is not “result”.</s:assert>
+          <s:assert test="result/test/text()='false'">p:step-available for 'imp:step1' is wrong.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron> 
+</t:test>

--- a/test-suite/tests/nw-step-available-007.xml
+++ b/test-suite/tests/nw-step-available-007.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>nw-step-available-007</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2024-12-06</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Initial commit</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests p:step-available with use-when and a chain of hidden steps.
+    If the use of step-available on p:import is treated as a special case,
+    this ends in failure. But an argument could be made that this contains
+    a deadlock.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step name="main"
+                    version="3.0"
+                    xmlns:p="http://www.w3.org/ns/xproc"
+                    xmlns:imp="http://example.com/steps"
+                    xmlns:ex="http://extension">
+
+      <p:import href="../pipelines/nw-decl1.xpl" use-when="p:step-available('imp:step2')"/>
+      <p:import href="../pipelines/nw-decl2.xpl" use-when="p:step-available('imp:step3')"/>
+      <p:import href="../pipelines/nw-decl3.xpl" use-when="p:step-available('imp:step1')"/>
+
+      <p:output port="result"/>
+      
+      <p:identity>
+        <p:with-input>
+          <result>
+            <test>{p:step-available('imp:step1')}</test>
+          </result>
+        </p:with-input>
+      </p:identity>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron"
+              xmlns="http://www.w3.org/1999/xhtml">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="result">The document root is not “result”.</s:assert>
+          <s:assert test="result/test/text()='false'">p:step-available for 'imp:step1' is wrong.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron> 
+</t:test>


### PR DESCRIPTION
I was having trouble with `ab-step-available-061`. My implementation was looking at the import statement and concluding that a deadlock existed. It needed to work out the `p:step-availalable()` in order to decide whether or not to load the library and it needed to load the library in order to work out if the step was available. That's an unsatisfactory conclusion for two reasons: a deadlock of one step is a bit odd and also the step isn't defined in the library so the answer is that it isn't available.

I decided to implement some special case logic for `use-when` on `p:import`. It works fine for `ab-step-available-061` but I was concerned that it might be tripped up in more complicated situations. These tests demonstrate how my implementation handles the more complicated cases that occurred to me.

* In `nw-step-available-005`, we decide 1 can be loaded because we decide 2 can be loaded because 3 can be loaded. The step is defined.
* In `nw-step-available-006`, we decide that 1 cannot be loaded because we decide that 2 cannot be loaded because we decide 3 cannot be loaded. The step is not defined.
* In `nw-step-available-007`, we have the screw case. Like 006, we conclude that the step is not defined because we decide that 3 cannot be loaded. *But* I think you could make a case that this situation is deadlocked. *If* you loaded 3, then you could load 2 and 1 and it would be defined.

However, I think I can live with these results. There is *a lot* of complexity in this area to handle complicated situations that are never going to occur in real life. And if they did occur, I think you could quite reasonable respond like the doctor who's patient came in complaining of a pain. "Doctor, doctor," the patient said, "it hurts when I do this." The doctor replied, "then don't do that."