### PR TITLE
Fix the element index

### DIFF
--- a/tools/xsl/test-index.xsl
+++ b/tools/xsl/test-index.xsl
@@ -198,9 +198,38 @@
         </xsl:for-each>
       </xsl:variable>
 
-      <xsl:variable name="all-spec-elements" as="xs:QName*">
-        <xsl:for-each select="$specs//*[(starts-with(@id, 'p.') or starts-with(@id, 'c.'))
-                                        and not(contains(substring(@id,3), '.'))]/@id">
+      <xsl:variable name="element-ids" as="xs:string+">
+        <xsl:for-each select="$specs//*[starts-with(@id, 'p.') or starts-with(@id, 'c.')]/@id/string()">
+          <xsl:choose>
+            <xsl:when test="contains(substring(., 3), '.')">
+              <!-- no -->
+            </xsl:when>
+            <xsl:when test="starts-with(. , 'c.archive-def-')">
+              <!-- no -->
+            </xsl:when>
+            <xsl:when test="starts-with(. , 'c.compress-def')">
+              <!-- no -->
+            </xsl:when>
+            <xsl:when test="starts-with(. , 'c.http-request-')">
+              <!-- no -->
+            </xsl:when>
+            <xsl:when test="starts-with(. , 'c.http-multipart')">
+              <!-- no -->
+            </xsl:when>
+            <xsl:when test=". = ('p.depends', 'p.library', 'p.message', 'p.timeout',
+                                 'c.param', 'c.param-set', 'p.serialization',
+                                 'p.standard', 'p.subpipeline')">
+              <!-- no -->
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:sequence select="."/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:variable>
+
+       <xsl:variable name="all-spec-elements" as="xs:QName*">
+        <xsl:for-each select="$element-ids">
           <xsl:choose>
             <!-- Ugh, I should fix the c. IDs so that they're consistently for
                  steps and not for a mixture of steps and data elements. -->


### PR DESCRIPTION
I noticed that the element index incorrectly identified a whole bunch of things as "untested steps" that were not, in fact, steps. It bugged me, so I've fixed it. I think we're now only missing tests for `p:css-formatter`, `p:xsl-formatter`, and `p:sleep`.

I'm not sure we can test the formatters, but I'll come up with something for `p:sleep`.