### PR TITLE
Fix the sleep durations

### DIFF
--- a/test-suite/tests/nw-sleep-001.xml
+++ b/test-suite/tests/nw-sleep-001.xml
@@ -5,6 +5,15 @@
   <t:title>Test nw-sleep-001</t:title>
   <t:revision-history>
     <t:revision>
+      <t:date>2025-01-04</t:date>
+      <t:author>
+        <t:name>Norm Tovey-Walsh</t:name>
+      </t:author>
+      <t:description xmlns="http://www.w3.org/1999/xhtml">
+        <p>Adjusted duration now that it’s expected to be in seconds.</p>
+      </t:description>
+    </t:revision>
+    <t:revision>
       <t:date>2024-12-28</t:date>
       <t:author>
         <t:name>Norm Tovey-Walsh</t:name>
@@ -31,7 +40,7 @@
       <p:with-input><doc/></p:with-input>
     </p:identity>
 
-    <p:sleep duration="1000"/>
+    <p:sleep duration="1"/>
 
   </p:declare-step>
 </t:pipeline>

--- a/test-suite/tests/nw-sleep-002.xml
+++ b/test-suite/tests/nw-sleep-002.xml
@@ -6,6 +6,15 @@
   <t:title>Test nw-sleep-002</t:title>
   <t:revision-history>
     <t:revision>
+      <t:date>2025-01-04</t:date>
+      <t:author>
+        <t:name>Norm Tovey-Walsh</t:name>
+      </t:author>
+      <t:description xmlns="http://www.w3.org/1999/xhtml">
+        <p>Adjusted duration now that it’s expected to be in seconds.</p>
+      </t:description>
+    </t:revision>
+    <t:revision>
       <t:date>2024-12-28</t:date>
       <t:author>
         <t:name>Norm Tovey-Walsh</t:name>
@@ -23,15 +32,16 @@
 <t:pipeline>
   <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
                   xmlns:ex="http://test"
-                  timeout="2"
                   version="3.0">
     <p:output port="result"/>
 
-    <p:identity>
-      <p:with-input><doc/></p:with-input>
-    </p:identity>
+    <p:group timeout="2">
+      <p:identity>
+        <p:with-input><doc/></p:with-input>
+      </p:identity>
 
-    <p:sleep duration="5000"/>
+      <p:sleep duration="5"/>
+    </p:group>
 
   </p:declare-step>
 </t:pipeline>


### PR DESCRIPTION
1. In anticipation of the spec changes, I've adjusted the durations so that they're a reasonable number of seconds.
2. I moved the timeout off the `p:declare-step` and onto a `p:group` where it makes more sense.