### PR TITLE
Tests that schema import is correctly handled

### DIFF
--- a/test-suite/documents/congrats.xsd
+++ b/test-suite/documents/congrats.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  
+  <xs:include schemaLocation="included.xsd"/>
+  
+  <xs:element name="CONGRATULATIONS" type="xs:string"/>
+  
+  <xs:element name="TEST">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="CONGRATULATIONS"/>
+        <xs:element ref="INCLUDED"/>
+        <xs:element ref="DEEPLY_INCLUDED"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test-suite/documents/include2.xsd
+++ b/test-suite/documents/include2.xsd
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="DEEPLY_INCLUDED" type="xs:string"/>
+</xs:schema>

--- a/test-suite/documents/included.xsd
+++ b/test-suite/documents/included.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  
+  <xs:include schemaLocation="include2.xsd"/>
+  
+  <xs:element name="INCLUDED">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="CONGRATULATIONS"/>
+        <xs:element ref="DEEPLY_INCLUDED"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test-suite/tests/nw-validate-with-xsd-006.xml
+++ b/test-suite/tests/nw-validate-with-xsd-006.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        features="p-validate-with-xsd"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-validate-with-xsd-006</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-06-14</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Check that schema module resolution works correctly.</p>
+   </t:description>
+   <t:pipeline>
+      <p:declare-step name="pipeline"
+                      version="3.0"
+                      xmlns:p="http://www.w3.org/ns/xproc">
+         <p:output port="result"/>
+         <p:validate-with-xml-schema name="validate" assert-valid="true">
+            <p:with-input port="source">
+              <CONGRATULATIONS>It worked</CONGRATULATIONS>
+            </p:with-input>
+            <p:with-input port="schema" href="../documents/congrats.xsd"/>
+         </p:validate-with-xml-schema>
+      </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="CONGRATULATIONS">The test failed?</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
Apparently there are no other tests in the test suite that use `xs:include` or `xs:import` to load schema components.

(I assert this because it was utterly broken in XML Calabash.)