### PR TITLE
New PSVI-related tests, err:XD0022

### DIFF
--- a/test-suite/documents/dated-sample.xml
+++ b/test-suite/documents/dated-sample.xml
@@ -1,0 +1,9 @@
+<doc xmlns="http://example.com/sample"
+     pubdate="2024-12-25">
+  <title>Some Title</title>
+  <p>A paragraph.</p>
+  <note xml:id='note'>
+    <p>A paragraph in note.</p>
+  </note>
+</doc>
+

--- a/test-suite/documents/sample.xsd
+++ b/test-suite/documents/sample.xsd
@@ -1,0 +1,81 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:s="http://example.com/sample"
+           targetNamespace="http://example.com/sample"
+	   elementFormDefault="qualified">
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"/>
+   
+  <xs:element name="doc">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element minOccurs="0" ref="s:title"/>
+        <xs:choice maxOccurs="unbounded">
+	  <xs:element ref="s:p"/>
+	  <xs:element ref="s:div"/>
+	  <xs:element ref="s:note"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="pubdate" type="xs:date"/>
+      <xs:attribute name="validated" type="xs:boolean" default="true"/>
+      <xs:attribute ref="xml:id"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="title" type="xs:string"/>
+
+  <xs:element name="div">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element minOccurs="0" ref="s:title"/>
+        <xs:choice maxOccurs="unbounded">
+	  <xs:element ref="s:p"/>
+	  <xs:element ref="s:note"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:id"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="note">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element minOccurs="0" ref="s:title"/>
+	<xs:element maxOccurs="unbounded" ref="s:p"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:id"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+	<xs:element ref="s:a"/>
+	<xs:element ref="s:img"/>
+	<xs:element ref="s:uri"/>
+      </xs:choice>
+      <xs:attribute ref="xml:id"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="a">
+    <xs:complexType>
+      <xs:simpleContent>
+	<xs:extension base="xs:string">
+	  <xs:attribute name="href" type="xs:anyURI"/>
+	</xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="img">
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:restriction base="xs:anyType">
+	  <xs:attribute name="src" type="xs:anyURI"/>
+          <xs:attribute ref="xml:id"/>
+	</xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="uri" type="xs:anyURI"/>
+</xs:schema>

--- a/test-suite/tests/nw-psvi-001.xml
+++ b/test-suite/tests/nw-psvi-001.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass" 
+        features="psvi-support"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-psvi-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Proposed test.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that p:validate-with-xml-schema produces PSVI annotations.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0"
+                     xmlns:ex="http://example.com/sample"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     psvi-required="true"
+                     exclude-inline-prefixes="#all">
+       <p:output port="result" sequence="true"/>
+
+       <p:load href="../documents/dated-sample.xml"/>
+
+       <p:validate-with-xml-schema>
+         <p:with-input port="schema">
+           <p:document href="../documents/sample.xsd"/>
+         </p:with-input>
+       </p:validate-with-xml-schema>
+
+       <p:identity>
+         <p:with-input><result>{/ex:doc/@pubdate/data() instance of xs:date}</result></p:with-input>
+       </p:identity>
+     </p:declare-step>
+   </t:pipeline>
+
+   <t:schematron>
+     <s:schema queryBinding="xslt2"
+               xmlns:s="http://purl.oclc.org/dsdl/schematron"
+               xmlns="http://www.w3.org/1999/xhtml">
+       <s:ns prefix="fn" uri="http://www.w3.org/2005/xpath-functions"/>
+       <s:pattern>
+         <s:rule context="/">
+           <s:assert test="result">The root element is not result.</s:assert>
+           <s:assert test="string(.) = 'true'">The result is not “true”.</s:assert>
+         </s:rule>
+       </s:pattern>
+     </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-psvi-002.xml
+++ b/test-suite/tests/nw-psvi-002.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XD0022"
+        features="no-psvi-support"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-psvi-002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-26</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Proposed test.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that p:validate-with-xml-schema produces PSVI annotations.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0"
+                     xmlns:ex="http://example.com/sample"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     psvi-required="true"
+                     exclude-inline-prefixes="#all">
+       <p:output port="result" sequence="true"/>
+       <p:identity>
+         <p:with-input><fail/></p:with-input>
+       </p:identity>
+     </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
Fix #429 

This PR adds two new tests, one that exercises `err:XD0022`.

We have an existing feature `p-validate-with-xsd` to assure that the processor will have schema validation capability (support for PSVIs). In order to make the failing test reliable, I added a new feature, `no-psvi-support` to assure that the processor **does not** support PSVIs.