### PR TITLE
New test for shared, common input

### DIFF
--- a/test-suite/pipelines/nw-import-002-lib-common.xpl
+++ b/test-suite/pipelines/nw-import-002-lib-common.xpl
@@ -1,0 +1,11 @@
+<p:library xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:test="http://test" version="3.0">
+
+  <p:declare-step type="test:common-step">
+    <p:output port="result"/>
+    <p:identity>
+      <p:with-input><common/></p:with-input>
+    </p:identity>
+  </p:declare-step>
+
+</p:library>

--- a/test-suite/pipelines/nw-import-002-lib1.xpl
+++ b/test-suite/pipelines/nw-import-002-lib1.xpl
@@ -1,0 +1,14 @@
+<p:library xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:test="http://test" version="3.0">
+
+  <p:import href="nw-import-002-lib2.xpl"/>
+  <p:import href="nw-import-002-lib-common.xpl"/>
+
+  <p:declare-step type="test:one">
+    <p:output port="result"/>
+    <p:identity>
+      <p:with-input><one/></p:with-input>
+    </p:identity>
+  </p:declare-step>
+
+</p:library>

--- a/test-suite/pipelines/nw-import-002-lib2.xpl
+++ b/test-suite/pipelines/nw-import-002-lib2.xpl
@@ -1,0 +1,13 @@
+<p:library xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:test="http://test" version="3.0">
+
+  <p:import href="nw-import-002-lib-common.xpl"/>
+
+  <p:declare-step type="test:two">
+    <p:output port="result"/>
+    <p:identity>
+      <p:with-input><two/></p:with-input>
+    </p:identity>
+  </p:declare-step>
+
+</p:library>

--- a/test-suite/tests/nw-import-002.xml
+++ b/test-suite/tests/nw-import-002.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-import-002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-24</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>This test verifies that multiple imports of the same common library do
+      not count as duplicates. It’s derived from a real-world bug report from Achim.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:test="http://test">
+         <p:import href="../pipelines/nw-import-002-lib1.xpl"/>
+         <p:import href="../pipelines/nw-import-002-lib2.xpl"/>
+         <p:output port="result"/>
+         <test:common-step/>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="common">The pipeline root is not “common”.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
This test verifies that multiple imports of the same common library do not count as duplicates. It’s derived from a real-world bug report from @xml-project 

The wrinkle here, the thing that previous tests didn't cover, seems to be the fact that the common library is imported twice, at two different levels.