### PR TITLE
Provide static options for web server host and port

### DIFF
--- a/test-suite/tests/ab-http-request-001.xml
+++ b/test-suite/tests/ab-http-request-001.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-001 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          method="get">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-002.xml
+++ b/test-suite/tests/ab-http-request-002.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-002 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          method="GET">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-003.xml
+++ b/test-suite/tests/ab-http-request-003.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-003 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          method="GeT">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-004.xml
+++ b/test-suite/tests/ab-http-request-004.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-004 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-xml">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-005.xml
+++ b/test-suite/tests/ab-http-request-005.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-005 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-xml">
             <p:with-input>
                <p:empty/>
             </p:with-input>
@@ -53,7 +64,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The document root is not result.</s:assert>
-               <s:assert test="result/base-uri/text()='http://localhost:8246/service/fixed-xml'">The base-uri is not right.</s:assert>
+               <s:assert test="ends-with(result/base-uri, '/service/fixed-xml')">The base-uri is not right.</s:assert>
                <s:assert test="result/content-type/text()='application/xml'">The content-type is not right.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-006.xml
+++ b/test-suite/tests/ab-http-request-006.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-006 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -33,7 +42,9 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:c="http://www.w3.org/ns/xproc-step">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-rdf"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-rdf"
                          method="post">
             <p:with-input>
                <c:content/>

--- a/test-suite/tests/ab-http-request-007.xml
+++ b/test-suite/tests/ab-http-request-007.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-007 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -33,7 +42,9 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:c="http://www.w3.org/ns/xproc-step">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-rdf">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-rdf">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-008.xml
+++ b/test-suite/tests/ab-http-request-008.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-008 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-rdf">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-rdf">
             <p:with-input>
                <p:empty/>
             </p:with-input>
@@ -53,7 +64,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="result/base-uri/text()='http://localhost:8246/service/fixed-rdf'">The base-uri is not right.</s:assert>
+               <s:assert test="ends-with(result/base-uri, '/service/fixed-rdf')">The base-uri is not right.</s:assert>
                <s:assert test="result/content-type/text()='application/rdf+xml'">The content-type is not right.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-009.xml
+++ b/test-suite/tests/ab-http-request-009.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-009 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-text">
+         <p:http-request href="{$WHOST}/service/fixed-text">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-010.xml
+++ b/test-suite/tests/ab-http-request-010.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-010 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-text">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-text">
             <p:with-input>
                <p:empty/>
             </p:with-input>
@@ -53,7 +64,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="result/base-uri/text()='http://localhost:8246/service/fixed-text'">The base-uri is not right.</s:assert>
+               <s:assert test="ends-with(result/base-uri, '/service/fixed-text')">The base-uri is not right.</s:assert>
                <s:assert test="result/content-type/text()='text/plain'">The content-type is not right.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-011.xml
+++ b/test-suite/tests/ab-http-request-011.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-011 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -33,7 +42,9 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:c="http://www.w3.org/ns/xproc-step">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-text"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-text"
                          method="post">
             <p:with-input>
                <c:body/>

--- a/test-suite/tests/ab-http-request-012.xml
+++ b/test-suite/tests/ab-http-request-012.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-012 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-binary">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-binary">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-013.xml
+++ b/test-suite/tests/ab-http-request-013.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-013 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-binary">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-binary">
             <p:with-input>
                <p:empty/>
             </p:with-input>
@@ -53,7 +64,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="result/base-uri/text()='http://localhost:8246/service/fixed-binary'">The base-uri is not correct.</s:assert>
+               <s:assert test="ends-with(result/base-uri, '/service/fixed-binary')">The base-uri is not correct.</s:assert>
                <s:assert test="result/content-type/text()='image/png'">The content-type is not correct.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-014.xml
+++ b/test-suite/tests/ab-http-request-014.xml
@@ -5,6 +5,15 @@
    <t:info>
       <t:title>http-request-014 (AB)</t:title>
       <t:revision-history>
+        <t:revision>
+          <t:date>2025-05-23</t:date>
+          <t:author>
+            <t:name>Norm Tovey-Walsh</t:name>
+          </t:author>
+          <t:description xmlns="http://www.w3.org/1999/xhtml">
+            <p>Added static options for web server host and port.</p>
+          </t:description>
+        </t:revision>
          <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
@@ -32,7 +41,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-multipart">
+
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-multipart">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-015.xml
+++ b/test-suite/tests/ab-http-request-015.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-015 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-multipart">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-multipart">
             <p:with-input>
                <p:empty/>
             </p:with-input>
@@ -56,7 +67,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="count(result/doc/base-uri[.='http://localhost:8246/service/fixed-multipart'])=2">There are not two docs with the right uri. </s:assert>
+               <s:assert test="count(result/doc/base-uri[ends-with(., '/service/fixed-multipart')])=2">There are not two docs with the right uri. </s:assert>
                <s:assert test="result/doc/content-type = 'text/html'">There is no entry with content-type 'text/html'.</s:assert>
                <s:assert test="result/doc/content-type = 'image/png'">There is no entry with content-type 'image/png'.</s:assert>
             </s:rule>

--- a/test-suite/tests/ab-http-request-016.xml
+++ b/test-suite/tests/ab-http-request-016.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-016 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -41,7 +50,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-multipart">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-multipart">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-017.xml
+++ b/test-suite/tests/ab-http-request-017.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-017 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -41,7 +50,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-alternative">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-alternative">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-018.xml
+++ b/test-suite/tests/ab-http-request-018.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-018 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-alternative">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-alternative">
             <p:with-input>
                <p:empty/>
             </p:with-input>
@@ -56,7 +67,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="count(result/doc/base-uri[.='http://localhost:8246/service/fixed-alternative'])=4">There are not four docs with the right uri. </s:assert>
+               <s:assert test="count(result/doc/base-uri[ends-with(., '/service/fixed-alternative')])=4">There are not four docs with the right uri. </s:assert>
                <s:assert test="result/doc/content-type = 'text/html'">There is no entry with content-type 'text/html'.</s:assert>
                <s:assert test="result/doc/content-type = 'image/png'">There is no entry with content-type 'image/png'.</s:assert>
                <s:assert test="result/doc/content-type = 'application/xhtml+xml'">There is no entry with content-type 'application/xhtml+xml'.</s:assert>

