### PR TITLE
Smoke test for p:lookup-uri

### DIFF
--- a/test-suite/tests/nw-lookup-uri-001.xml
+++ b/test-suite/tests/nw-lookup-uri-001.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-lookup-uri-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-15</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:lookup-uri() function. The assumption here is that there’s nothing
+      special about the uri <code>https://xproc.org/</code> and so that’s what the
+      function returns.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>
+                  <lookup-xproc>{p:lookup-uri('https://xproc.org/')}</lookup-xproc>
+               </result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The document root is not result.</s:assert>
+               <s:assert test="result/lookup-xproc/text() != 'https://xproc.org/'">Lookup URI returned an unexpected result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
There were no tests for p:lookup-uri()

