### PR TITLE
Reworked tests to produce a single result document

### DIFF
--- a/test-suite/tests/ab-namespace-rename-010.xml
+++ b/test-suite/tests/ab-namespace-rename-010.xml
@@ -5,6 +5,15 @@
       <t:title>p:namespace-rename-010 (AB)</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-06-17</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Fixed cut-and-paste error in Schematron message.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -53,7 +62,7 @@
                prefix="x"/>
          <s:pattern>
             <s:rule context="/">
-               <s:assert test="doc">The root element is not 'Q{http://foo.com}doc'.</s:assert>
+               <s:assert test="doc">The root element is not Q{}doc'.</s:assert>
                <s:assert test="*/@x:attr2">Root does not have an attribute Q{http://test.com}attr2.</s:assert>
                <s:assert test="*/@attr1">Root does not have an attribute Q{}attr1.</s:assert>
                <s:assert test="count(doc/p)=2">Root does not have two children 'p'.</s:assert>

--- a/test-suite/tests/ab-use-when-002.xml
+++ b/test-suite/tests/ab-use-when-002.xml
@@ -5,6 +5,15 @@
       <t:title>AB use-when-002</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-06-17</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Reworked test to produce a single result document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2022-01-22</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -48,6 +57,7 @@
                </p:inline>
             </p:with-input>
          </p:identity>
+         <p:wrap-sequence wrapper="wrapper"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
@@ -58,7 +68,8 @@
                prefix="p"/>
          <s:pattern>
             <s:rule context="/">
-               <s:assert test="count(/*) = 0">Document root should not have a child element.</s:assert>
+               <s:assert test="wrapper">The document element isn’t wrapper.</s:assert>
+               <s:assert test="empty(wrapper/*)">Wrapper should not have a child element.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-xslt-013.xml
+++ b/test-suite/tests/ab-xslt-013.xml
@@ -6,6 +6,15 @@
       <t:title>AB-xslt-013</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-06-17</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Reworked test to produce a single result document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -47,6 +56,7 @@
                </xsl:stylesheet>
             </p:with-input>
          </p:xslt>
+         <p:wrap-sequence wrapper="wrapper"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
@@ -55,9 +65,10 @@
                 xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
-               <s:assert test="/a">The document root has no child element 'a'.</s:assert>
-               <s:assert test="/b">The document root has no child element 'b'.</s:assert>
-               <s:assert test="/c">The document root has no child element 'c'.</s:assert>
+               <s:assert test="/wrapper">The document element ins’t wrapper.</s:assert>
+               <s:assert test="/wrapper/a">The wrapper has no child element 'a'.</s:assert>
+               <s:assert test="/wrapper/b">The wrapper  has no child element 'b'.</s:assert>
+               <s:assert test="/wrapper/c">The wrapper has no child element 'c'.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-xslt-062.xml
+++ b/test-suite/tests/ab-xslt-062.xml
@@ -6,6 +6,16 @@
       <t:title>AB-xslt-062</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-06-17</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Reworked test to check for the initial context node more
+               directly and to produce a single result document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2021-06-10</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -41,12 +51,11 @@
             <p:with-input port="stylesheet">
                <xsl:stylesheet version="2.0"
                                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                 <xsl:variable name="root" select="."/>
                   <xsl:template match="doc1">
-                     <xsl:copy-of select="."/>
+                     <xsl:copy-of select="$root"/>
                   </xsl:template>
-                  <xsl:template match="*">
-                     <xsl:copy-of select="."/>
-                  </xsl:template>
+                  <xsl:template match="*"/>
                </xsl:stylesheet>
             </p:with-input>
          </p:xslt>

--- a/test-suite/tests/ab-xslt-129.xml
+++ b/test-suite/tests/ab-xslt-129.xml
@@ -6,6 +6,15 @@
       <t:title>AB-xslt-129</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-06-17</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Reworked test to produce a single result document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2023-01-04</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -39,6 +48,7 @@
                </xsl:stylesheet>
             </p:with-input>
          </p:xslt>
+         <p:wrap-sequence wrapper="wrapper"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
@@ -47,8 +57,10 @@
                 xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
-               <s:assert test="/result">The document root is not 'result'.</s:assert>
-               <s:assert test="/result/text()='true'">Test for required node identity fails.</s:assert>
+               <s:assert test="/wrapper">The document root is not 'wrapper'.</s:assert>
+               <s:assert test="count(/wrapper/result) = 2">Wrong number of results.</s:assert>
+               <s:assert test="empty(/wrapper/result[. = 'false'])"
+                         >Test for required node identity fails.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>

--- a/test-suite/tests/ab-xslt-135.xml
+++ b/test-suite/tests/ab-xslt-135.xml
@@ -6,6 +6,15 @@
       <t:title>AB-xslt-135</t:title>
       <t:revision-history>
          <t:revision>
+            <t:date>2025-06-17</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Reworked test to produce a single result document.</p>
+            </t:description>
+         </t:revision>
+         <t:revision>
             <t:date>2023-01-04</t:date>
             <t:author>
                <t:name>Achim Berndzen</t:name>
@@ -39,6 +48,7 @@
                </xsl:stylesheet>
             </p:with-input>
          </p:xslt>
+         <p:wrap-sequence wrapper="wrapper"/>
       </p:declare-step>
    </t:pipeline>
    <t:schematron>
@@ -47,8 +57,10 @@
                 xmlns="http://www.w3.org/1999/xhtml">
          <s:pattern>
             <s:rule context="/">
-               <s:assert test="/result">The document root is not 'result'.</s:assert>
-               <s:assert test="/result/text()='true'">Test for required node identity fails.</s:assert>
+               <s:assert test="/wrapper">The document root is not 'wrapper'.</s:assert>
+               <s:assert test="count(/wrapper/result) = 2">Wrong number of results.</s:assert>
+               <s:assert test="empty(/wrapper/result[. = 'false'])"
+                         >Test for required node identity fails.</s:assert>
             </s:rule>
          </s:pattern>
       </s:schema>


### PR DESCRIPTION
Schematron can handle a document that contains more than one top-level element, but the result is difficult to reparse. Reparsing the test results was useful in finding a couple of namespace-related errors in my implementation, so I’ve reworked the few tests that produce sequences so that they produce a single result.

The changes are all trivial except for ab-xslt-062 where I think I’ve improved the test.