--- a/test-suite/tests/ab-http-request-019.xml
+++ b/test-suite/tests/ab-http-request-019.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-019 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-alternative">
+         <p:http-request href="{$WHOST}/service/fixed-alternative">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-020.xml
+++ b/test-suite/tests/ab-http-request-020.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-020 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <doc/>

--- a/test-suite/tests/ab-http-request-021.xml
+++ b/test-suite/tests/ab-http-request-021.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-021 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <doc/>
@@ -54,7 +65,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="result/base-uri='http://localhost:8246/service/echo'">The URI is not right.</s:assert>
+               <s:assert test="ends-with(result/base-uri, '/service/echo')">The URI is not right.</s:assert>
                <s:assert test="result/content-type='application/xml'">The content type is not right.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-022.xml
+++ b/test-suite/tests/ab-http-request-022.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-022 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <doc/>

--- a/test-suite/tests/ab-http-request-023.xml
+++ b/test-suite/tests/ab-http-request-023.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-023 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="text/html">

--- a/test-suite/tests/ab-http-request-024.xml
+++ b/test-suite/tests/ab-http-request-024.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-024 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="text/html">
@@ -56,7 +67,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="result/base-uri='http://localhost:8246/service/echo'">The URI is not right.</s:assert>
+               <s:assert test="ends-with(result/base-uri, '/service/echo')">The URI is not right.</s:assert>
                <s:assert test="result/content-type='text/html'">The content type is not right.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-025.xml
+++ b/test-suite/tests/ab-http-request-025.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-025 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="text/html">

--- a/test-suite/tests/ab-http-request-026.xml
+++ b/test-suite/tests/ab-http-request-026.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-026 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="application/json">{{"key1" : "value1", "key2": "value2"}}</p:inline>

--- a/test-suite/tests/ab-http-request-027.xml
+++ b/test-suite/tests/ab-http-request-027.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-027 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="application/json">{{"key1" : "value1", "key2": "value2"}}</p:inline>
@@ -54,7 +65,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="result/base-uri='http://localhost:8246/service/echo'">The URI is not right.</s:assert>
+               <s:assert test="ends-with(result/base-uri, '/service/echo')">The URI is not right.</s:assert>
                <s:assert test="result/content-type='application/json'">The content type is not right.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-028.xml
+++ b/test-suite/tests/ab-http-request-028.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-028 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -41,7 +50,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="application/json">{{"key1" : "value1", "key2": "value2"}}</p:inline>

--- a/test-suite/tests/ab-http-request-029.xml
+++ b/test-suite/tests/ab-http-request-029.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-029 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="text/plain">This is jüst söme encoded text.</p:inline>

--- a/test-suite/tests/ab-http-request-030.xml
+++ b/test-suite/tests/ab-http-request-030.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-030 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="text/plain">This is jüst söme encoded text.</p:inline>
@@ -54,7 +65,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="result/base-uri='http://localhost:8246/service/echo'">The URI is not right.</s:assert>
+               <s:assert test="ends-with(result/base-uri, '/service/echo')">The URI is not right.</s:assert>
                <s:assert test="starts-with(result/content-type,'text/plain')">The content type is not right.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-031.xml
+++ b/test-suite/tests/ab-http-request-031.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-031 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="text/plain">This is jüst söme encoded text.</p:inline>

--- a/test-suite/tests/ab-http-request-032.xml
+++ b/test-suite/tests/ab-http-request-032.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-032 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:document content-type="image/png"

--- a/test-suite/tests/ab-http-request-033.xml
+++ b/test-suite/tests/ab-http-request-033.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-033 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:document content-type="image/png"
@@ -55,7 +66,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="result">The root element is not 'result'.</s:assert>
-               <s:assert test="result/base-uri='http://localhost:8246/service/echo'">The URI is not right.</s:assert>
+               <s:assert test="ends-with(result/base-uri, '/service/echo')">The URI is not right.</s:assert>
                <s:assert test="result/content-type/text()= 'image/png'">The content type is not right.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-034.xml
+++ b/test-suite/tests/ab-http-request-034.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-034 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:document content-type="image/png"

--- a/test-suite/tests/ab-http-request-035.xml
+++ b/test-suite/tests/ab-http-request-035.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-035 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'override-content-type' : 12}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-036.xml
+++ b/test-suite/tests/ab-http-request-036.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-036 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'http-version' : 12}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-037.xml
+++ b/test-suite/tests/ab-http-request-037.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-037 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-29</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -33,8 +42,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'accept-multipart' : 12}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-038.xml
+++ b/test-suite/tests/ab-http-request-038.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-038 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-29</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,7 +43,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'override-content-encoding' : 12}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-040.xml
+++ b/test-suite/tests/ab-http-request-040.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-040 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'permit-expired-ssl-certificate' : 12}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-041.xml
+++ b/test-suite/tests/ab-http-request-041.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-041 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'permit-untrusted-ssl-certificate' : 12}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-042.xml
+++ b/test-suite/tests/ab-http-request-042.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-042 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'follow-redirect' : false() }">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-043.xml
+++ b/test-suite/tests/ab-http-request-043.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-043 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'timeout' : false() }">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-044.xml
+++ b/test-suite/tests/ab-http-request-044.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-044 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'fail-on-timeout' : 'yes' }">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-045.xml
+++ b/test-suite/tests/ab-http-request-045.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-045 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'status-only' : 'yes' }">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-046.xml
+++ b/test-suite/tests/ab-http-request-046.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-046 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'suppress-cookies' : 'yes' }">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-047.xml
+++ b/test-suite/tests/ab-http-request-047.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-047 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'send-body-anyway' : 'yes' }">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-048.xml
+++ b/test-suite/tests/ab-http-request-048.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-048 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'status-only' : false()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-049.xml
+++ b/test-suite/tests/ab-http-request-049.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-049 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'status-only' : true()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-050.xml
+++ b/test-suite/tests/ab-http-request-050.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-050 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'status-only' : true()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-051.xml
+++ b/test-suite/tests/ab-http-request-051.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-051 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,8 +41,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-multipart"
+         <p:http-request href="{$WHOST}/service/fixed-multipart"
                          parameters="map{'multipart' : true()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-052.xml
