### PR TITLE
Tests for proposal on issue #1156: Document properties after select

### DIFF
--- a/test-suite/tests/ab-serialization-prop-001.xml
+++ b/test-suite/tests/ab-serialization-prop-001.xml
@@ -1,0 +1,54 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+    expected="pass" >
+    <t:info>
+        <t:title>ab-serialization-prop-001</t:title>
+        <t:revision-history>
+            <t:revision>
+                <t:date>2025-06-13</t:date>
+                <t:author>
+                    <t:name>Achim Berndzen</t:name>
+                </t:author>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
+                    <p>Added tests for serialization properties</p>
+                </t:description>
+            </t:revision>
+        </t:revision-history>
+    </t:info>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
+        <p>Tests that serialization property is removed if content-type changes.</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input>
+                    <p:inline document-properties="map{'serialization' : map{'indent' : true()}}">
+                        <doc>
+                            <element>Some text.</element>
+                        </doc>
+                    </p:inline>
+                </p:with-input>
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input select="doc/element/text()" />
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input><result>{empty(p:document-properties(.)?(QName('','serialization')))}</result></p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:schematron>
+        <s:schema queryBinding="xslt2"
+            xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="result">The root element is not result.</s:assert>
+                    <s:assert test="result/text()='true'">The text node in result is not equal to 'true'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>
+    </t:schematron>
+</t:test>
+

--- a/test-suite/tests/ab-serialization-prop-002.xml
+++ b/test-suite/tests/ab-serialization-prop-002.xml
@@ -1,0 +1,54 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+    expected="pass" >
+    <t:info>
+        <t:title>ab-serialization-prop-002</t:title>
+        <t:revision-history>
+            <t:revision>
+                <t:date>2025-06-13</t:date>
+                <t:author>
+                    <t:name>Achim Berndzen</t:name>
+                </t:author>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
+                    <p>Added tests for serialization properties</p>
+                </t:description>
+            </t:revision>
+        </t:revision-history>
+    </t:info>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
+        <p>Tests that serialization property is removed if content-type changes.</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input>
+                    <p:inline document-properties="map{'serialization' : map{'indent' : true()}}">
+                        <doc>
+                            <element>Some text.</element>
+                        </doc>
+                    </p:inline>
+                </p:with-input>
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input select="string(doc/element)" />
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input><result>{empty(p:document-properties(.)?(QName('','serialization')))}</result></p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:schematron>
+        <s:schema queryBinding="xslt2"
+            xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="result">The root element is not result.</s:assert>
+                    <s:assert test="result/text()='true'">The text node in result is not equal to 'true'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>
+    </t:schematron>
+</t:test>
+

--- a/test-suite/tests/ab-serialization-prop-003.xml
+++ b/test-suite/tests/ab-serialization-prop-003.xml
@@ -1,0 +1,50 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+    expected="pass" >
+    <t:info>
+        <t:title>ab-serialization-prop-003</t:title>
+        <t:revision-history>
+            <t:revision>
+                <t:date>2025-06-13</t:date>
+                <t:author>
+                    <t:name>Achim Berndzen</t:name>
+                </t:author>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
+                    <p>Added tests for serialization properties</p>
+                </t:description>
+            </t:revision>
+        </t:revision-history>
+    </t:info>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
+        <p>Tests that serialization property is removed if content-type changes.</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input>
+                    <p:inline content-type="text/plain" document-properties="map{'serialization' : map{'indent' : true()}}">Some text.</p:inline>
+                </p:with-input>
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input select="string(./text())" />
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input><result>{empty(p:document-properties(.)?(QName('','serialization')))}</result></p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:schematron>
+        <s:schema queryBinding="xslt2"
+            xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="result">The root element is not result.</s:assert>
+                    <s:assert test="result/text()='true'">The text node in result is not equal to 'true'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>
+    </t:schematron>
+</t:test>
+

