### PR TITLE
Correct dependency and timing problems

### DIFF
--- a/test-suite/tests/nw-send-mail-001.xml
+++ b/test-suite/tests/nw-send-mail-001.xml
@@ -4,6 +4,15 @@
       <t:title>p:send-mail-001</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-04-21</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Add dependencies for multithreading and a delay so sendri has time to process the message.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-05-30</t:date>
             <t:author>
                <t:name>Norm Tovey-Walsh</t:name>
@@ -30,7 +39,7 @@
 
 <!-- Make sure that succeeded -->
 <p:cast-content-type content-type="application/xml"/>
-<p:validate-with-schematron>
+<p:validate-with-schematron name="delete-check">
   <p:with-input port="schema">
     <s:schema xmlns:s="http://purl.oclc.org/dsdl/schematron">
       <s:ns prefix="fn" uri="http://www.w3.org/2005/xpath-functions"/>
@@ -45,7 +54,8 @@
 
 <!-- Send the email message -->
 <p:send-mail parameters="map{'host':'localhost', 'port':1025,'debug':false()}"
-             auth="map{'username':'username','password':'password'}">
+             auth="map{'username':'username','password':'password'}"
+             depends="delete-check">
   <p:with-input>
     <p:inline>
       <emx:Message
@@ -71,6 +81,8 @@
     </p:inline>
   </p:with-input>
 </p:send-mail>
+
+<p:sleep duration="1"/>
 
 <!-- Check the Sendria log -->
 <p:http-request href="http://localhost:1080/api/messages/" method="get"/>

--- a/test-suite/tests/nw-send-mail-002.xml
+++ b/test-suite/tests/nw-send-mail-002.xml
@@ -4,6 +4,15 @@
       <t:title>p:send-mail-002</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-04-21</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Add dependencies for multithreading and a delay so sendri has time to process the message.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-10-12</t:date>
             <t:author>
                <t:name>Norm Tovey-Walsh</t:name>
@@ -38,7 +47,7 @@
 </p:http-request>
 
 <!-- Make sure that succeeded -->
-<p:if test=".?code != 'OK'">
+<p:if test=".?code != 'OK'" name="check-delete">
   <p:error code="Q{{http://example.com/}}irrelevant">
     <p:with-input>
       <p:empty/>
@@ -47,7 +56,8 @@
 </p:if>
 
 <p:send-mail parameters="map{'host':'localhost', 'port':1025}"
-             auth="map{'username':'username','password':'password'}">
+             auth="map{'username':'username','password':'password'}"
+             depends="check-delete">
   <p:with-input>
     <p:inline>
       <emx:Message
@@ -81,6 +91,8 @@
     </p:inline>
   </p:with-input>
 </p:send-mail>
+
+<p:sleep duration="1"/>
 
 <!-- Check the Sendria log -->
 <p:http-request href="http://localhost:1080/api/messages/" method="get"/>

--- a/test-suite/tests/nw-send-mail-003.xml
+++ b/test-suite/tests/nw-send-mail-003.xml
@@ -4,6 +4,15 @@
       <t:title>p:send-mail-003</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-04-21</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Add dependencies for multithreading and a delay so sendri has time to process the message.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-10-12</t:date>
             <t:author>
                <t:name>Norm Tovey-Walsh</t:name>
@@ -38,7 +47,7 @@
 </p:http-request>
 
 <!-- Make sure that succeeded -->
-<p:if test=".?code != 'OK'">
+<p:if test=".?code != 'OK'" name="check-delete">
   <p:error code="Q{{http://example.com/}}irrelevant">
     <p:with-input>
       <p:empty/>
@@ -47,7 +56,8 @@
 </p:if>
 
 <p:send-mail parameters="map{'host':'localhost', 'port':1025}"
-             auth="map{'username':'username','password':'password'}">
+             auth="map{'username':'username','password':'password'}"
+             depends="check-delete">
   <p:with-input>
     <p:inline>
       <emx:Message
@@ -84,6 +94,8 @@
     </p:inline>
   </p:with-input>
 </p:send-mail>
+
+<p:sleep duration="1"/>
 
 <!-- Check the Sendria log -->
 <p:http-request href="http://localhost:1080/api/messages/" method="get"/>


### PR DESCRIPTION
There was no implicit dependency between the steps that clear the Sendria log and the step that sent email. Consequently, they could run in either order. Fixed with an explicit dependency.

I also discovered that the step would sometimes fail because (I think) the Sendria server sometimes takes a moment or two to process the email. I fixed that with a short delay. (It could be more reliably fixed with a loop checking the HTTP output, but...I'm not doing that today!)