### PR TITLE
New test for re-entrant import

### DIFF
--- a/test-suite/pipelines/import-034-lib1.xpl
+++ b/test-suite/pipelines/import-034-lib1.xpl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:library version="3.1" xmlns:p="http://www.w3.org/ns/xproc">
+    <p:option name="static-option" static="true" select="42" />
+</p:library>

--- a/test-suite/pipelines/import-034-lib2.xpl
+++ b/test-suite/pipelines/import-034-lib2.xpl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:library version="3.1" xmlns:p="http://www.w3.org/ns/xproc"
+    xmlns:test="http://test">
+    <p:import href="import-034-lib3.xpl" />
+    <p:import href="import-034-lib1.xpl" />
+    
+    <p:declare-step type="test:step">
+        <p:output port="result" />
+        
+        <p:identity>
+            <p:with-input><dummy /></p:with-input>
+        </p:identity>
+    </p:declare-step>
+</p:library>

--- a/test-suite/pipelines/import-034-lib3.xpl
+++ b/test-suite/pipelines/import-034-lib3.xpl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:library version="3.1" xmlns:p="http://www.w3.org/ns/xproc"
+    xmlns:test="http://test">
+    <p:import href="import-034-lib1.xpl" />
+    
+    <p:declare-step type="test:step1">
+        <p:output port="result" />
+        
+        <p:identity>
+            <p:with-input><dummy /></p:with-input>
+        </p:identity>
+    </p:declare-step>
+</p:library>

--- a/test-suite/tests/ab-import-034.xml
+++ b/test-suite/tests/ab-import-034.xml
@@ -1,0 +1,46 @@
+<t:test xmlns:t="http://xproc.org/ns/testsuite/3.0" expected="pass">
+   <t:info>
+      <t:title>p:import-034 (AB)</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-08-07</t:date>
+            <t:author>
+               <t:name>Achim Berndzen</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial test</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests p:import: Testing re-entrant import does not raise a static error for shadowing static options (XS0088).</p>
+   </t:description>
+   
+   
+   <t:pipeline>
+      <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:test="http://test" name="pipeline" version="3.0">
+         <p:import href="../pipelines/import-034-lib1.xpl" />
+         <p:import href="../pipelines/import-034-lib2.xpl" />
+         
+         <p:output port="result" />
+         
+         <p:identity>
+            <p:with-input><result>No static error raised.</result></p:with-input>
+         </p:identity>
+      </p:declare-step>
+   </t:pipeline>
+   
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+         xmlns:s="http://purl.oclc.org/dsdl/schematron">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The root element is not 'result'.</s:assert>
+               <s:assert test="result/text()='No static error raised.'">The text child of root element is not correct.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
Test repeated import of a pipeline (on different levels) does not raise an error for shadowed static attributes.