+++ b/test-suite/tests/ab-http-request-052.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-052 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-29</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,8 +43,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-multipart"
+         <p:http-request href="{$WHOST}/service/fixed-multipart"
                          parameters="map{'accept-multipart' : false()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-053.xml
+++ b/test-suite/tests/ab-http-request-053.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-053 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-29</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -35,9 +44,12 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-multipart"
-                         parameters="map{'accept-multipart' : false(),                                          'status-only' : true()}">
+         <p:http-request href="{$WHOST}/service/fixed-multipart"
+                         parameters="map{'accept-multipart' : false(),
+                                         'status-only' : true()}">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-054.xml
+++ b/test-suite/tests/ab-http-request-054.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-054 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -42,8 +51,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:try>
-            <p:http-request href="http://localhost:8246/service/fixed-multipart"
+            <p:http-request href="{$WHOST}/service/fixed-multipart"
                             parameters="map{'accept-multipart' : false()}">
                <p:with-input>
                   <p:empty/>

--- a/test-suite/tests/ab-http-request-055.xml
+++ b/test-suite/tests/ab-http-request-055.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-055 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          assert=".?status-code lt 400">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-056.xml
+++ b/test-suite/tests/ab-http-request-056.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-056 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          assert=".?status-code = 418">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-057.xml
+++ b/test-suite/tests/ab-http-request-057.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-057 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-13</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          assert=".?headers?CONTENT-TYPE= 'application/json'">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-058.xml
+++ b/test-suite/tests/ab-http-request-058.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-058 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          assert=".?headers?content-type='application/xml'">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-059.xml
+++ b/test-suite/tests/ab-http-request-059.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-059 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          headers="map{'content-type' : 'text/csv' }">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-060.xml
+++ b/test-suite/tests/ab-http-request-060.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-060 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-14</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          headers="map{'header' : 'value', 'HEADER' : 'value'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-061.xml
+++ b/test-suite/tests/ab-http-request-061.xml
@@ -7,6 +7,15 @@
       <t:title>http-request-061 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -46,8 +55,10 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:chttp="http://www.w3.org/ns/xproc-http">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request name="one"
-                         href="http://localhost:8246/service/echoheaders"
+                         href="{$WHOST}/service/echoheaders"
                          method="post"
                          headers="map{'header' : 'value1'}">
             <p:with-input>
@@ -57,7 +68,7 @@
             </p:with-input>
          </p:http-request>
          <p:http-request name="two"
-                         href="http://localhost:8246/service/echoheaders"
+                         href="{$WHOST}/service/echoheaders"
                          method="post">
             <p:with-input>
                <p:inline document-properties="map{'chttp:HEADER' : 'value2'}">
@@ -66,7 +77,7 @@
             </p:with-input>
          </p:http-request>
          <p:http-request name="three"
-                         href="http://localhost:8246/service/echoheaders"
+                         href="{$WHOST}/service/echoheaders"
                          method="post"
                          headers="map{'header' : 'value1'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-062.xml
+++ b/test-suite/tests/ab-http-request-062.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-062 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          headers="map{'BASE-URI' : 'http://xproc.org/ns/testsuite/3.0'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-063.xml
+++ b/test-suite/tests/ab-http-request-063.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-063 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          headers="map{'BASE-URI' : 'http://xproc.org/ns/testsuite/3.0'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-065.xml
+++ b/test-suite/tests/ab-http-request-065.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-065 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          parameters="map{'override-content-type' : 'text/plain'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-066.xml
+++ b/test-suite/tests/ab-http-request-066.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-066 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          parameters="map{'override-content-type' : 'text/plain'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-067.xml
+++ b/test-suite/tests/ab-http-request-067.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-067 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          parameters="map{'override-content-type' : 'text/plain'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-068.xml
+++ b/test-suite/tests/ab-http-request-068.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-068 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          parameters="map{'override-content-type' : 'text/plain'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-069.xml
+++ b/test-suite/tests/ab-http-request-069.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-069 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          parameters="map{'override-content-type' : 'application/json'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-070.xml
+++ b/test-suite/tests/ab-http-request-070.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-070 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          parameters="map{'override-content-type' : 'application/json'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-071.xml
+++ b/test-suite/tests/ab-http-request-071.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-071 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-14</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          parameters="map{'override-content-type' : 'application/xml'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-072.xml
+++ b/test-suite/tests/ab-http-request-072.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-072 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-14</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          parameters="map{'override-content-type' : 'application/json'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-073.xml
+++ b/test-suite/tests/ab-http-request-073.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-073 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-14</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          auth="map{'username' : 12, 'auth-method' : 'Digest'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-074.xml
+++ b/test-suite/tests/ab-http-request-074.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-074 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-14</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          auth="map{'password' : 12, 'auth-method' : 'Digest'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-075.xml
+++ b/test-suite/tests/ab-http-request-075.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-075 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-14</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          auth="map{'auth-method' : 89}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-076.xml
+++ b/test-suite/tests/ab-http-request-076.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-076 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-03-19</t:date>
             <t:author>
                <t:name>Norman Tovey-Walsh</t:name>
@@ -33,8 +42,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          auth="map{'send-authorization' : 89}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-078.xml
+++ b/test-suite/tests/ab-http-request-078.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-078 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-15</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,8 +34,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/docs/basic-auth/"
+                         href="{$WHOST}/docs/basic-auth/"
                          parameters="map{'status-only': true()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-079.xml
+++ b/test-suite/tests/ab-http-request-079.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-079 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,8 +41,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/docs/basic-auth/"
+                         href="{$WHOST}/docs/basic-auth/"
                          parameters="map{'status-only': true()}"
                          assert="">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-080.xml
+++ b/test-suite/tests/ab-http-request-080.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-080 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-15</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,8 +34,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/docs/basic-auth/"
+                         href="{$WHOST}/docs/basic-auth/"
                          auth="map{'username' : 'me'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-081.xml
+++ b/test-suite/tests/ab-http-request-081.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-081 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-15</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,8 +34,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/docs/basic-auth/"
+                         href="{$WHOST}/docs/basic-auth/"
                          auth="map{'password' : '123456'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-082.xml