--- a/test-suite/tests/ab-serialization-prop-004.xml
+++ b/test-suite/tests/ab-serialization-prop-004.xml
@@ -1,0 +1,54 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+    expected="pass" >
+    <t:info>
+        <t:title>ab-serialization-prop-004</t:title>
+        <t:revision-history>
+            <t:revision>
+                <t:date>2025-06-13</t:date>
+                <t:author>
+                    <t:name>Achim Berndzen</t:name>
+                </t:author>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
+                    <p>Added tests for serialization properties</p>
+                </t:description>
+            </t:revision>
+        </t:revision-history>
+    </t:info>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
+        <p>Tests that serialization property is kept if content-type does not changes.</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input>
+                    <p:inline document-properties="map{'serialization' : map{'indent' : true()}}">
+                        <doc>
+                            <element>text</element>
+                        </doc>
+                    </p:inline>
+                </p:with-input>
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input select="//element" />
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input><result>{exists(p:document-properties(.)?(QName('','serialization')))}</result></p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:schematron>
+        <s:schema queryBinding="xslt2"
+            xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="result">The root element is not result.</s:assert>
+                    <s:assert test="result/text()='true'">The text node in result is not equal to 'true'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>
+    </t:schematron>
+</t:test>
+

--- a/test-suite/tests/ab-serialization-prop-005.xml
+++ b/test-suite/tests/ab-serialization-prop-005.xml
@@ -1,0 +1,50 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+    expected="pass" >
+    <t:info>
+        <t:title>ab-serialization-prop-005</t:title>
+        <t:revision-history>
+            <t:revision>
+                <t:date>2025-06-13</t:date>
+                <t:author>
+                    <t:name>Achim Berndzen</t:name>
+                </t:author>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
+                    <p>Added tests for serialization properties</p>
+                </t:description>
+            </t:revision>
+        </t:revision-history>
+    </t:info>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
+        <p>Tests that serialization property is kept if content-type does not changes.</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input>
+                    <p:inline content-type="text/plain" document-properties="map{'serialization' : map{'indent' : true()}}">Some text.</p:inline>
+                </p:with-input>
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input select="//text()" />
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input><result>{exists(p:document-properties(.)?(QName('','serialization')))}</result></p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:schematron>
+        <s:schema queryBinding="xslt2"
+            xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="result">The root element is not result.</s:assert>
+                    <s:assert test="result/text()='true'">The text node in result is not equal to 'true'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>
+    </t:schematron>
+</t:test>
+

--- a/test-suite/tests/ab-serialization-prop-006.xml
+++ b/test-suite/tests/ab-serialization-prop-006.xml
@@ -1,0 +1,50 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0"
+    expected="pass" >
+    <t:info>
+        <t:title>ab-serialization-prop-006</t:title>
+        <t:revision-history>
+            <t:revision>
+                <t:date>2025-06-13</t:date>
+                <t:author>
+                    <t:name>Achim Berndzen</t:name>
+                </t:author>
+                <t:description xmlns="http://www.w3.org/1999/xhtml">
+                    <p>Added tests for serialization properties</p>
+                </t:description>
+            </t:revision>
+        </t:revision-history>
+    </t:info>
+    <t:description xmlns="http://www.w3.org/1999/xhtml">
+        <p>Tests that serialization property is kept if content-type does not changes.</p>
+    </t:description>
+    <t:pipeline>
+        <p:declare-step version="3.0" xmlns:p="http://www.w3.org/ns/xproc">
+            <p:output port="result" />
+            <p:identity>
+                <p:with-input>
+                    <p:inline content-type="application/json" document-properties="map{'serialization' : map{'indent' : true()}}">"Some text."</p:inline>
+                </p:with-input>
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input select="string(.)" />
+            </p:identity>
+            
+            <p:identity>
+                <p:with-input><result>{exists(p:document-properties(.)?(QName('','serialization')))}</result></p:with-input>
+            </p:identity>
+        </p:declare-step>
+    </t:pipeline>
+    <t:schematron>
+        <s:schema queryBinding="xslt2"
+            xmlns:s="http://purl.oclc.org/dsdl/schematron">
+            <s:pattern>
+                <s:rule context="/">
+                    <s:assert test="result">The root element is not result.</s:assert>
+                    <s:assert test="result/text()='true'">The text node in result is not equal to 'true'.</s:assert>
+                </s:rule>
+            </s:pattern>
+        </s:schema>
+    </t:schematron>
+</t:test>
+


### PR DESCRIPTION
Tests for proposal to solve https://github.com/xproc/3.0-specification/issues/1156:
All document properties are preserved except "serialization" which is removed if content-type changes.