### PR TITLE
Tests p:urify() against . and .. resolution

### DIFF
--- a/test-suite/tests/nw-urify-path-001.xml
+++ b/test-suite/tests/nw-urify-path-001.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-path-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-04-27</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests how . and .. entries are handled at the end of a resolved path.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify(".", "http://example.com/path/to/place/")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'http://example.com/path/to/place/'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-path-002.xml
+++ b/test-suite/tests/nw-urify-path-002.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-path-002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-04-27</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests how . and .. entries are handled at the end of a resolved path.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("..", "http://example.com/path/to/place/")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'http://example.com/path/to/'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-urify-path-003.xml
+++ b/test-suite/tests/nw-urify-path-003.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+        expected="pass">
+   <t:info>
+      <t:title>nw-urify-path-003</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-04-27</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests how . and .. entries are handled at the end of a resolved path.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" name="pipeline" version="3.0">
+         <p:output port="result"/>
+         <p:identity>
+            <p:with-input>
+               <result>{p:urify("../a/.", "http://example.com/path/to/place/")}</result>
+            </p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                queryBinding="xslt2">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">Root element is not 'result'.</s:assert>
+               <s:assert test="string(result)= 'http://example.com/path/to/a/'">Incorrect URI in result.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
These tests check the special case of resolving a “.” or “..” entry. I think these resolutions have to return a string that ends with “/” in order to be correct, though it’s not immediately obvious to me if or where this special case is documented.