+++ b/test-suite/tests/ab-http-request-082.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-082 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-15</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,8 +34,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/docs/basic-auth/"
+                         href="{$WHOST}/docs/basic-auth/"
                          auth="map{'username' : 'me', 'auth-method' : 'i-am-not-a-known-auth-method'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-083.xml
+++ b/test-suite/tests/ab-http-request-083.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-083 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-15</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,8 +34,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/docs/basic-auth/"
+                         href="{$WHOST}/docs/basic-auth/"
                          auth="map{'auth-method' : 'i-am-not-a-known-auth-method'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-084.xml
+++ b/test-suite/tests/ab-http-request-084.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-084 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-15</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,9 +33,13 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/docs/basic-auth/"
-                         auth="map{'username' : 'unknown',                        'password' : 'testpassword',                       'auth-method' : 'Basic'}">
+         <p:http-request href="{$WHOST}/docs/basic-auth/"
+                         auth="map{'username' : 'unknown',
+                                   'password' : 'testpassword',
+                                   'auth-method' : 'Basic'}">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-085.xml
+++ b/test-suite/tests/ab-http-request-085.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-085 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/docs/basic-auth/"
+         <p:http-request href="{$WHOST}/docs/basic-auth/"
                          auth="map{'username' : 'testuser',                        'password' : 'testpassword',                       'auth-method' : 'Basic'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-086.xml
+++ b/test-suite/tests/ab-http-request-086.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-086 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/docs/basic-auth/"
+         <p:http-request href="{$WHOST}/docs/basic-auth/"
                          auth="map{'username' : 'testuser',                        'password' : 'testpassword',                       'auth-method' : 'Basic'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-087.xml
+++ b/test-suite/tests/ab-http-request-087.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-087 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/docs/basic-auth/"
+         <p:http-request href="{$WHOST}/docs/basic-auth/"
                          auth="map{'username' : 'testuser',                        'password' : 'testpassword',                       'auth-method' : 'Basic',                       'preemptive-auth' : true()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-088.xml
+++ b/test-suite/tests/ab-http-request-088.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-088 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -33,8 +42,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="post"
-                         href="http://localhost:8246/service/fixed-rdf-charset">
+                         href="{$WHOST}/service/fixed-rdf-charset">
             <p:with-input>
                <c:content xmlns:c="http://www.w3.org/ns/xproc-step"/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-089.xml
+++ b/test-suite/tests/ab-http-request-089.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-089 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -33,8 +42,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="post"
-                         href="http://localhost:8246/service/fixed-rdf-charset">
+                         href="{$WHOST}/service/fixed-rdf-charset">
             <p:with-input>
                <c:content xmlns:c="http://www.w3.org/ns/xproc-step"/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-090.xml
+++ b/test-suite/tests/ab-http-request-090.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-090 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,8 +41,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="post"
-                         href="http://localhost:8246/service/echoparams">
+                         href="{$WHOST}/service/echoparams">
             <p:with-input>
                <p:inline content-type="application/x-www-form-urlencoded">name=W3C&amp;spec=XProc</p:inline>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-091.xml
+++ b/test-suite/tests/ab-http-request-091.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-091 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,8 +41,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/service/echoparams?name=W3C&amp;spec=XProc">
+                         href="{$WHOST}/service/echoparams?name=W3C&amp;spec=XProc">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-092.xml
+++ b/test-suite/tests/ab-http-request-092.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-092 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -34,8 +43,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/service/over-here">
+                         href="{$WHOST}/service/over-here">
             <p:with-input>
                <p:empty/>
             </p:with-input>

--- a/test-suite/tests/ab-http-request-093.xml
+++ b/test-suite/tests/ab-http-request-093.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-093 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,8 +41,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/service/over-here"
+                         href="{$WHOST}/service/over-here"
                          parameters="map{'suppress-cookies' : false()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-094.xml
+++ b/test-suite/tests/ab-http-request-094.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-094 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,8 +41,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/service/over-here"
+                         href="{$WHOST}/service/over-here"
                          parameters="map{'suppress-cookies' : true()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-095.xml
+++ b/test-suite/tests/ab-http-request-095.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-095 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-01-18</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -25,8 +34,10 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/service/fixed-xml"
+                         href="{$WHOST}/service/fixed-xml"
                          parameters="map{'timeout' : -1}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-096.xml
+++ b/test-suite/tests/ab-http-request-096.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-096 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/over-here"
+         <p:http-request href="{$WHOST}/service/over-here"
                          parameters="map{'follow-redirect' : 0}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-097.xml
+++ b/test-suite/tests/ab-http-request-097.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-097 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/over-here"
+         <p:http-request href="{$WHOST}/service/over-here"
                          parameters="map{'follow-redirect' : 0}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-101.xml
+++ b/test-suite/tests/ab-http-request-101.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-101 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <doc1/>

--- a/test-suite/tests/ab-http-request-102.xml
+++ b/test-suite/tests/ab-http-request-102.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-102 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <doc1/>
@@ -56,7 +67,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="properties">The document root is not response.</s:assert>
-               <s:assert test="count(properties/prop[@uri='http://localhost:8246/service/echo'])=2">The base-uri is not correct.</s:assert>
+               <s:assert test="count(properties/prop[ends-with(@uri, '/service/echo')])=2">The base-uri is not correct.</s:assert>
                <s:assert test="count(properties/prop[@content-type='application/xml'])=2">The content-type is not correct.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-103.xml
+++ b/test-suite/tests/ab-http-request-103.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-103 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          headers="map{'content-type' : 'multipart/fixed'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-104.xml
+++ b/test-suite/tests/ab-http-request-104.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-104 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,7 +41,9 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          headers="map{'content-type' : 'multipart/fixed'}">
             <p:with-input>
@@ -57,7 +68,7 @@
          <s:pattern>
             <s:rule context="/">
                <s:assert test="properties">The document root is not response.</s:assert>
-               <s:assert test="count(properties/prop[@uri='http://localhost:8246/service/echo'])=2">The base-uri is not correct.</s:assert>
+               <s:assert test="count(properties/prop[ends-with(@uri, '/service/echo')])=2">The base-uri is not correct.</s:assert>
                <s:assert test="count(properties/prop[@content-type='application/xml'])=2">The content-type is not correct.</s:assert>
             </s:rule>
          </s:pattern>

