### PR TITLE
Test the updates to p:filter

### DIFF
--- a/test-suite/tests/nw-filter-012.xml
+++ b/test-suite/tests/nw-filter-012.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>p:filter 012 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-21</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Proposed test.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:filter that returns a constant.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:output port="result"/>
+         <p:option name="select" as="xs:string?" select="'chapter'"/>
+         <p:variable name="eq" select="'='"/>
+
+         <p:identity>
+           <p:with-input>
+             <book>
+               <chapter>Hello, world.</chapter>
+               <appendix>Goodbye, world.</appendix>
+             </book>
+           </p:with-input>
+         </p:identity>
+
+         <p:filter select="count(/book/*[local-name(.) {$eq} '{$select}'])"/>
+
+         <p:cast-content-type content-type="application/xml"/>
+      </p:declare-step>
+   </t:pipeline>
+
+   <t:schematron>
+     <s:schema queryBinding="xslt2"
+               xmlns:s="http://purl.oclc.org/dsdl/schematron"
+               xmlns="http://www.w3.org/1999/xhtml">
+       <s:ns prefix="fn" uri="http://www.w3.org/2005/xpath-functions"/>
+       <s:pattern>
+         <s:rule context="/">
+           <s:assert test="fn:number">The result root is not a number.</s:assert>
+           <s:assert test="string(.) = '1'">The result is not 1.</s:assert>
+         </s:rule>
+       </s:pattern>
+     </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-filter-012.xml
+++ b/test-suite/tests/nw-filter-012.xml
@@ -5,7 +5,7 @@
       <t:title>p:filter 012 (NW)</t:title>
       <t:revision-history>
          <t:revision>
-            <t:date>2024-12-21</t:date>
+            <t:date>2024-12-24</t:date>
             <t:author>
                <t:name>Norm Tovey-Walsh</t:name>
             </t:author>


### PR DESCRIPTION
This test assures that `p:filter` is implemented in accordance with the update in https://github.com/xproc/3.0-steps/pull/645

(Evidence suggests all implementations already do this.)