### PR TITLE
Timeout-related tests

### DIFF
--- a/test-suite/tests/nw-http-request-132.xml
+++ b/test-suite/tests/nw-http-request-132.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test features="p:http-request"
+        expected="fail" code="err:XC0078"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error">
+   <t:info>
+      <t:title>p:http-request 132 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-26</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test timeout on p:http-request when fail-on-timeout is true.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step exclude-inline-prefixes="c xs"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:c="http://www.w3.org/ns/xproc-step"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:output port="result"/>
+         <p:http-request method="get"
+                         href="http://localhost:8246/service/slow"
+                         parameters="map{'timeout': 2, 'fail-on-timeout': true()}">
+            <p:with-input>
+               <p:empty/>
+            </p:with-input>
+         </p:http-request>
+         <p:identity>
+            <p:with-input pipe="report"/>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-http-request-133.xml
+++ b/test-suite/tests/nw-http-request-133.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test features="p:http-request"
+        expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error">
+   <t:info>
+      <t:title>p:http-request 133 (NW)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-26</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test timeout on p:http-request when fail-on-timeout is false.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step exclude-inline-prefixes="c xs"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:c="http://www.w3.org/ns/xproc-step"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:output port="result"/>
+         <p:http-request method="get"
+                         href="http://localhost:8246/service/slow"
+                         assert="true()"
+                         parameters="map{'timeout': 2, 'fail-on-timeout': false()}">
+            <p:with-input>
+               <p:empty/>
+            </p:with-input>
+         </p:http-request>
+
+         <!-- Make the report be the default-readable-port -->
+         <p:identity>
+            <p:with-input pipe="report"/>
+         </p:identity>
+
+         <p:identity>
+           <p:with-input>
+             <code>{.?status-code}</code>
+           </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron"
+              xmlns="http://www.w3.org/1999/xhtml">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="code">Root element is not 'code'.</s:assert>
+          <s:assert test=". = '408'">The status code is not 408.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-step-timeout-001.xml
+++ b/test-suite/tests/nw-step-timeout-001.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test features="p:http-request"
+        expected="fail" code="err:XD0053"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error">
+   <t:info>
+      <t:title>nw-step-timeout-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-26</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test step timeout on an atomic step.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step exclude-inline-prefixes="c xs"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc"
+                      xmlns:c="http://www.w3.org/ns/xproc-step"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:output port="result"/>
+         <p:http-request method="get" timeout="2"
+                         href="http://localhost:8246/service/slow"
+                         assert="true()">
+            <p:with-input>
+               <p:empty/>
+            </p:with-input>
+         </p:http-request>
+      </p:declare-step>
+   </t:pipeline>
+</t:test>

--- a/test-suite/tests/nw-step-timeout-002.xml
+++ b/test-suite/tests/nw-step-timeout-002.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test features="p:http-request"
+        expected="fail" code="err:XD0053"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        xmlns:err="http://www.w3.org/ns/xproc-error">
+   <t:info>
+      <t:title>nw-step-timeout-002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2024-12-26</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <!-- I suppose one could argue for repeating this test for
+        each compound step, but I'm assuming one's enough for now. -->
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test step timeout on a compound step.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step exclude-inline-prefixes="c xs"
+                     version="3.0"
+                     xmlns:p="http://www.w3.org/ns/xproc"
+                     xmlns:c="http://www.w3.org/ns/xproc-step"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema">
+       <p:output port="result"/>
+
+       <p:for-each timeout="2">
+         <p:with-input><doc/></p:with-input>
+
+         <p:http-request method="get"
+                         href="http://localhost:8246/service/slow"
+                         assert="true()">
+           <p:with-input>
+             <p:empty/>
+           </p:with-input>
+         </p:http-request>
+
+         <!-- Nothing else should get run, but I can't think
+              of an interoperable way to test that... -->
+         <p:identity/>
+       </p:for-each>
+     </p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
Fix #389 

Two tests for the timeout parameter on `p:http-request` and two for the general `[p:]timeout` option on steps.

Do we need a feature for timeouts?