### PR TITLE
Test that explicitly named try/catch outputs are handled correctly

### DIFF
--- a/test-suite/tests/try-catch-009.xml
+++ b/test-suite/tests/try-catch-009.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>Try/catch 009</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-08-12</t:date>
+            <t:author>
+               <t:name>Norman Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Make sure that an explicitly named output port works on p:try.</p>
+   </t:description>
+   <t:pipeline>
+     <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                     version="3.1">
+       <p:output port="result" sequence="true">
+         <p:pipe port="my-result" step="try-catch"/>
+       </p:output>
+        
+       <p:try name="try-catch">
+         <p:output port="my-result" primary="true" sequence="true"/>
+         <p:group>
+           <p:identity>
+             <p:with-input>
+               <p:inline exclude-inline-prefixes="#all">
+                 <doc>Hello, world</doc>
+               </p:inline>
+             </p:with-input>
+           </p:identity>
+         </p:group>
+         <p:catch>
+           <p:output port="my-result" primary="true" sequence="true"/>
+           <p:identity/>
+         </p:catch>
+       </p:try>
+     </p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/doc">
+               <s:assert test=". = 'Hello, world'">The pipeline root is incorrect.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
XML Calabash wasn't handling them correctly.