### PR TITLE
Test that p:xslt static-parameters are handled correctly.

### DIFF
--- a/test-suite/tests/nw-xslt-003.xml
+++ b/test-suite/tests/nw-xslt-003.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:test expected="pass"
+        features="xslt-2"
+        xmlns:t="http://xproc.org/ns/testsuite/3.0">
+   <t:info>
+      <t:title>nw-xslt-003</t:title>
+      <t:revision-history>
+         <t:revision>
+            <t:date>2025-08-14</t:date>
+            <t:author>
+               <t:name>Norm Tovey-Walsh</t:name>
+            </t:author>
+            <t:description xmlns="http://www.w3.org/1999/xhtml">
+               <p>Initial commit.</p>
+            </t:description>
+         </t:revision>
+      </t:revision-history>
+   </t:info>
+   <t:description xmlns="http://www.w3.org/1999/xhtml">
+      <p>Tests that p:xslt static-parameters are handled correctly.</p>
+   </t:description>
+   <t:pipeline>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.1">
+  <p:output port="result"/>
+
+  <p:xslt>
+    <p:with-input port="source">
+      <foo/>
+    </p:with-input>
+    <p:with-input port="stylesheet">
+      <p:inline>
+        <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+          <xsl:param name="myparam" static="yes" select="'default'"/>
+          <xsl:template match="foo">
+            <result>
+              <xsl:value-of select="$myparam"/>
+            </result>
+          </xsl:template>
+        </xsl:stylesheet>
+      </p:inline>
+    </p:with-input>
+    <p:with-option name="static-parameters" select="map{QName('','myparam'): 'override'}"/>
+    <p:with-option name="version" select="'3.0'"/>
+  </p:xslt>
+</p:declare-step>
+   </t:pipeline>
+   <t:schematron>
+      <s:schema queryBinding="xslt2"
+                xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                xmlns="http://www.w3.org/1999/xhtml">
+         <s:pattern>
+            <s:rule context="/">
+               <s:assert test="result">The output root is not “result”.</s:assert>
+            </s:rule>
+            <s:rule context="result">
+               <s:assert test=". = 'override'">The override was not used.</s:assert>
+            </s:rule>
+         </s:pattern>
+      </s:schema>
+   </t:schematron>
+</t:test>


### PR DESCRIPTION
Hat tip to @galtm for the [issue](https://codeberg.org/xmlcalabash/xmlcalabash3/issues/202) that revealed the oversight.