--- a/test-suite/tests/ab-http-request-105.xml
+++ b/test-suite/tests/ab-http-request-105.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-105 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -40,8 +49,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          headers="map{'content-type' : 'multipart/fixed'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-109.xml
+++ b/test-suite/tests/ab-http-request-109.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-109 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-04-09</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -33,8 +42,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          headers="map{'content-type' : 'surely-not-correct'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-110.xml
+++ b/test-suite/tests/ab-http-request-110.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-110 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-02-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          headers="map{'transfer-encoding' : 'not-supported'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-111.xml
+++ b/test-suite/tests/ab-http-request-111.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-111 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -31,8 +40,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          headers="map{'content-type' : 'application/json'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-112.xml
+++ b/test-suite/tests/ab-http-request-112.xml
@@ -8,6 +8,15 @@
       <t:title>http-request-112 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2020-02-02</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -24,8 +33,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post"
                          headers="map{'content-type' : 'application/xml'}">
             <p:with-input>

--- a/test-suite/tests/ab-http-request-113.xml
+++ b/test-suite/tests/ab-http-request-113.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-113 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,8 +41,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline document-properties="map{'serialization' : map{'encoding' : 'ISO-8859-1'}}">

--- a/test-suite/tests/ab-http-request-114.xml
+++ b/test-suite/tests/ab-http-request-114.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-114 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,8 +41,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="text/html"

--- a/test-suite/tests/ab-http-request-115.xml
+++ b/test-suite/tests/ab-http-request-115.xml
@@ -6,6 +6,15 @@
       <t:title>http-request-115 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -32,8 +41,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/echo"
+         <p:http-request href="{$WHOST}/service/echo"
                          method="post">
             <p:with-input>
                <p:inline content-type="text/plain"

--- a/test-suite/tests/ab-http-request-116.xml
+++ b/test-suite/tests/ab-http-request-116.xml
@@ -8,6 +8,15 @@
       <t:title>p:http-request 116 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -35,8 +44,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/fixed-xml"
+         <p:http-request href="{$WHOST}/service/fixed-xml"
                          parameters="map{'override-content-type' : 'surely-not-correct'}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/ab-http-request-117.xml
+++ b/test-suite/tests/ab-http-request-117.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 117 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-24</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -26,8 +35,10 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-singlepart"
+         <p:http-request href="{$WHOST}/service/check-singlepart"
                          method="get">
             <p:with-input>
                <doc1/>

--- a/test-suite/tests/ab-http-request-118.xml
+++ b/test-suite/tests/ab-http-request-118.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 118 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-24</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -26,8 +35,10 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-singlepart"
+         <p:http-request href="{$WHOST}/service/check-singlepart"
                          parameters="map{'send-body-anyway' : false()}"
                          method="get">
             <p:with-input>

--- a/test-suite/tests/ab-load-010.xml
+++ b/test-suite/tests/ab-load-010.xml
@@ -5,6 +5,15 @@
       <t:title>load 010 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-10-14</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -21,8 +30,10 @@
    <t:pipeline>
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:load href="http://localhost:8246/service/this-is-a"/>
+         <p:load href="{$WHOST}/service/this-is-a"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>

--- a/test-suite/tests/ab-load-011.xml
+++ b/test-suite/tests/ab-load-011.xml
@@ -5,6 +5,15 @@
       <t:title>load 011 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-10-17</t:date>
             <t:author>
                <t:name>Norm Tovey-Walsh</t:name>
@@ -32,7 +41,9 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:fn="http://www.w3.org/2005/xpath-functions">
          <p:output port="result"/>
-         <p:load href="http://localhost:8246/service/this-is-a" />
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:load href="{$WHOST}/service/this-is-a" />
          <p:identity>
             <p:with-input>
                <result>
@@ -50,9 +61,9 @@
             <s:rule context="/">
                <s:assert test="result">The document root is not 'result'.</s:assert>
                <s:assert test="result/prop">Document does not have a child element named 'prop'</s:assert>
-               <s:assert test="result/prop/text()='http://localhost:8246/service/this-is-d'">The text in element 'prop' is not right.</s:assert>
+               <s:assert test="ends-with(result/prop, '/service/this-is-d')">The text in element 'prop' is not right.</s:assert>
                <s:assert test="result/base">Document does not have a child element named 'base'</s:assert>
-               <s:assert test="result/base/text()='http://localhost:8246/service/this-is-d'">The text in element 'base' is not right.</s:assert>
+               <s:assert test="ends-with(result/base, '/service/this-is-d')">The text in element 'base' is not right.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-p-document-042.xml
+++ b/test-suite/tests/ab-p-document-042.xml
@@ -5,6 +5,15 @@
       <t:title>ab-p-document 042 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-10-14</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -22,9 +31,11 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:identity>
             <p:with-input>
-               <p:document href="http://localhost:8246/service/this-is-a" />
+               <p:document href="{$WHOST}/service/this-is-a" />
             </p:with-input>
          </p:identity>
       </p:declare-step>

--- a/test-suite/tests/ab-p-document-043.xml
+++ b/test-suite/tests/ab-p-document-043.xml
@@ -5,6 +5,15 @@
       <t:title>ab-p-document 043 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-10-17</t:date>
             <t:author>
                <t:name>Norm Tovey-Walsh</t:name>
@@ -32,9 +41,11 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:fn="http://www.w3.org/2005/xpath-functions">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:identity>
             <p:with-input>
-               <p:document href="http://localhost:8246/service/this-is-a" />
+               <p:document href="{$WHOST}/service/this-is-a" />
             </p:with-input>
          </p:identity>
          <p:identity>
@@ -54,9 +65,9 @@
             <s:rule context="/">
                <s:assert test="result">The document root is not 'result'.</s:assert>
                <s:assert test="result/prop">Document does not have a child element named 'prop'</s:assert>
-               <s:assert test="result/prop/text()='http://localhost:8246/service/this-is-d'">The text in element 'prop' is not right.</s:assert>
+               <s:assert test="ends-with(result/prop, '/service/this-is-d')">The text in element 'prop' is not right.</s:assert>
                <s:assert test="result/base">Document does not have a child element named 'base'</s:assert>
