### PR TITLE
Fixed prolog order in test

### DIFF
--- a/test-suite/tests/nw-err-xs0071-001.xml
+++ b/test-suite/tests/nw-err-xs0071-001.xml
@@ -5,6 +5,15 @@
   <t:title>Test nw-err-xs0071-001</t:title>
   <t:revision-history>
     <t:revision>
+      <t:date>2024-12-27</t:date>
+      <t:author>
+        <t:name>Achim Berndzen</t:name>
+      </t:author>
+      <t:description xmlns="http://www.w3.org/1999/xhtml">
+        <p>Fixed order in prolog.</p>
+      </t:description>
+    </t:revision>
+    <t:revision>
       <t:date>2024-12-26</t:date>
       <t:author>
         <t:name>Norm Tovey-Walsh</t:name>
@@ -23,9 +32,8 @@
   <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
                   xmlns:ex="http://test"
                   version="3.0">
-    <p:output port="result"/>
-
     <p:import href="../pipelines/err-xs0071.xpl"/>
+    <p:output port="result"/>
 
     <p:identity>
       <p:with-input><doc/></p:with-input>


### PR DESCRIPTION
The original should raise XS0100 because p:import has to appear before p:output