### PR TITLE
New/updated tests for default connections and drp

### DIFF
--- a/test-suite/tests/ab-with-input-058.xml
+++ b/test-suite/tests/ab-with-input-058.xml
@@ -1,4 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0003">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0003 err:XS0032">
    <t:info>
       <t:title>with-input-058</t:title>
       <t:revision-history>

--- a/test-suite/tests/ab-with-input-059.xml
+++ b/test-suite/tests/ab-with-input-059.xml
@@ -1,4 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0003">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0003 err:XS0032">
    <t:info>
       <t:title>with-input-059</t:title>
       <t:revision-history>

--- a/test-suite/tests/ab-with-input-060.xml
+++ b/test-suite/tests/ab-with-input-060.xml
@@ -1,4 +1,4 @@
-<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0003">
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" xmlns:err="http://www.w3.org/ns/xproc-error" expected="fail" code="err:XS0003 err:XS0032">
    <t:info>
       <t:title>with-input-060</t:title>
       <t:revision-history>

--- a/test-suite/tests/nw-drp-001.xml
+++ b/test-suite/tests/nw-drp-001.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-drp-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-03-08</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added test.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test that a secondary output port binds to the default input, not
+      the default readable port.</p>
+   </t:description>
+   <t:pipeline>
+
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="http://example.com/"
+                name="main" version="3.0">
+  <p:output port="result" pipe="secondary"/>
+
+  <p:declare-step type="ex:test" name="ptest">
+    <p:input port="source" primary="true">
+      <primary-input/>
+    </p:input>
+    <p:input port="alternate">
+      <alternate-input/>
+    </p:input>
+    <p:output port="result" primary="true" pipe="@primary-out"/>
+    <p:output port="secondary" pipe="@secondary-out"/>
+
+    <p:identity name="primary-out">
+      <p:with-input pipe="source@ptest"/>
+    </p:identity>
+
+    <p:identity name="secondary-out">
+      <p:with-input pipe="alternate@ptest"/>
+    </p:identity>
+  </p:declare-step>
+
+  <p:identity>
+    <p:with-input><DRP/></p:with-input>
+  </p:identity>
+
+  <ex:test/>
+
+</p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="alternate-input">The root element is not correct.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-drp-002.xml
+++ b/test-suite/tests/nw-drp-002.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0003 err:XS0032"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-drp-002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-03-08</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added test.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Test that a secondary output port binds to the default input, not
+      the default readable port. It’s an error if there is no default input.</p>
+   </t:description>
+   <t:pipeline>
+
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="http://example.com/"
+                name="main" version="3.0">
+  <p:output port="result" pipe="secondary"/>
+
+  <p:declare-step type="ex:test" name="ptest">
+    <p:input port="source" primary="true">
+      <primary-input/>
+    </p:input>
+    <p:input port="alternate"/>
+    <p:output port="result" primary="true" pipe="@primary-out"/>
+    <p:output port="secondary" pipe="@secondary-out"/>
+
+    <p:identity name="primary-out">
+      <p:with-input pipe="source@ptest"/>
+    </p:identity>
+
+    <p:identity name="secondary-out">
+      <p:with-input pipe="alternate@ptest"/>
+    </p:identity>
+  </p:declare-step>
+
+  <p:identity>
+    <p:with-input><DRP/></p:with-input>
+  </p:identity>
+
+  <ex:test/>
+
+</p:declare-step>
+   </t:pipeline>
+</t:test>


### PR DESCRIPTION
I think the new test here is `nw-drp-001` which checks that the default connection for a secondary input port is its default connection. I’m surprised there wasn’t a test for this, but apparently there wasn’t.
    
I’ve also updated the allowed error codes for several drp-related tests so that either err:XS0003 or err:XS0032 is allowed.