-               <s:assert test="result/base/text()='http://localhost:8246/service/this-is-d'">The text in element 'base' is not right.</s:assert>
+               <s:assert test="ends-with(result/base, '/service/this-is-d')">The text in element 'base' is not right.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/bom-009.xml
+++ b/test-suite/tests/bom-009.xml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test expected="pass"
+<t:test expected="pass" features="webaccess"
         xmlns:t="http://xproc.org/ns/testsuite/3.0">
    <t:info>
       <t:title>bom-009</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2025-02-05</t:date>
             <t:author>
@@ -22,10 +31,11 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
 
          <p:identity>
             <p:with-input>
-              <p:document content-type="text/plain" href="http://localhost:8246/docs/not-a-bom.txt"/>
+              <p:document content-type="text/plain" href="{$WHOST}/docs/not-a-bom.txt"/>
             </p:with-input>
          </p:identity>
 

--- a/test-suite/tests/bom-012.xml
+++ b/test-suite/tests/bom-012.xml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test expected="pass"
+<t:test expected="pass" features="webaccess"
         xmlns:t="http://xproc.org/ns/testsuite/3.0">
    <t:info>
       <t:title>bom-012</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2025-02-07</t:date>
             <t:author>
@@ -31,10 +40,11 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
 
          <p:identity>
             <p:with-input>
-              <p:document content-type="text/plain" href="http://localhost:8246/docs/not-a-bom.txt"/>
+              <p:document content-type="text/plain" href="{$WHOST}/docs/not-a-bom.txt"/>
             </p:with-input>
          </p:identity>
 

--- a/test-suite/tests/bom-012a.xml
+++ b/test-suite/tests/bom-012a.xml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test expected="pass"
+<t:test expected="pass" features="webaccess"
         xmlns:t="http://xproc.org/ns/testsuite/3.0">
    <t:info>
       <t:title>bom-012a</t:title>
       <t:revision-history>
+         <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
          <t:revision>
             <t:date>2025-02-07</t:date>
             <t:author>
@@ -31,10 +40,11 @@
       <p:declare-step version="3.0"
                       xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
 
          <p:identity>
             <p:with-input>
-              <p:document content-type="text/plain; charset=UTF-8" href="http://localhost:8246/docs/not-a-bom.txt"/>
+              <p:document content-type="text/plain; charset=UTF-8" href="{$WHOST}/docs/not-a-bom.txt"/>
             </p:with-input>
          </p:identity>
 

--- a/test-suite/tests/nw-http-request-117.xml
+++ b/test-suite/tests/nw-http-request-117.xml
@@ -8,6 +8,15 @@
       <t:title>p:http-request 117 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,8 +36,10 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-multipart"
+         <p:http-request href="{$WHOST}/service/check-multipart"
                          method="post"
                          headers="map{                          'content-type': 'multipart/mixed; boundary=--not-an-acceptable-boundary'                        }">
             <p:with-input>

--- a/test-suite/tests/nw-http-request-118.xml
+++ b/test-suite/tests/nw-http-request-118.xml
@@ -8,6 +8,15 @@
       <t:title>p:http-request 118 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -28,9 +37,11 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-multipart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-multipart"
                          method="post"
-                         headers="map{                          'content-type': 'multipart/alternative; boundary=--not-an-acceptable-boundary'                        }">
+                         headers="map { 'content-type': 'multipart/alternative; boundary=--not-an-acceptable-boundary' }">
             <p:with-input>
                <p:inline>
                   <doc1/>

--- a/test-suite/tests/nw-http-request-119.xml
+++ b/test-suite/tests/nw-http-request-119.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 119 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,9 +36,11 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-multipart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-multipart"
                          method="post"
-                         headers="map{                          'content-type': 'multipart/mixed; boundary=this-is-my-boundary'                        }">
+                         headers="map{ 'content-type': 'multipart/mixed; boundary=this-is-my-boundary' }">
             <p:with-input>
                <p:inline>
                   <doc1/>

--- a/test-suite/tests/nw-http-request-120.xml
+++ b/test-suite/tests/nw-http-request-120.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 120 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,9 +36,11 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-multipart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-multipart"
                          method="post"
-                         headers="map{                          'content-type': 'multipart/alternative; boundary=this-is-my-boundary'                        }">
+                         headers="map { 'content-type': 'multipart/alternative; boundary=this-is-my-boundary' }">
             <p:with-input>
                <p:inline>
                   <doc1/>

--- a/test-suite/tests/nw-http-request-121.xml
+++ b/test-suite/tests/nw-http-request-121.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 121 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,9 +36,11 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-multipart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-multipart"
                          method="post"
-                         headers="map{                          'content-type': 'multipart/mixed'                        }">
+                         headers="map { 'content-type': 'multipart/mixed' }">
             <p:with-input>
                <p:inline>
                   <doc1/>

--- a/test-suite/tests/nw-http-request-122.xml
+++ b/test-suite/tests/nw-http-request-122.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 122 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,9 +36,11 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-multipart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-multipart"
                          method="post"
-                         headers="map{                          'content-type': 'multipart/alternative'                        }">
+                         headers="map { 'content-type': 'multipart/alternative' }">
             <p:with-input>
                <p:inline>
                   <doc1/>

--- a/test-suite/tests/nw-http-request-123.xml
+++ b/test-suite/tests/nw-http-request-123.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 123 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-23</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -36,7 +45,9 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-singlepart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-singlepart"
                          method="delete">
             <p:with-input>
                <doc1/>

--- a/test-suite/tests/nw-http-request-124.xml
+++ b/test-suite/tests/nw-http-request-124.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 124 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-23</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -36,7 +45,9 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-singlepart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-singlepart"
                          method="delete"
                          parameters="map{'send-body-anyway': false()}">
             <p:with-input>

--- a/test-suite/tests/nw-http-request-125.xml
+++ b/test-suite/tests/nw-http-request-125.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 125 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,7 +36,9 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-singlepart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-singlepart"
                          method="delete"
                          parameters="map{'send-body-anyway': true()}">
             <p:with-input>

--- a/test-suite/tests/nw-http-request-126.xml
+++ b/test-suite/tests/nw-http-request-126.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 126 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,7 +36,9 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-multipart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-multipart"
                          method="post">
             <p:with-input>
                <p:inline>

