### PR TITLE
Windows p:urify() tests where the filepath uses “\”

### DIFF
--- a/test-suite/tests/nw-urify-windows-169.xml
+++ b/test-suite/tests/nw-urify-windows-169.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-069</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve a string with an implicit file URI scheme with an absolute path
+ on drive C: against an absolute file URI on drive C:, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("C:\Users\Jane\Documents and Files\Thing",
+                             "file:///C:/Users/Jane%20Doe/Documents/")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///C:/Users/Jane/Documents%20and%20Files/Thing'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-windows-170.xml
+++ b/test-suite/tests/nw-urify-windows-170.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-170</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve a string with an implicit file URI scheme with an absolute path
+ on drive D: against an absolute file URI on drive D:, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("C:\Users\Jane\Documents and Files\Thing",
+                             "file:///D:/Users/Jane%20Doe/Documents/")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///C:/Users/Jane/Documents%20and%20Files/Thing'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-windows-171.xml
+++ b/test-suite/tests/nw-urify-windows-171.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-171</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve a string with an implicit file URI scheme with an absolute path
+ on drive C: against an absolute file URI with an authority, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("C:\Users\Jane\Documents and Files\Thing",
+                             "file://hostname/Documents/")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///C:/Users/Jane/Documents%20and%20Files/Thing'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-windows-172.xml
+++ b/test-suite/tests/nw-urify-windows-172.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-172</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve a string with an implicit file URI scheme with an absolute path
+ on drive C: against an absolute http: URI, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("C:\Users\Jane\Documents and Files\Thing",
+                             "http://example.com/Documents/")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///C:/Users/Jane/Documents%20and%20Files/Thing'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-windows-173.xml
+++ b/test-suite/tests/nw-urify-windows-173.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-173</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve a string with an implicit file URI scheme with an absolute path
+ on drive C: against an absolute file URI, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("C:\Users\Jane\Documents and Files\Thing",
+                             "file:///home/jdoe/documents/")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///C:/Users/Jane/Documents%20and%20Files/Thing'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-windows-174.xml
+++ b/test-suite/tests/nw-urify-windows-174.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-174</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve a string with an implicit file URI scheme with an absolute path
+ on drive C: against a non-hierarchical urn URI, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("C:\Users\Jane\Documents and Files\Thing",
+                             "urn:publicid:ISO+8879%3A1986:ENTITIES+Added+Latin+1:EN")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///C:/Users/Jane/Documents%20and%20Files/Thing'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-windows-175.xml
+++ b/test-suite/tests/nw-urify-windows-175.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-175</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve a string with an implicit file URI scheme with an absolute path
+ on drive C: against a relative file URI, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("C:\Users\Jane\Documents and Files\Thing",
+                             "file:not-absolute")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///C:/Users/Jane/Documents%20and%20Files/Thing'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-windows-176.xml
+++ b/test-suite/tests/nw-urify-windows-176.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-176</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve a string against the implicit base URI, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("C:\Users\Jane\Documents and Files\Thing")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///C:/Users/Jane/Documents%20and%20Files/Thing'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-windows-177.xml
+++ b/test-suite/tests/nw-urify-windows-177.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-177</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve C:\ string against the implicit base URI, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("C:\")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///C:/'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-windows-178.xml
+++ b/test-suite/tests/nw-urify-windows-178.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        features="urify-windows"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-windows-178</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-02-21</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Test for the <code>p:urify()</code> function on Windows.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Resolve D:\ string against the implicit base URI, using backslashes.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("D:\")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'file:///D:/'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
For unknown reasons, all of the `p:urify` tests that resolve Windows filepaths, do so against paths that have already had “\” translated into “/”. For example, the path in `nw-urify-windows-007` is `C:/Users/Jane/Documents and Files/Thing`. But on a Windows system, I think those strings are naturally going to include “\”, and I had a bug to prove it 😄 

These tests are copies of all the tests that use `C:/…` filepaths with the equivalent `C:\…` filepath