### PR TITLE
New XInclude tests

### DIFF
--- a/test-suite/documents/four.xml
+++ b/test-suite/documents/four.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<four xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="three.xml"/>
+</four>

--- a/test-suite/documents/one.xml
+++ b/test-suite/documents/one.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<one/>
+

--- a/test-suite/documents/three.xml
+++ b/test-suite/documents/three.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<three xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="two.xml"/>
+</three>

--- a/test-suite/documents/two.xml
+++ b/test-suite/documents/two.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<two xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="one.xml"/>
+</two>
+

--- a/test-suite/tests/nw-xinclude-001.xml
+++ b/test-suite/tests/nw-xinclude-001.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-xinclude-001</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-05-17</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that the base URI is preserved correctly in nested inclusions.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+        <p:output port="result"/>
+        <p:xinclude fixup-xml-base="false">
+          <p:with-input href="../documents/four.xml"/>
+        </p:xinclude>
+        <p:add-xml-base/>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="four">Root element is not 'four'.</s:assert>
+               <s:assert test="ends-with(four/@xml:base, '/four.xml')">Four has wrong base uri.</s:assert>
+               <s:assert test="ends-with(four/three/@xml:base, 'three.xml')">Three has wrong base uri.</s:assert>
+               <s:assert test="ends-with(four/three/two/@xml:base, 'two.xml')">Two has wrong base uri.</s:assert>
+               <s:assert test="ends-with(four/three/two/one/@xml:base, 'one.xml')">One has wrong base uri.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-xinclude-002.xml
+++ b/test-suite/tests/nw-xinclude-002.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-xinclude-002</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-05-17</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that the base URI is preserved correctly in nested inclusions.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+        <p:output port="result"/>
+        <p:xinclude fixup-xml-base="true">
+          <p:with-input href="../documents/four.xml"/>
+        </p:xinclude>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="four">Root element is not 'four'.</s:assert>
+               <s:assert test="empty(four/@xml:base)">Four has an xml:base attribute.</s:assert>
+               <s:assert test="ends-with(four/three/@xml:base, '/three.xml')">Three has wrong base uri.</s:assert>
+               <s:assert test="ends-with(four/three/two/@xml:base, '/two.xml')">Two has wrong base uri.</s:assert>
+               <s:assert test="ends-with(four/three/two/one/@xml:base, '/one.xml')">One has wrong base uri.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>

--- a/test-suite/tests/nw-xinclude-003.xml
+++ b/test-suite/tests/nw-xinclude-003.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-xinclude-003</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-05-17</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that the base URI is preserved correctly in nested inclusions.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+        <p:output port="result"/>
+        <p:xinclude fixup-xml-base="true">
+          <p:with-input href="../documents/four.xml"/>
+        </p:xinclude>
+        <p:add-xml-base/>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="four">Root element is not 'four'.</s:assert>
+               <s:assert test="ends-with(four/@xml:base, 'four.xml')">Four has wrong base uri.</s:assert>
+               <s:assert test="ends-with(four/three/@xml:base, 'three.xml')">Three has wrong base uri.</s:assert>
+               <s:assert test="ends-with(four/three/two/@xml:base, 'two.xml')">Two has wrong base uri.</s:assert>
+               <s:assert test="ends-with(four/three/two/one/@xml:base, 'one.xml')">One has wrong base uri.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
These tests check that the base URI is correctly preserved irrespective of the `fixup-xml-base` setting. There's nothing remarkable here, this is how it has always been specified. But my implementation had a bug that would have failed this test, so I'm putting it in the test suite.