--- a/test-suite/tests/nw-http-request-127.xml
+++ b/test-suite/tests/nw-http-request-127.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 127 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,7 +36,9 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-multipart"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/check-multipart"
                          method="post">
             <p:with-input>
                <p:inline document-properties="map{'serialization': map {'encoding': 'iso-8859-1'}}">

--- a/test-suite/tests/nw-http-request-128.xml
+++ b/test-suite/tests/nw-http-request-128.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 128 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -28,8 +37,10 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-multipart"
+         <p:http-request href="{$WHOST}/service/check-multipart"
                          method="post"
                          xmlns:chttp="http://www.w3.org/ns/xproc-http">
             <p:with-input>

--- a/test-suite/tests/nw-http-request-129.xml
+++ b/test-suite/tests/nw-http-request-129.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 129 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -26,8 +35,10 @@
                       xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/check-singlepart"
+         <p:http-request href="{$WHOST}/service/check-singlepart"
                          method="get"
                          parameters="map{'send-body-anyway': true()}">
             <p:with-input>

--- a/test-suite/tests/nw-http-request-130.xml
+++ b/test-suite/tests/nw-http-request-130.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 130 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-09</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,7 +36,9 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
-         <p:http-request href="http://localhost:8246/service/head-with-body"
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
+         <p:http-request href="{$WHOST}/service/head-with-body"
                          method="head"
                          parameters="map{'send-body-anyway': true()}">
             <p:with-input>

--- a/test-suite/tests/nw-http-request-131.xml
+++ b/test-suite/tests/nw-http-request-131.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 131 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-09-10</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -38,8 +47,10 @@ map produced on the report port.</p>
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/service/this-is-a"
+                         href="{$WHOST}/service/this-is-a"
                          parameters="map{'follow-redirect': 2}">
             <p:with-input>
                <p:empty/>
@@ -69,9 +80,9 @@ map produced on the report port.</p>
          <s:pattern>
             <s:rule context="/*">
                <s:assert test="self::wrap">The root is not wrap.</s:assert>
-               <s:assert test="base-uri = 'http://localhost:8246/service/this-is-c'">The base-uri is incorrect.</s:assert>
+               <s:assert test="ends-with(base-uri, '/service/this-is-c')">The base-uri is incorrect.</s:assert>
                <s:assert test="code = 302">The status-code is incorrect.</s:assert>
-               <s:assert test="location = 'http://localhost:8246/service/this-is-d'">The redirect location is incorrect.</s:assert>
+               <s:assert test="ends-with(location, '/service/this-is-d')">The redirect location is incorrect.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/nw-http-request-132.xml
+++ b/test-suite/tests/nw-http-request-132.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 132 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-12-26</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,8 +36,10 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/service/slow"
+                         href="{$WHOST}/service/slow"
                          parameters="map{'timeout': 2, 'fail-on-timeout': true()}">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/nw-http-request-133.xml
+++ b/test-suite/tests/nw-http-request-133.xml
@@ -7,6 +7,15 @@
       <t:title>p:http-request 133 (NW)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-12-26</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,8 +36,10 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get"
-                         href="http://localhost:8246/service/slow"
+                         href="{$WHOST}/service/slow"
                          assert="true()"
                          parameters="map{'timeout': 2, 'fail-on-timeout': false()}">
             <p:with-input>

--- a/test-suite/tests/nw-make-absolute-uris-001.xml
+++ b/test-suite/tests/nw-make-absolute-uris-001.xml
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test features="p:http-request"
-        expected="pass"
+<t:test expected="pass"
         xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error">
    <t:info>
       <t:title>p:make-absolute-uris 001 (NW)</t:title>
       <t:revision-history>
+        <t:revision>
+          <t:date>2025-05-23</t:date>
+          <t:author>
+            <t:name>Norman Walsh</t:name>
+          </t:author>
+          <t:description xmlns="http://www.w3.org/1999/xhtml">
+            <p>Removed spurious feature.</p>
+          </t:description>
+        </t:revision>
          <t:revision>
             <t:date>2024-05-15</t:date>
             <t:author>

--- a/test-suite/tests/nw-make-absolute-uris-002.xml
+++ b/test-suite/tests/nw-make-absolute-uris-002.xml
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test features="p:http-request"
-        expected="pass"
+<t:test expected="pass"
         xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error">
    <t:info>
       <t:title>p:make-absolute-uris 002 (NW)</t:title>
       <t:revision-history>
+        <t:revision>
+          <t:date>2025-05-23</t:date>
+          <t:author>
+            <t:name>Norman Walsh</t:name>
+          </t:author>
+          <t:description xmlns="http://www.w3.org/1999/xhtml">
+            <p>Removed spurious feature.</p>
+          </t:description>
+        </t:revision>
          <t:revision>
             <t:date>2024-05-15</t:date>
             <t:author>

--- a/test-suite/tests/nw-make-absolute-uris-003.xml
+++ b/test-suite/tests/nw-make-absolute-uris-003.xml
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:test features="p:http-request"
-        expected="pass"
+<t:test expected="pass"
         xmlns:t="http://xproc.org/ns/testsuite/3.0"
         xmlns:err="http://www.w3.org/ns/xproc-error">
    <t:info>
       <t:title>p:make-absolute-uris 003 (NW)</t:title>
       <t:revision-history>
+        <t:revision>
+          <t:date>2025-05-23</t:date>
+          <t:author>
+            <t:name>Norman Walsh</t:name>
+          </t:author>
+          <t:description xmlns="http://www.w3.org/1999/xhtml">
+            <p>Removed spurious feature.</p>
+          </t:description>
+        </t:revision>
          <t:revision>
             <t:date>2024-05-15</t:date>
             <t:author>

--- a/test-suite/tests/nw-send-mail-001.xml
+++ b/test-suite/tests/nw-send-mail-001.xml
@@ -4,6 +4,15 @@
       <t:title>p:send-mail-001</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for SMTP host and ports.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2025-04-21</t:date>
             <t:author>
                <t:name>Norm Tovey-Walsh</t:name>
@@ -30,8 +39,12 @@
       <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result" />
 
