### PR TITLE
Test casting from c:data

### DIFF
--- a/test-suite/tests/ab-cast-content-type-028.xml
+++ b/test-suite/tests/ab-cast-content-type-028.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>cast-content-type 028</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-02-01</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>Test casting from c:data to XML.</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests that a c:data document is decoded if cast to XML.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step name="pipeline"
+                    version="3.0"
+                    xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      <p:cast-content-type content-type="application/xml">
+        <p:with-input>
+          <c:data xmlns:c="http://www.w3.org/ns/xproc-step"
+                  encoding="base64"
+                  content-type="application/xml">PGRvYy8+</c:data>
+        </p:with-input>
+      </p:cast-content-type>
+    </p:declare-step>
+  </t:pipeline>
+  <t:schematron>
+    <s:schema queryBinding="xslt2"
+              xmlns:s="http://purl.oclc.org/dsdl/schematron">
+      <s:pattern>
+        <s:rule context="/">
+          <s:assert test="doc">The root element is not 'doc'.</s:assert>
+        </s:rule>
+      </s:pattern>
+    </s:schema>
+  </t:schematron>
+</t:test>


### PR DESCRIPTION
This is a test for the proposed change to `p:cast-content-type` that casting from XML that's a `c:data` document always decodes the data, even if it's casting to the same content type.

I think this is better than adding a `p:decode` step, but I can see arguments in both directions.