### PR TITLE
Report an error if an AVT is syntactically invalid

### DIFF
--- a/test-suite/tests/nw-avt-001.xml
+++ b/test-suite/tests/nw-avt-001.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="fail" code="err:XS0107"
+        xmlns:err="http://www.w3.org/ns/xproc-error"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+  <t:info>
+    <t:title>nw-avt-001</t:title>
+    <t:revision-history>
+      <t:revision>
+        <t:date>2025-03-16</t:date>
+        <t:author>
+          <t:name>Norm Tovey-Walsh</t:name>
+        </t:author>
+        <t:description xmlns="http://www.w3.org/1999/xhtml">
+          <p>New test</p>
+        </t:description>
+      </t:revision>
+    </t:revision-history>
+  </t:info>
+  <t:description xmlns="http://www.w3.org/1999/xhtml">
+    <p>Tests for a static error in an AVT.</p>
+  </t:description>
+  <t:pipeline>
+    <p:declare-step version="3.0"
+                    xmlns:p="http://www.w3.org/ns/xproc">
+      <p:output port="result"/>
+      <p:add-attribute match="/*"
+                       attribute-name="avt"
+                       attribute-value="{(17}">
+        <p:with-input>
+          <doc/>
+        </p:with-input>
+      </p:add-attribute>
+    </p:declare-step>
+  </t:pipeline>
+</t:test>


### PR DESCRIPTION
My implementation had a bug where a syntactic error in an AVT wasn’t correctly reported. This test demonstrates the problem.