+<p:option name="SHOST" select="'localhost'" static="true"/>
+<p:option name="SMTPPORT" select="1025" static="true"/>
+<p:option name="APIPORT" select="1080" static="true"/>
+
 <!-- Clear the Sendria log -->
-<p:http-request href="http://localhost:1080/api/messages/" method="delete">
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="delete">
   <p:with-input>
     <p:empty/>
   </p:with-input>
@@ -53,7 +66,7 @@
 </p:validate-with-schematron>
 
 <!-- Send the email message -->
-<p:send-mail parameters="map{'host':'localhost', 'port':1025,'debug':false()}"
+<p:send-mail parameters="map{'host': $SHOST, 'port': $SMTPPORT, 'debug':false()}"
              auth="map{'username':'username','password':'password'}"
              depends="delete-check">
   <p:with-input>
@@ -85,7 +98,7 @@
 <p:sleep duration="1"/>
 
 <!-- Check the Sendria log -->
-<p:http-request href="http://localhost:1080/api/messages/" method="get"/>
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="get"/>
 <p:cast-content-type content-type="application/xml"/>
 
       </p:declare-step>

--- a/test-suite/tests/nw-send-mail-002.xml
+++ b/test-suite/tests/nw-send-mail-002.xml
@@ -4,6 +4,15 @@
       <t:title>p:send-mail-002</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for SMTP host and ports.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2025-04-21</t:date>
             <t:author>
                <t:name>Norm Tovey-Walsh</t:name>
@@ -39,8 +48,12 @@
       <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result" />
 
+<p:option name="SHOST" select="'localhost'" static="true"/>
+<p:option name="SMTPPORT" select="1025" static="true"/>
+<p:option name="APIPORT" select="1080" static="true"/>
+
 <!-- Clear the Sendria log -->
-<p:http-request href="http://localhost:1080/api/messages/" method="delete">
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="delete">
   <p:with-input>
     <p:empty/>
   </p:with-input>
@@ -55,7 +68,7 @@
   </p:error>
 </p:if>
 
-<p:send-mail parameters="map{'host':'localhost', 'port':1025}"
+<p:send-mail parameters="map{'host': $SHOST, 'port': $SMTPPORT}"
              auth="map{'username':'username','password':'password'}"
              depends="check-delete">
   <p:with-input>
@@ -95,9 +108,9 @@
 <p:sleep duration="1"/>
 
 <!-- Check the Sendria log -->
-<p:http-request href="http://localhost:1080/api/messages/" method="get"/>
-<p:http-request href="http://localhost:1080/api/messages/" method="get"/>
-<p:http-request href="http://localhost:1080/api/messages/" method="get"/>
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="get"/>
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="get"/>
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="get"/>
 <p:cast-content-type content-type="application/xml"/>
 
       </p:declare-step>

--- a/test-suite/tests/nw-send-mail-003.xml
+++ b/test-suite/tests/nw-send-mail-003.xml
@@ -4,6 +4,15 @@
       <t:title>p:send-mail-003</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for SMTP host and ports.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2025-04-21</t:date>
             <t:author>
                <t:name>Norm Tovey-Walsh</t:name>
@@ -39,8 +48,12 @@
       <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
          <p:output port="result" />
 
+<p:option name="SHOST" select="'localhost'" static="true"/>
+<p:option name="SMTPPORT" select="1025" static="true"/>
+<p:option name="APIPORT" select="1080" static="true"/>
+
 <!-- Clear the Sendria log -->
-<p:http-request href="http://localhost:1080/api/messages/" method="delete">
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="delete">
   <p:with-input>
     <p:empty/>
   </p:with-input>
@@ -55,7 +68,7 @@
   </p:error>
 </p:if>
 
-<p:send-mail parameters="map{'host':'localhost', 'port':1025}"
+<p:send-mail parameters="map{'host': $SHOST, 'port': $SMTPPORT}"
              auth="map{'username':'username','password':'password'}"
              depends="check-delete">
   <p:with-input>
@@ -98,9 +111,9 @@
 <p:sleep duration="1"/>
 
 <!-- Check the Sendria log -->
-<p:http-request href="http://localhost:1080/api/messages/" method="get"/>
-<p:http-request href="http://localhost:1080/api/messages/" method="get"/>
-<p:http-request href="http://localhost:1080/api/messages/" method="get"/>
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="get"/>
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="get"/>
+<p:http-request href="http://{$SHOST}:{$APIPORT}/api/messages/" method="get"/>
 <p:cast-content-type content-type="application/xml"/>
 
       </p:declare-step>

--- a/test-suite/tests/nw-step-timeout-001.xml
+++ b/test-suite/tests/nw-step-timeout-001.xml
@@ -7,6 +7,15 @@
       <t:title>nw-step-timeout-001</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-12-26</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -27,8 +36,10 @@
                       xmlns:c="http://www.w3.org/ns/xproc-step"
                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
          <p:output port="result"/>
+         <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
+
          <p:http-request method="get" timeout="2"
-                         href="http://localhost:8246/service/slow"
+                         href="{$WHOST}/service/slow"
                          assert="true()">
             <p:with-input>
                <p:empty/>

--- a/test-suite/tests/nw-step-timeout-002.xml
+++ b/test-suite/tests/nw-step-timeout-002.xml
@@ -7,6 +7,15 @@
       <t:title>nw-step-timeout-002</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-05-23</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Added static options for web server host and port.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2024-12-26</t:date>
             <t:author>
                <t:name>Norman Walsh</t:name>
@@ -29,12 +38,13 @@
                      xmlns:c="http://www.w3.org/ns/xproc-step"
                      xmlns:xs="http://www.w3.org/2001/XMLSchema">
        <p:output port="result"/>
+       <p:option name="WHOST" select="'http://localhost:8246'" static="true"/>
 
        <p:for-each timeout="2">
          <p:with-input><doc/></p:with-input>
 
          <p:http-request method="get"
-                         href="http://localhost:8246/service/slow"
+                         href="{$WHOST}/service/slow"
                          assert="true()">
            <p:with-input>
              <p:empty/>


### PR DESCRIPTION
Fix #852

This is a bit messy, but it allows the test driver to change the host and ports used for web access. I also cleaned up the features on a couple of tests where webaccess was needed but unspecified and specified where it wasn’t needed.